### PR TITLE
feat: add build system for dual distribution (NPM + Plugin)

### DIFF
--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -1,0 +1,72 @@
+name: Publish Plugin to Marketplace
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish-plugin:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout kata
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Get version from release tag
+        id: version
+        run: |
+          # Extract version from tag (v0.1.9 → 0.1.9)
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Publishing plugin version: $VERSION"
+
+      - name: Build plugin distribution
+        run: |
+          npm run build:hooks
+          node scripts/build.js plugin
+
+      - name: Checkout marketplace
+        uses: actions/checkout@v4
+        with:
+          repository: gannonh/kata-marketplace
+          token: ${{ secrets.MARKETPLACE_TOKEN }}
+          path: marketplace
+
+      - name: Update marketplace with plugin files
+        run: |
+          # Clean existing plugin directory in marketplace
+          rm -rf marketplace/plugins/kata/*
+
+          # Copy built plugin to marketplace
+          mkdir -p marketplace/plugins/kata
+          cp -r dist/plugin/* marketplace/plugins/kata/
+
+          # Update version in marketplace.json if it exists
+          if [ -f marketplace/marketplace.json ]; then
+            # Use Node.js to update the version
+            node -e "
+              const fs = require('fs');
+              const m = JSON.parse(fs.readFileSync('marketplace/marketplace.json', 'utf8'));
+              const plugin = m.plugins.find(p => p.name === 'kata');
+              if (plugin) {
+                plugin.version = '${{ steps.version.outputs.version }}';
+                fs.writeFileSync('marketplace/marketplace.json', JSON.stringify(m, null, 2) + '\n');
+                console.log('Updated kata version to ${{ steps.version.outputs.version }}');
+              }
+            "
+          fi
+
+      - name: Commit and push to marketplace
+        working-directory: marketplace
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git diff --staged --quiet || git commit -m "chore: update kata plugin to v${{ steps.version.outputs.version }}"
+          git push

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,8 +52,15 @@ jobs:
             echo "should_publish=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Build NPM distribution
+        if: steps.check.outputs.should_publish == 'true'
+        run: |
+          npm run build:hooks
+          node scripts/build.js npm
+
       - name: Publish to npm
         if: steps.check.outputs.should_publish == 'true'
+        working-directory: dist/npm
         run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ skills.bak/
 tmp/
 .DS_Store
 .claude/plans/
+
+# build output
+dist/

--- a/.planning/phases/02-marketplace-distribution/HANDOFF.md
+++ b/.planning/phases/02-marketplace-distribution/HANDOFF.md
@@ -1,0 +1,191 @@
+# Handoff: Build System for Dual Distribution
+
+## Session Summary
+
+Implemented build system for dual distribution (NPM + Plugin). Currently testing plugin distribution locally and finding issues.
+
+## What Was Completed
+
+### Files Created
+- `scripts/build.js` - Main build script with path transformation
+- `.github/workflows/plugin-release.yml` - CI for plugin releases
+- `docs/DISTRIBUTION.md` - Full documentation
+- `.gitignore` - Added `dist/`
+
+### Files Modified
+- `package.json` - Added build scripts (`build`, `build:plugin`, `build:npm`)
+- `.github/workflows/publish.yml` - Now builds from `dist/npm/`
+
+### External Changes
+- Pushed built plugin to `gannonh/kata-marketplace` repo
+- Updated `marketplace.json` to use `"source": "./plugins/kata"` (local source)
+- `MARKETPLACE_TOKEN` secret added to kata repo
+
+## Test Results
+
+### NPM Distribution - PASSED ✓
+```bash
+npm run build:npm
+cd dist/npm && npm link
+cd /tmp/test-npm-install && npx kata --local
+# All files installed correctly
+# Paths transformed to ./.claude/kata/... (correct for local)
+```
+
+### Plugin Distribution - IN PROGRESS (ISSUES FOUND)
+```bash
+npm run build:plugin
+# Paths transformed to @./kata/... (verified)
+# No @~/.claude/ references remain (verified)
+
+# Testing with:
+claude --plugin-dir /Users/gannonhall/dev/oss/kata/dist/plugin
+```
+
+## Issues Found
+
+### Issue 1: VERSION path hardcoded to `~/.claude/kata/VERSION`
+
+**Symptom:**
+```
+/kata:whats-new
+Bash(cat ~/.claude/kata/VERSION 2>/dev/null)
+Error: Exit code 1
+Installed version: Unknown
+```
+
+**Root cause:** Skills reference `~/.claude/kata/VERSION` but in plugin context, VERSION is at `./kata/VERSION` relative to plugin root.
+
+**Files affected:**
+- `skills/kata-showing-whats-new/SKILL.md`
+- `skills/kata-updating/SKILL.md`
+
+### Issue 2: Update guidance is NPM-specific
+
+**Symptom:** When version unknown, skill suggests:
+```
+To fix: npx @gannonh/kata --global
+```
+
+**Problem:** For plugin users, this is wrong. They should use `/plugin update kata@kata-marketplace`.
+
+**Solution needed:**
+1. Detect if running as plugin vs NPM install
+2. For plugins: suggest `/plugin update`
+3. For NPM: suggest `npx @gannonh/kata`
+4. Consider removing `/kata:update` command entirely for plugins (Claude Code handles plugin updates)
+
+### Issue 3: /kata:update should be excluded from plugin distribution
+
+**Symptom:**
+```
+/kata:update
+Bash(cat ~/.claude/kata/VERSION 2>/dev/null)
+Error: Exit code 1
+Bash(npm view @gannonh/kata version 2>/dev/null)
+0.1.8
+Installed version: Unknown (no VERSION file)
+```
+
+Same VERSION path issue, but bigger problem: **plugins have their own update mechanism**.
+
+**Solution:**
+1. Exclude `/kata:update` command from plugin build entirely
+2. Exclude `skills/kata-updating/` from plugin build
+3. Plugin users should use `/plugin update kata@kata-marketplace`
+
+**Files to exclude in plugin build:**
+- `commands/kata/update.md`
+- `skills/kata-updating/`
+
+### Issue 4: Skills need plugin-aware paths
+
+The build system transforms `@~/.claude/kata/` → `@./kata/` but hardcoded bash commands like `cat ~/.claude/kata/VERSION` are NOT transformed.
+
+**Options:**
+1. Transform all `~/.claude/kata/` references (including in bash) during build
+2. Use environment variable like `$KATA_ROOT`
+3. Use `$CLAUDE_PLUGIN_ROOT` (available in plugin context)
+
+## Known Issue Areas to Check
+
+1. **Path resolution** - Does `@./kata/...` resolve correctly from plugin context?
+2. **Plugin manifest** - Is `.claude-plugin/plugin.json` correct?
+3. **Hooks** - Are hooks loading from plugin directory?
+4. **Skills** - Are skills being discovered?
+5. **Commands** - Do `/kata:*` commands appear?
+
+## Commands for Testing
+
+```bash
+# Rebuild plugin
+npm run build:plugin
+
+# Test locally
+claude --plugin-dir /Users/gannonhall/dev/oss/kata/dist/plugin
+
+# In Claude Code:
+/kata:help
+/help  # Check if kata commands listed
+```
+
+## What's Left
+
+1. **Fix plugin distribution issues** (currently blocked)
+2. Test plugin from marketplace (`/plugin install kata@kata-marketplace`)
+3. Test NPM from registry (after version bump and publish)
+4. Create SUMMARY.md for this plan
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `scripts/build.js` | Build script - modify if path transform is wrong |
+| `dist/plugin/` | Built plugin output |
+| `dist/npm/` | Built NPM output |
+| `docs/DISTRIBUTION.md` | Full documentation |
+
+## Path Transformation Logic
+
+In `scripts/build.js`:
+```javascript
+function transformPluginPaths(content) {
+  return content.replace(/@~\/\.claude\/kata\//g, '@./kata/');
+}
+```
+
+This transforms `@~/.claude/kata/workflows/...` → `@./kata/workflows/...`
+
+**LIMITATION:** Only transforms `@~/.claude/kata/` references. Does NOT transform:
+- Bash commands: `cat ~/.claude/kata/VERSION`
+- Other hardcoded paths in skill content
+
+**Fix needed:** Either:
+1. Expand regex to transform all `~/.claude/kata/` patterns
+2. Or use `$CLAUDE_PLUGIN_ROOT` variable in skills (available in plugin context)
+
+## Repos
+
+- **kata**: https://github.com/gannonh/kata (source)
+- **kata-marketplace**: https://github.com/gannonh/kata-marketplace (plugin distribution)
+
+## Resume Command
+
+```
+Resume from .planning/phases/02-marketplace-distribution/HANDOFF.md
+
+Issues found with plugin distribution:
+1. VERSION path hardcoded to ~/.claude/kata/VERSION (doesn't work in plugin context)
+2. Update suggestions are NPM-specific, not plugin-aware
+3. /kata:update command should be EXCLUDED from plugin (plugins use /plugin update)
+4. Build system only transforms @~/.claude/kata/ refs, not bash commands
+
+Next steps:
+1. Modify scripts/build.js to EXCLUDE from plugin build:
+   - commands/kata/update.md
+   - skills/kata-updating/
+2. Fix path transformation to include bash commands OR use $CLAUDE_PLUGIN_ROOT
+3. Make whats-new skill plugin-aware (show plugin update instructions)
+4. Rebuild plugin and re-test
+5. Push fixed plugin to kata-marketplace
+```

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -1,0 +1,280 @@
+# Kata Distribution System
+
+Kata has two distribution channels: **NPM** (for `npx` installation) and **Plugin** (for Claude Code marketplace).
+
+## Repositories
+
+| Repository | URL | Purpose |
+|------------|-----|---------|
+| **kata** | https://github.com/gannonh/kata | Source code, NPM package |
+| **kata-marketplace** | https://github.com/gannonh/kata-marketplace | Plugin distribution for Claude Code |
+
+## How It Works
+
+### Build System
+
+The build script (`scripts/build.js`) creates two distributions from the source:
+
+```
+kata/                          # Source repo
+├── scripts/build.js           # Build script
+├── dist/
+│   ├── plugin/                # Plugin distribution (transformed paths)
+│   └── npm/                   # NPM distribution (original paths)
+```
+
+**Key difference:** Plugin distribution transforms `@~/.claude/kata/` → `@./kata/` in all markdown files. This is because plugins run from the marketplace directory, not `~/.claude/`.
+
+### NPM Distribution
+
+**Flow:**
+1. Developer bumps version in `package.json`
+2. Push to `main` branch
+3. GitHub Actions (`publish.yml`) detects version change
+4. Runs `npm run build:npm` → creates `dist/npm/`
+5. Publishes `dist/npm/` to NPM registry
+
+**User installation:**
+```bash
+npx @gannonh/kata --global   # Install to ~/.claude/
+npx @gannonh/kata --local    # Install to ./.claude/
+```
+
+### Plugin Distribution
+
+**Flow:**
+1. Developer creates GitHub Release (e.g., v0.1.9)
+2. GitHub Actions (`plugin-release.yml`) triggers
+3. Runs `npm run build:plugin` → creates `dist/plugin/`
+4. Pushes `dist/plugin/` contents to `kata-marketplace/plugins/kata/`
+5. Updates version in `kata-marketplace/.claude-plugin/marketplace.json`
+
+**User installation:**
+```
+/plugin marketplace add gannonh/kata-marketplace
+/plugin install kata@kata-marketplace
+```
+
+## Testing Each Distribution
+
+### Test NPM Distribution Locally
+
+```bash
+# 1. Build the NPM distribution
+cd /path/to/kata
+npm run build:npm
+
+# 2. Link it locally
+cd dist/npm
+npm link
+
+# 3. Test installation in a new directory
+mkdir /tmp/test-npm-install
+cd /tmp/test-npm-install
+npx kata --local
+
+# 4. Verify installation
+ls -la .claude/
+# Should see: kata/, agents/, skills/, commands/, hooks/
+
+# 5. Check paths are correct (should have ~/.claude/ references)
+grep "@~/.claude/" .claude/skills/kata-executing-phases/SKILL.md
+# Should show: @~/.claude/kata/workflows/phase-execute.md
+
+# 6. Cleanup
+npm unlink -g @gannonh/kata
+rm -rf /tmp/test-npm-install
+```
+
+### Test Plugin Distribution Locally
+
+```bash
+# 1. Build the plugin distribution
+cd /path/to/kata
+npm run build:plugin
+
+# 2. Verify paths are transformed
+grep "@./kata/" dist/plugin/skills/kata-executing-phases/SKILL.md
+# Should show: @./kata/workflows/phase-execute.md
+
+# 3. Verify no old paths remain
+grep -r "@~/.claude/" dist/plugin/
+# Should return nothing
+
+# 4. Test with Claude Code using --plugin-dir
+claude --plugin-dir ./dist/plugin
+
+# 5. In Claude Code, verify commands work
+/kata:help
+```
+
+### Test Plugin from Marketplace (Production)
+
+In a **fresh Claude Code session** (not in the kata repo):
+
+```
+# 1. Add the marketplace
+/plugin marketplace add gannonh/kata-marketplace
+
+# 2. Install Kata
+/plugin install kata@kata-marketplace
+
+# 3. Verify installation
+/plugin list
+# Should show: kata@kata-marketplace (version 0.1.9)
+
+# 4. Test commands
+/kata:help
+
+# 5. Test a skill (natural language)
+"What kata commands are available?"
+```
+
+### Test NPM from Registry (Production)
+
+```bash
+# In a new directory (not the kata repo)
+mkdir /tmp/test-kata
+cd /tmp/test-kata
+
+# Install from NPM
+npx @gannonh/kata --local
+
+# Start Claude Code and verify
+claude
+/kata:help
+```
+
+## Build Commands
+
+```bash
+# Build both distributions
+npm run build
+
+# Build plugin only
+npm run build:plugin
+
+# Build NPM only
+npm run build:npm
+```
+
+## CI/CD Workflows
+
+### `.github/workflows/publish.yml` (NPM)
+
+**Triggers:** Push to `main` with version change in `package.json`
+
+**Steps:**
+1. Checkout code
+2. Build hooks (`npm run build:hooks`)
+3. Build NPM distribution (`node scripts/build.js npm`)
+4. Publish from `dist/npm/` to NPM
+5. Create GitHub Release
+
+### `.github/workflows/plugin-release.yml` (Plugin)
+
+**Triggers:** GitHub Release published
+
+**Steps:**
+1. Checkout kata repo
+2. Build hooks
+3. Build plugin distribution (`node scripts/build.js plugin`)
+4. Checkout kata-marketplace repo
+5. Copy `dist/plugin/*` to `kata-marketplace/plugins/kata/`
+6. Update version in `marketplace.json`
+7. Commit and push to kata-marketplace
+
+**Required secret:** `MARKETPLACE_TOKEN` - GitHub PAT with write access to kata-marketplace
+
+## Setting Up MARKETPLACE_TOKEN
+
+1. Go to https://github.com/settings/tokens
+2. Generate new token (classic) with `repo` scope
+3. Go to https://github.com/gannonh/kata/settings/secrets/actions
+4. Add secret named `MARKETPLACE_TOKEN` with the token value
+
+## Directory Structure After Build
+
+### `dist/plugin/` (for marketplace)
+
+```
+dist/plugin/
+├── .claude-plugin/
+│   └── plugin.json          # Plugin manifest
+├── agents/                   # Subagent definitions
+├── commands/kata/            # Slash commands
+├── hooks/                    # Hook scripts
+├── kata/                     # Workflows, templates, references
+├── skills/                   # Skill definitions
+├── CHANGELOG.md
+└── VERSION                   # Current version
+```
+
+### `dist/npm/` (for npx)
+
+```
+dist/npm/
+├── bin/
+│   └── install.js           # npx entry point
+├── agents/
+├── commands/kata/
+├── hooks/
+├── kata/
+│   └── VERSION              # Version file
+├── skills/
+├── package.json
+└── CHANGELOG.md
+```
+
+## Troubleshooting
+
+### Plugin paths not resolving
+
+**Symptom:** `@./kata/workflows/...` file not found
+
+**Cause:** Path transformation didn't run or plugin installed from wrong source
+
+**Fix:** Rebuild with `npm run build:plugin` and verify paths:
+```bash
+grep -r "@~/.claude/" dist/plugin/  # Should return nothing
+grep "@./kata/" dist/plugin/skills/kata-executing-phases/SKILL.md  # Should match
+```
+
+### NPM publish fails
+
+**Symptom:** CI fails at publish step
+
+**Check:**
+1. `NPM_TOKEN` secret is set in GitHub repo
+2. Version in `package.json` is higher than published version
+3. `dist/npm/package.json` exists after build
+
+### Plugin marketplace not updating
+
+**Symptom:** Old version still shows after release
+
+**Check:**
+1. `MARKETPLACE_TOKEN` secret is set
+2. GitHub Release was published (not draft)
+3. Check kata-marketplace repo for recent commits
+
+### GitHub raw content shows old file
+
+**Cause:** CDN caching (5-10 minute delay)
+
+**Verify actual content:**
+```bash
+gh api repos/gannonh/kata-marketplace/contents/.claude-plugin/marketplace.json --jq '.content' | base64 -d
+```
+
+## Version Alignment
+
+Keep versions in sync across:
+
+| File | Location |
+|------|----------|
+| `package.json` | `kata/package.json` → `"version": "X.Y.Z"` |
+| `plugin.json` | `kata/.claude-plugin/plugin.json` → `"version": "X.Y.Z"` |
+| `marketplace.json` | `kata-marketplace/.claude-plugin/marketplace.json` → `"version": "X.Y.Z"` |
+
+The build system generates `VERSION` files from `package.json`. The CI updates `marketplace.json` automatically on release.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "test": "node --test --test-reporter spec tests/**/*.test.js",
     "test:skills": "node --test --test-reporter spec tests/skills/*.test.js",
     "test:skill": "node --test --test-reporter spec",
