### PR TITLE
Release v1.0.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kata",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Spec-driven development framework for Claude Code. Provides structured workflows for requirements gathering, research, planning, execution, and verification.",
   "author": {
     "name": "gannonh",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-01-23
+
+### Fixed
+- **Plugin release workflow**: Changed trigger from `release` event to `workflow_run` to fix GitHub limitation where workflows using GITHUB_TOKEN don't trigger downstream workflows
+- **CI test runner**: Fixed glob pattern expansion issue on CI runners
+- **NPM publish**: Removed dev scripts from dist package.json to prevent prepublishOnly failures
+
 ## [1.0.0] - 2026-01-23
 
 Kata 1.0 ships with **Claude Code plugin support** as the recommended installation method.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gannonh/kata",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "module",
   "description": "Spec-driven development framework for Claude Code.",
   "scripts": {


### PR DESCRIPTION
## Summary

Patch release to fix CI workflow issues discovered during v1.0.0 release.

### Fixed
- **Plugin release workflow**: Changed trigger from `release` event to `workflow_run` to fix GitHub limitation where workflows using GITHUB_TOKEN don't trigger downstream workflows
- **CI test runner**: Fixed glob pattern expansion issue on CI runners
- **NPM publish**: Removed dev scripts from dist package.json to prevent prepublishOnly failures

## Test plan
- [ ] CI passes on PR
- [ ] Merge triggers NPM publish workflow
- [ ] NPM publish completion triggers plugin-release workflow
- [ ] Both distributions are published successfully