### PR TITLE
Release v1.0.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kata",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Spec-driven development framework for Claude Code. Provides structured workflows for requirements gathering, research, planning, execution, and verification.",
   "author": {
     "name": "gannonh",

--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -92,19 +92,22 @@ jobs:
           mkdir -p marketplace/plugins/kata
           cp -r dist/plugin/* marketplace/plugins/kata/
 
-          # Update version in marketplace.json if it exists
-          if [ -f marketplace/marketplace.json ]; then
+          # Update version in marketplace.json (in .claude-plugin directory)
+          MARKETPLACE_JSON="marketplace/.claude-plugin/marketplace.json"
+          if [ -f "$MARKETPLACE_JSON" ]; then
             # Use Node.js to update the version
             node -e "
               const fs = require('fs');
-              const m = JSON.parse(fs.readFileSync('marketplace/marketplace.json', 'utf8'));
+              const m = JSON.parse(fs.readFileSync('$MARKETPLACE_JSON', 'utf8'));
               const plugin = m.plugins.find(p => p.name === 'kata');
               if (plugin) {
                 plugin.version = '${{ steps.version.outputs.version }}';
-                fs.writeFileSync('marketplace/marketplace.json', JSON.stringify(m, null, 2) + '\n');
+                fs.writeFileSync('$MARKETPLACE_JSON', JSON.stringify(m, null, 2) + '\n');
                 console.log('Updated kata version to ${{ steps.version.outputs.version }}');
               }
             "
+          else
+            echo "Warning: marketplace.json not found at $MARKETPLACE_JSON"
           fi
 
       - name: Commit and push to marketplace

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.2] - 2026-01-23
+
+### Fixed
+- **Marketplace version update**: Fixed plugin-release workflow to update version in correct path (`.claude-plugin/marketplace.json`)
+
 ## [1.0.1] - 2026-01-23
 
 ### Fixed

--- a/docs/release-mgmt.md
+++ b/docs/release-mgmt.md
@@ -1,0 +1,376 @@
+# Release Management
+
+This document covers the complete release process for Kata, including CI/CD workflows, distribution channels, testing procedures, and troubleshooting.
+
+## Overview
+
+Kata has two distribution channels:
+
+| Channel | Repository | Installation |
+|---------|-----------|--------------|
+| **NPM** | [gannonh/kata](https://github.com/gannonh/kata) | `npx @gannonh/kata` |
+| **Plugin** | [gannonh/kata-marketplace](https://github.com/gannonh/kata-marketplace) | `/plugin install kata@kata-marketplace` |
+
+## Release Flow
+
+```
+Merge PR to main
+       ↓
+publish.yml triggers (version change detected)
+       ↓
+Run tests → Build → Publish to NPM → Create GitHub Release (v1.0.1)
+       ↓
+plugin-release.yml triggers (workflow_run)
+       ↓
+Build plugin → Push to kata-marketplace
+       ↓
+Both distributions live
+```
+
+## Version Alignment
+
+Keep versions in sync across:
+
+| File | Location |
+|------|----------|
+| `package.json` | `kata/package.json` → `"version": "X.Y.Z"` |
+| `plugin.json` | `kata/.claude-plugin/plugin.json` → `"version": "X.Y.Z"` |
+| `marketplace.json` | `kata-marketplace/.claude-plugin/marketplace.json` → `"version": "X.Y.Z"` (auto-updated by CI) |
+
+The build system generates `VERSION` files from `package.json`. The CI updates `marketplace.json` automatically on release.
+
+---
+
+## Creating a Release
+
+### 1. Bump Version
+
+Update both files:
+
+```bash
+# package.json
+npm version patch  # or minor/major
+
+# plugin.json - manually match the version
+```
+
+### 2. Update CHANGELOG
+
+Add entry to `CHANGELOG.md` following [Keep a Changelog](https://keepachangelog.com/) format:
+
+```markdown
+## [1.0.2] - 2026-01-24
+
+### Added
+- New feature description
+
+### Fixed
+- Bug fix description
+```
+
+### 3. Create PR and Merge
+
+```bash
+git checkout -b release/v1.0.2
+git add package.json .claude-plugin/plugin.json CHANGELOG.md
+git commit -m "chore: bump version to 1.0.2"
+git push -u origin release/v1.0.2
+gh pr create --title "Release v1.0.2"
+gh pr merge --merge --delete-branch
+```
+
+### 4. Monitor CI
+
+```bash
+gh run list --limit 5
+gh run watch <run-id>
+```
+
+---
+
+## CI/CD Workflows
+
+### `.github/workflows/publish.yml` (NPM)
+
+**Triggers:** Push to `main` with version change in `package.json`
+
+**Steps:**
+1. Checkout code
+2. Get package version, compare to NPM registry
+3. If version changed:
+   - Run tests (`npm test`)
+   - Build hooks (`npm run build:hooks`)
+   - Build NPM distribution (`node scripts/build.js npm`)
+   - Validate build artifacts
+   - Publish from `dist/npm/` to NPM
+   - Create GitHub Release (tagged `vX.Y.Z`)
+
+### `.github/workflows/plugin-release.yml` (Plugin)
+
+**Triggers:** `workflow_run` completion of `publish.yml`
+
+**Steps:**
+1. Check if release exists for current version
+2. If release exists:
+   - Run tests
+   - Build hooks
+   - Build plugin distribution (`node scripts/build.js plugin`)
+   - Validate plugin build
+   - Checkout kata-marketplace repo
+   - Copy `dist/plugin/*` to `kata-marketplace/plugins/kata/`
+   - Update version in `marketplace.json`
+   - Commit and push to kata-marketplace
+
+**Required secrets:**
+- `NPM_TOKEN` - NPM publish token
+- `MARKETPLACE_TOKEN` - GitHub PAT with write access to kata-marketplace
+
+---
+
+## Build System
+
+The build script (`scripts/build.js`) creates two distributions from the source:
+
+```
+kata/                          # Source repo
+├── scripts/build.js           # Build script
+├── dist/
+│   ├── plugin/                # Plugin distribution (transformed paths)
+│   └── npm/                   # NPM distribution (original paths)
+```
+
+**Key difference:** Plugin distribution transforms `@~/.claude/kata/` → `@./kata/` in all markdown files. This is because plugins run from the marketplace directory, not `~/.claude/`.
+
+### Build Commands
+
+```bash
+npm run build          # Build both distributions
+npm run build:plugin   # Build plugin only
+npm run build:npm      # Build NPM only
+npm run build:hooks    # Build hooks only (CJS → ESM)
+```
+
+### Directory Structure After Build
+
+**`dist/plugin/` (for marketplace):**
+```
+dist/plugin/
+├── .claude-plugin/
+│   └── plugin.json          # Plugin manifest
+├── agents/                   # Subagent definitions
+├── commands/kata/            # Slash commands
+├── hooks/                    # Hook scripts
+├── kata/                     # Workflows, templates, references
+├── skills/                   # Skill definitions
+├── CHANGELOG.md
+└── VERSION
+```
+
+**`dist/npm/` (for npx):**
+```
+dist/npm/
+├── bin/
+│   └── install.js           # npx entry point
+├── agents/
+├── commands/kata/
+├── hooks/
+├── kata/
+│   └── VERSION
+├── skills/
+├── package.json
+└── CHANGELOG.md
+```
+
+---
+
+## Testing
+
+### Automated Tests
+
+```bash
+# Build validation tests (runs in CI)
+npm test
+
+# Smoke tests (post-release)
+npm run test:smoke
+
+# Smoke tests with specific version
+KATA_VERSION=1.0.1 npm run test:smoke
+
+# Smoke tests with Claude CLI integration
+TEST_CLI=1 npm run test:smoke
+```
+
+### Local Build Testing
+
+**Test NPM distribution:**
+```bash
+npm run build:npm
+cd dist/npm && npm link
+mkdir /tmp/test-npm && cd /tmp/test-npm
+npx kata --local
+ls -la .claude/  # Verify: kata/, agents/, skills/, commands/, hooks/
+grep "@~/.claude/" .claude/skills/kata-executing-phases/SKILL.md  # Should match
+npm unlink -g @gannonh/kata
+```
+
+**Test plugin distribution:**
+```bash
+npm run build:plugin
+grep "@./kata/" dist/plugin/skills/kata-executing-phases/SKILL.md  # Should match
+grep -r "@~/.claude/" dist/plugin/  # Should return nothing
+claude --plugin-dir ./dist/plugin
+/kata:help
+```
+
+### Post-Release Smoke Tests
+
+#### NPX Install Smoke Test
+
+```bash
+cd ~/dev/oss/kata-burner
+
+# Create fresh test directory
+mkdir kata-npx-test && cd kata-npx-test
+
+# Test NPX install
+npx @gannonh/kata@1.0.1 --local
+
+# Verify files installed
+ls -la .claude/
+# Expected: kata/, agents/, skills/, commands/, hooks/
+
+# Verify version
+cat .claude/kata/VERSION
+# Expected: 1.0.1
+
+# Start Claude Code
+claude
+
+# In Claude Code, verify commands work
+/kata:help
+/kata:whats-new
+
+# Cleanup
+cd .. && rm -rf kata-npx-test
+```
+
+#### Plugin Install Smoke Test
+
+```bash
+cd ~/dev/oss/kata-burner
+
+# Create fresh test directory
+mkdir kata-plugin-test && cd kata-plugin-test
+
+# Start Claude Code
+claude
+
+# In Claude Code:
+/plugin marketplace add gannonh/kata-marketplace
+/plugin install kata@kata-marketplace
+
+# Verify plugin loaded
+/kata:help
+/kata:whats-new
+
+# Verify version matches release
+# Check statusline shows plugin update method (not npx)
+
+# Cleanup
+cd .. && rm -rf kata-plugin-test
+```
+
+### Verification Checklist
+
+- [ ] NPX: `npx @gannonh/kata@X.Y.Z` installs without errors
+- [ ] NPX: `/kata:help` shows all commands
+- [ ] NPX: VERSION file shows correct version
+- [ ] Plugin: Marketplace add succeeds
+- [ ] Plugin: Plugin install succeeds
+- [ ] Plugin: `/kata:help` shows all commands
+- [ ] Plugin: No `~/.claude/` path errors in plugin mode
+- [ ] Both: `/kata:whats-new` shows release changelog
+
+---
+
+## Troubleshooting
+
+### Plugin paths not resolving
+
+**Symptom:** `@./kata/workflows/...` file not found
+
+**Cause:** Path transformation didn't run or plugin installed from wrong source
+
+**Fix:** Rebuild with `npm run build:plugin` and verify paths:
+```bash
+grep -r "@~/.claude/" dist/plugin/  # Should return nothing
+grep "@./kata/" dist/plugin/skills/kata-executing-phases/SKILL.md  # Should match
+```
+
+### NPM publish fails
+
+**Symptom:** CI fails at publish step
+
+**Check:**
+1. `NPM_TOKEN` secret is set in GitHub repo
+2. Version in `package.json` is higher than published version
+3. `dist/npm/package.json` exists after build
+
+### Plugin marketplace not updating
+
+**Symptom:** Old version still shows after release
+
+**Check:**
+1. `MARKETPLACE_TOKEN` secret is set
+2. GitHub Release was published (not draft)
+3. Check kata-marketplace repo for recent commits
+4. Verify `workflow_run` trigger fired: `gh run list --workflow=plugin-release.yml`
+
+### Plugin workflow didn't trigger
+
+**Symptom:** NPM published but plugin-release.yml never ran
+
+**Cause:** GitHub doesn't trigger workflows on releases created by workflows using `GITHUB_TOKEN`
+
+**Solution:** The workflow uses `workflow_run` trigger instead of `release` trigger. If it still fails:
+```bash
+# Manually trigger (if workflow allows)
+gh workflow run plugin-release.yml
+```
+
+### GitHub raw content shows old file
+
+**Cause:** CDN caching (5-10 minute delay)
+
+**Verify actual content:**
+```bash
+gh api repos/gannonh/kata-marketplace/contents/.claude-plugin/marketplace.json --jq '.content' | base64 -d
+```
+
+### Tests fail with glob pattern
+
+**Symptom:** CI can't find test files with `tests/**/*.test.js`
+
+**Fix:** Use explicit paths in package.json:
+```json
+"test": "node --test ./tests/build.test.js ./tests/smoke.test.js"
+```
+
+---
+
+## Setting Up Secrets
+
+### NPM_TOKEN
+
+1. Go to https://www.npmjs.com/settings/YOUR_USERNAME/tokens
+2. Generate new Automation token
+3. Go to https://github.com/gannonh/kata/settings/secrets/actions
+4. Add secret named `NPM_TOKEN`
+
+### MARKETPLACE_TOKEN
+
+1. Go to https://github.com/settings/tokens
+2. Generate new token (classic) with `repo` scope
+3. Go to https://github.com/gannonh/kata/settings/secrets/actions
+4. Add secret named `MARKETPLACE_TOKEN`

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "@gannonh/kata",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "type": "module",
   "description": "Spec-driven development framework for Claude Code.",
   "scripts": {
     "test": "node --test --test-reporter spec ./tests/build.test.js",
-    "test:build": "node --test --test-reporter spec tests/build.test.js",
+    "test:smoke": "node --test --test-reporter spec ./tests/smoke.test.js",
+    "test:all": "node --test --test-reporter spec ./tests/build.test.js ./tests/smoke.test.js",
     "build": "node scripts/build.js all",
     "build:plugin": "node scripts/build.js plugin",
     "build:npm": "node scripts/build.js npm",

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -1,0 +1,243 @@
+import { test, describe, before, after } from 'node:test';
+import assert from 'node:assert';
+import { execSync, spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+const ROOT = process.cwd();
+const TEST_DIR = path.join(os.tmpdir(), `kata-smoke-test-${Date.now()}`);
+
+/**
+ * Post-release smoke tests for NPX and Plugin distributions.
+ *
+ * These tests verify that published distributions install correctly
+ * and contain all required files.
+ *
+ * Run after a release with:
+ *   KATA_VERSION=1.0.1 npm run test:smoke
+ *
+ * Or for local builds:
+ *   npm run test:smoke
+ */
+
+const KATA_VERSION = process.env.KATA_VERSION || null;
+
+describe('NPX Install Smoke Test', () => {
+  const npxTestDir = path.join(TEST_DIR, 'npx-test');
+
+  before(() => {
+    fs.mkdirSync(npxTestDir, { recursive: true });
+  });
+
+  after(() => {
+    fs.rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  test('npx install creates .claude directory', () => {
+    const pkg = KATA_VERSION ? `@gannonh/kata@${KATA_VERSION}` : path.join(ROOT, 'dist/npm');
+
+    // Run npx install (or local install for dev)
+    if (KATA_VERSION) {
+      execSync(`npx ${pkg} --local`, { cwd: npxTestDir, stdio: 'pipe' });
+    } else {
+      // For local testing, use the installer directly
+      execSync(`node ${path.join(ROOT, 'bin/install.js')} --local`, {
+        cwd: npxTestDir,
+        stdio: 'pipe'
+      });
+    }
+
+    assert.ok(
+      fs.existsSync(path.join(npxTestDir, '.claude')),
+      '.claude directory should be created'
+    );
+  });
+
+  test('install creates kata directory', () => {
+    assert.ok(
+      fs.existsSync(path.join(npxTestDir, '.claude/kata')),
+      '.claude/kata directory should exist'
+    );
+  });
+
+  test('install creates agents directory', () => {
+    assert.ok(
+      fs.existsSync(path.join(npxTestDir, '.claude/agents')),
+      '.claude/agents directory should exist'
+    );
+  });
+
+  test('install creates skills directory', () => {
+    assert.ok(
+      fs.existsSync(path.join(npxTestDir, '.claude/skills')),
+      '.claude/skills directory should exist'
+    );
+  });
+
+  test('install creates commands directory', () => {
+    assert.ok(
+      fs.existsSync(path.join(npxTestDir, '.claude/commands')),
+      '.claude/commands directory should exist'
+    );
+  });
+
+  test('install creates hooks directory', () => {
+    assert.ok(
+      fs.existsSync(path.join(npxTestDir, '.claude/hooks')),
+      '.claude/hooks directory should exist'
+    );
+  });
+
+  test('VERSION file exists', () => {
+    assert.ok(
+      fs.existsSync(path.join(npxTestDir, '.claude/kata/VERSION')),
+      '.claude/kata/VERSION should exist'
+    );
+  });
+
+  test('VERSION file matches expected version', () => {
+    const versionFile = path.join(npxTestDir, '.claude/kata/VERSION');
+    const installedVersion = fs.readFileSync(versionFile, 'utf8').trim();
+
+    if (KATA_VERSION) {
+      assert.strictEqual(
+        installedVersion,
+        KATA_VERSION,
+        `VERSION should be ${KATA_VERSION}, got ${installedVersion}`
+      );
+    } else {
+      // For local testing, just verify it's a valid semver
+      assert.match(
+        installedVersion,
+        /^\d+\.\d+\.\d+/,
+        'VERSION should be valid semver'
+      );
+    }
+  });
+
+  test('kata:help command file exists', () => {
+    assert.ok(
+      fs.existsSync(path.join(npxTestDir, '.claude/commands/kata/help.md')),
+      'kata:help command should exist'
+    );
+  });
+
+  test('skills have correct path references for NPM install', () => {
+    const skillPath = path.join(npxTestDir, '.claude/skills/kata-executing-phases/SKILL.md');
+    if (fs.existsSync(skillPath)) {
+      const content = fs.readFileSync(skillPath, 'utf8');
+      // NPM install should have ~/.claude/ paths
+      assert.ok(
+        content.includes('@~/.claude/') || content.includes('@./'),
+        'Skill should have valid path references'
+      );
+    }
+  });
+});
+
+describe('Plugin Build Smoke Test', () => {
+  // Plugin installation requires Claude Code interactive commands
+  // We can only verify the build output here
+
+  before(() => {
+    execSync('npm run build:plugin', { cwd: ROOT, stdio: 'pipe' });
+  });
+
+  test('plugin build creates dist/plugin directory', () => {
+    assert.ok(
+      fs.existsSync(path.join(ROOT, 'dist/plugin')),
+      'dist/plugin should exist'
+    );
+  });
+
+  test('plugin.json exists', () => {
+    assert.ok(
+      fs.existsSync(path.join(ROOT, 'dist/plugin/.claude-plugin/plugin.json')),
+      'plugin.json should exist'
+    );
+  });
+
+  test('plugin.json has valid structure', () => {
+    const pluginJson = JSON.parse(
+      fs.readFileSync(path.join(ROOT, 'dist/plugin/.claude-plugin/plugin.json'), 'utf8')
+    );
+
+    assert.ok(pluginJson.name, 'plugin.json should have name');
+    assert.ok(pluginJson.version, 'plugin.json should have version');
+    assert.ok(pluginJson.description, 'plugin.json should have description');
+  });
+
+  test('plugin VERSION file exists', () => {
+    assert.ok(
+      fs.existsSync(path.join(ROOT, 'dist/plugin/VERSION')),
+      'VERSION should exist in plugin build'
+    );
+  });
+
+  test('plugin skills have transformed paths (not ~/.claude/)', () => {
+    const skillPath = path.join(ROOT, 'dist/plugin/skills/kata-executing-phases/SKILL.md');
+    if (fs.existsSync(skillPath)) {
+      const content = fs.readFileSync(skillPath, 'utf8');
+      assert.ok(
+        !content.includes('@~/.claude/kata/'),
+        'Plugin skills should NOT have ~/.claude/ paths'
+      );
+      assert.ok(
+        content.includes('@./kata/'),
+        'Plugin skills should have @./kata/ paths'
+      );
+    }
+  });
+
+  test('no stale ~/.claude/ references in plugin build', () => {
+    const pluginDir = path.join(ROOT, 'dist/plugin');
+    const result = spawnSync('grep', ['-r', '@~/.claude/', pluginDir], {
+      encoding: 'utf8'
+    });
+
+    assert.strictEqual(
+      result.stdout.trim(),
+      '',
+      `Plugin build should not contain ~/.claude/ references: ${result.stdout}`
+    );
+  });
+});
+
+describe('Claude CLI Integration', { skip: !process.env.TEST_CLI }, () => {
+  // These tests require Claude CLI and are opt-in via TEST_CLI=1
+  const cliTestDir = path.join(TEST_DIR, 'cli-test');
+
+  before(() => {
+    fs.mkdirSync(cliTestDir, { recursive: true });
+    execSync(`node ${path.join(ROOT, 'bin/install.js')} --local`, {
+      cwd: cliTestDir,
+      stdio: 'pipe'
+    });
+  });
+
+  test('claude --print with kata:help executes successfully', () => {
+    try {
+      const result = execSync(
+        'claude --print "Run /kata:help and summarize what commands are available"',
+        {
+          cwd: cliTestDir,
+          encoding: 'utf8',
+          timeout: 60000
+        }
+      );
+
+      assert.ok(
+        result.includes('kata') || result.includes('phase') || result.includes('project'),
+        'Claude should respond with kata-related content'
+      );
+    } catch (err) {
+      // Claude CLI might not be installed - skip gracefully
+      if (err.message.includes('command not found') || err.message.includes('ENOENT')) {
+        console.log('Skipping: Claude CLI not available');
+        return;
+      }
+      throw err;
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Patch release to fix marketplace version update issue.

### Fixed
- **Marketplace version update**: Fixed plugin-release workflow to update version in correct path (`.claude-plugin/marketplace.json`)

### Added
- Smoke tests (`tests/smoke.test.js`)
- Release management docs (`docs/release-mgmt.md`)

## Test plan
- [ ] CI passes
- [ ] Merge triggers publish workflow
- [ ] Plugin workflow updates marketplace.json to 1.0.2
- [ ] `claude plugin update kata@kata-marketplace` gets v1.0.2