+    "build": "node scripts/build.js all",
+    "build:plugin": "node scripts/build.js plugin",
+    "build:npm": "node scripts/build.js npm",
     "build:hooks": "node scripts/build-hooks.cjs",
     "prepublishOnly": "npm run build:hooks"
   },

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,0 +1,346 @@
+#!/usr/bin/env node
+
+/**
+ * Build script for Kata dual distribution.
+ *
+ * Targets:
+ * - plugin: Lean distribution for Claude Code marketplace (/plugin install)
+ *   - Path transform: @~/.claude/kata/ → @./kata/
+ *   - Output: dist/plugin/
+ *
+ * - npm: Distribution via npx @gannonh/kata
+ *   - No path transform (install.js handles at runtime)
+ *   - Output: dist/npm/
+ *
+ * Usage:
+ *   node scripts/build.js plugin   # Build plugin only
+ *   node scripts/build.js npm      # Build npm only
+ *   node scripts/build.js all      # Build both (default)
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT = path.dirname(__dirname);
+
+// ANSI colors
+const green = '\x1b[32m';
+const amber = '\x1b[33m';
+const red = '\x1b[31m';
+const dim = '\x1b[2m';
+const reset = '\x1b[0m';
+
+// Get version from package.json
+const pkg = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8'));
+
+/**
+ * Files/directories to include in both distributions
+ */
+const COMMON_INCLUDES = [
+  'commands/kata',
+  'skills',
+  'agents',
+  'hooks',
+  'kata',
+  'CHANGELOG.md',
+];
+
+/**
+ * Files/directories to exclude from copy operations
+ */
+const EXCLUDES = [
+  '.planning',
+  'tests',
+  '.git',
+  'dev',
+  'scripts',
+  'node_modules',
+  '.secrets',
+  '.github',
+  'assets',
+  'dist',
+  '.DS_Store',
+];
+
+/**
+ * Plugin-specific includes
+ */
+const PLUGIN_INCLUDES = [
+  '.claude-plugin',
+];
+
+/**
+ * NPM-specific includes
+ */
+const NPM_INCLUDES = [
+  'bin',
+  'package.json',
+];
+
+/**
+ * Clean a directory (remove and recreate)
+ */
+function cleanDir(dir) {
+  if (fs.existsSync(dir)) {
+    fs.rmSync(dir, { recursive: true });
+  }
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+/**
+ * Check if path should be excluded
+ */
+function shouldExclude(name) {
+  return EXCLUDES.includes(name) || name.startsWith('.');
+}
+
+/**
+ * Copy a file, optionally transforming paths in .md files
+ */
+function copyFile(src, dest, transform = null) {
+  const content = fs.readFileSync(src, 'utf8');
+  if (transform && src.endsWith('.md')) {
+    fs.writeFileSync(dest, transform(content));
+  } else {
+    fs.copyFileSync(src, dest);
+  }
+}
+
+/**
+ * Recursively copy a directory with optional path transformation
+ */
+function copyDir(src, dest, transform = null) {
+  if (!fs.existsSync(src)) {
+    console.log(`  ${amber}!${reset} Skipping ${src} (not found)`);
+    return false;
+  }
+
+  fs.mkdirSync(dest, { recursive: true });
+  const entries = fs.readdirSync(src, { withFileTypes: true });
+
+  for (const entry of entries) {
+    // Skip excluded files/directories
+    if (shouldExclude(entry.name)) continue;
+    // Skip hooks/dist - it's for npm publishing only
+    if (entry.name === 'dist' && src.includes('hooks')) continue;
+
+    const srcPath = path.join(src, entry.name);
+    const destPath = path.join(dest, entry.name);
+
+    if (entry.isDirectory()) {
+      copyDir(srcPath, destPath, transform);
+    } else {
+      copyFile(srcPath, destPath, transform);
+    }
+  }
+  return true;
+}
+
+/**
+ * Copy a file or directory to destination
+ */
+function copyPath(src, dest, transform = null) {
+  const srcPath = path.join(ROOT, src);
+  const destPath = path.join(dest, src);
+
+  if (!fs.existsSync(srcPath)) {
+    console.log(`  ${amber}!${reset} Skipping ${src} (not found)`);
+    return false;
+  }
+
+  const stat = fs.statSync(srcPath);
+  if (stat.isDirectory()) {
+    return copyDir(srcPath, destPath, transform);
+  } else {
+    fs.mkdirSync(path.dirname(destPath), { recursive: true });
+    copyFile(srcPath, destPath, transform);
+    return true;
+  }
+}
+
+/**
+ * Transform paths for plugin distribution
+ * @~/.claude/kata/ → @./kata/
+ */
+function transformPluginPaths(content) {
+  return content.replace(/@~\/\.claude\/kata\//g, '@./kata/');
+}
+
+/**
+ * Write VERSION file
+ */
+function writeVersion(dest) {
+  const versionPath = path.join(dest, 'VERSION');
+  fs.writeFileSync(versionPath, pkg.version);
+}
+
+/**
+ * Validate build output
+ */
+function validateBuild(dest, target) {
+  const errors = [];
+
+  // Check required directories exist
+  const requiredDirs = ['kata', 'agents', 'skills'];
+  for (const dir of requiredDirs) {
+    const dirPath = path.join(dest, dir);
+    if (!fs.existsSync(dirPath)) {
+      errors.push(`Missing directory: ${dir}`);
+    }
+  }
+
+  // For plugin target, verify no ~/.claude/ references remain
+  if (target === 'plugin') {
+    const checkForOldPaths = (dir) => {
+      if (!fs.existsSync(dir)) return;
+      const entries = fs.readdirSync(dir, { withFileTypes: true });
+      for (const entry of entries) {
+        const fullPath = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+          checkForOldPaths(fullPath);
+        } else if (entry.name.endsWith('.md')) {
+          const content = fs.readFileSync(fullPath, 'utf8');
+          if (content.includes('@~/.claude/')) {
+            errors.push(`Old path reference in ${fullPath.replace(dest, '')}`);
+          }
+        }
+      }
+    };
+    checkForOldPaths(dest);
+  }
+
+  // For npm target, verify install.js exists
+  if (target === 'npm') {
+    const installPath = path.join(dest, 'bin', 'install.js');
+    if (!fs.existsSync(installPath)) {
+      errors.push('Missing bin/install.js');
+    }
+  }
+
+  return errors;
+}
+
+/**
+ * Build plugin distribution
+ */
+function buildPlugin() {
+  console.log(`\n${green}Building plugin distribution...${reset}\n`);
+
+  const dest = path.join(ROOT, 'dist', 'plugin');
+  cleanDir(dest);
+
+  // Copy common files with path transformation
+  for (const item of COMMON_INCLUDES) {
+    if (copyPath(item, dest, transformPluginPaths)) {
+      console.log(`  ${green}✓${reset} Copied ${item}`);
+    }
+  }
+
+  // Copy plugin-specific files
+  for (const item of PLUGIN_INCLUDES) {
+    if (copyPath(item, dest)) {
+      console.log(`  ${green}✓${reset} Copied ${item}`);
+    }
+  }
+
+  // Write VERSION file
+  writeVersion(dest);
+  console.log(`  ${green}✓${reset} Wrote VERSION (${pkg.version})`);
+
+  // Validate build
+  const errors = validateBuild(dest, 'plugin');
+  if (errors.length > 0) {
+    console.log(`\n${red}Validation errors:${reset}`);
+    for (const error of errors) {
+      console.log(`  ${red}✗${reset} ${error}`);
+    }
+    return false;
+  }
+
+  console.log(`\n${green}✓ Plugin build complete: dist/plugin/${reset}`);
+  return true;
+}
+
+/**
+ * Build npm distribution
+ */
+function buildNpm() {
+  console.log(`\n${green}Building npm distribution...${reset}\n`);
+
+  const dest = path.join(ROOT, 'dist', 'npm');
+  cleanDir(dest);
+
+  // Copy common files (no path transformation - install.js handles it)
+  for (const item of COMMON_INCLUDES) {
+    if (copyPath(item, dest)) {
+      console.log(`  ${green}✓${reset} Copied ${item}`);
+    }
+  }
+
+  // Copy npm-specific files
+  for (const item of NPM_INCLUDES) {
+    if (copyPath(item, dest)) {
+      console.log(`  ${green}✓${reset} Copied ${item}`);
+    }
+  }
+
+  // Write VERSION file to kata/ directory (matches install.js behavior)
+  const kataDir = path.join(dest, 'kata');
+  if (fs.existsSync(kataDir)) {
+    fs.writeFileSync(path.join(kataDir, 'VERSION'), pkg.version);
+    console.log(`  ${green}✓${reset} Wrote kata/VERSION (${pkg.version})`);
+  }
+
+  // Validate build
+  const errors = validateBuild(dest, 'npm');
+  if (errors.length > 0) {
+    console.log(`\n${red}Validation errors:${reset}`);
+    for (const error of errors) {
+      console.log(`  ${red}✗${reset} ${error}`);
+    }
+    return false;
+  }
+
+  console.log(`\n${green}✓ npm build complete: dist/npm/${reset}`);
+  return true;
+}
+
+/**
+ * Main entry point
+ */
+function main() {
+  const args = process.argv.slice(2);
+  const target = args[0] || 'all';
+
+  console.log(`${amber}Kata Build System${reset}`);
+  console.log(`${dim}Version: ${pkg.version}${reset}`);
+
+  let success = true;
+
+  switch (target) {
+    case 'plugin':
+      success = buildPlugin();
+      break;
+    case 'npm':
+      success = buildNpm();
+      break;
+    case 'all':
+      success = buildPlugin() && buildNpm();
+      break;
+    default:
+      console.error(`${red}Unknown target: ${target}${reset}`);
+      console.log(`\nUsage: node scripts/build.js [plugin|npm|all]`);
+      process.exit(1);
+  }
+
+  if (!success) {
+    process.exit(1);
+  }
+
+  console.log(`\n${green}Build complete!${reset}\n`);
+}
+
+main();


### PR DESCRIPTION
## Summary

- Create build system that produces platform-specific distributions for Kata
- **Plugin** (`dist/plugin/`): Lean distribution for Claude Code marketplace
- **NPM** (`dist/npm/`): Distribution via `npx @gannonh/kata`

## Changes

- `scripts/build.js` - Main build script with path transformation
- `.github/workflows/plugin-release.yml` - CI for plugin releases to kata-marketplace
- `.github/workflows/publish.yml` - Updated to build from `dist/npm/`
- `docs/DISTRIBUTION.md` - Full documentation
- `package.json` - Added build scripts

## Path Transformation

Plugin distribution transforms `@~/.claude/kata/` → `@./kata/` so paths resolve correctly from plugin context.

## Known Issues (documented in HANDOFF.md)

- [ ] VERSION path hardcoded to `~/.claude/kata/VERSION` (needs plugin-aware fix)
- [ ] `/kata:update` should be excluded from plugin build (plugins use `/plugin update`)
- [ ] Bash commands not transformed (only `@` references)

## Test Plan

- [x] `npm run build:npm` produces correct output
- [x] `npm run build:plugin` produces correct output with transformed paths
- [x] NPM local install works via `npx kata --local`
- [ ] Plugin install from marketplace (blocked by known issues above)