### PR TITLE
Release v1.1.3

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kata",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Spec-driven development framework for Claude Code. Provides structured workflows for requirements gathering, research, planning, execution, and verification.",
   "author": {
     "name": "gannonh",

--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -61,9 +61,10 @@ jobs:
       - name: Validate plugin build
         if: steps.check_release.outputs.should_publish == 'true'
         run: |
-          # Verify critical files exist (Phase 2.2: skills-only, no commands)
+          # Verify critical files exist
           test -f dist/plugin/.claude-plugin/plugin.json
           test -d dist/plugin/skills
+          test -d dist/plugin/commands
           test -d dist/plugin/hooks
           test -d dist/plugin/agents
           test -f dist/plugin/VERSION

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,10 +65,11 @@ jobs:
       - name: Validate build artifacts
         if: steps.check.outputs.should_publish == 'true'
         run: |
-          # Verify critical files exist in dist (Phase 2.2: skills-only, no commands)
+          # Verify critical files exist in dist
           test -f dist/npm/bin/install.js
           test -f dist/npm/package.json
           test -d dist/npm/skills
+          test -d dist/npm/commands
           test -d dist/npm/hooks
           test -d dist/npm/agents
           echo "✓ All required files present"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+## [1.1.3] - 2026-01-25
+
+### Fixed
+- **Autocomplete not working**: Restored `commands/` layer as thin wrappers for skills. Skills provide the implementation, commands provide `/` menu autocomplete. This fixes autocomplete that broke in 1.1.0 when commands were removed.
+- **Command→skill mapping mismatch**: Fixed `executing-quick-tasks` command referencing wrong skill (`kata-executing-task-executes` → `kata-executing-quick-tasks`)
+- **Stale command references**: Removed references to non-existent `/kata:discussing-milestones` skill, fixed `/kata:update` → `/kata:updating`, fixed `/kata:analyze-codebase` → `/kata:mapping-codebases`
+
+### Changed
+- **Command naming convention**: All 27 commands renamed from old syntax to new gerund form (e.g., `phase-execute.md` → `executing-phases.md`, `project-new.md` → `starting-projects.md`)
+- **Build system**: Added commands to both NPM and plugin builds. Plugin build lifts `commands/kata/*` to `commands/*` and strips `kata:` prefix from command names.
+- **Tests and CI/CD**: Updated to validate commands directory exists in distributions
+
 ## [1.1.2] - 2026-01-25
 
 ### Fixed

--- a/agents/kata-entity-generator.md
+++ b/agents/kata-entity-generator.md
@@ -8,7 +8,7 @@ color: cyan
 <role>
 You are a Kata entity generator. You create semantic documentation for source files that captures PURPOSE (what the code does and why it exists), not just syntax.
 
-You are spawned by `/kata:analyze-codebase` with a list of file paths.
+You are spawned by `/kata:mapping-codebases` with a list of file paths.
 
 Your job: Read each file, analyze its purpose, write entity markdown to `.planning/intel/entities/`, return statistics only.
 </role>

--- a/commands/kata/adding-phases.md
+++ b/commands/kata/adding-phases.md
@@ -1,0 +1,20 @@
+---
+name: kata:adding-phases
+description: Add phase to end of current milestone in roadmap
+version: 0.1.0
+argument-hint: <description>
+disable-model-invocation: true
+allowed-tools:
+  - Read
+  - Write
+  - Bash
+---
+
+## Step 1: Parse Context
+
+Phase Description: "$ARGUMENTS"
+
+## Step 2: Invoke Skill
+
+Run the following skill to add the phase:
+`Skill("kata-adding-phases")`

--- a/commands/kata/adding-todos.md
+++ b/commands/kata/adding-todos.md
@@ -1,0 +1,20 @@
+---
+name: kata:adding-todos
+description: Capture idea or task as todo from current conversation context
+argument-hint: [optional description]
+version: 0.1.0
+disable-model-invocation: true
+allowed-tools:
+  - Read
+  - Write
+  - Bash
+---
+
+## Step 1: Parse Context
+
+Arguments: "$ARGUMENTS"
+
+## Step 2: Invoke Skill
+
+Run the following skill:
+`Skill("kata-adding-todos")`

--- a/commands/kata/auditing-milestones.md
+++ b/commands/kata/auditing-milestones.md
@@ -1,0 +1,20 @@
+---
+name: kata:auditing-milestones
+description: Audit milestone completion against original intent before archiving
+argument-hint: [version]
+version: 0.1.0
+disable-model-invocation: true
+allowed-tools:
+  - Read
+  - Write
+  - Bash
+---
+
+## Step 1: Parse Context
+
+Arguments: "$ARGUMENTS"
+
+## Step 2: Invoke Skill
+
+Run the following skill:
+`Skill("kata-auditing-milestones")`

--- a/commands/kata/checking-todos.md
+++ b/commands/kata/checking-todos.md
@@ -1,0 +1,20 @@
+---
+name: kata:checking-todos
+description: List pending todos and select one to work on
+argument-hint: [area filter]
+version: 0.1.0
+disable-model-invocation: true
+allowed-tools:
+  - Read
+  - Write
+  - Bash
+---
+
+## Step 1: Parse Context
+
+Arguments: "$ARGUMENTS"
+
+## Step 2: Invoke Skill
+
+Run the following skill:
+`Skill("kata-checking-todos")`

--- a/commands/kata/completing-milestones.md
+++ b/commands/kata/completing-milestones.md
@@ -1,0 +1,20 @@
+---
+name: kata:completing-milestones
+description: Archive completed milestone and prepare for next version
+argument-hint: <version>
+version: 0.1.0
+disable-model-invocation: true
+allowed-tools:
+  - Read
+  - Write
+  - Bash
+---
+
+## Step 1: Parse Context
+
+Arguments: "$ARGUMENTS"
+
+## Step 2: Invoke Skill
+
+Run the following skill:
+`Skill("kata-completing-milestones")`

--- a/commands/kata/configuring-settings.md
+++ b/commands/kata/configuring-settings.md
@@ -1,0 +1,20 @@
+---
+name: kata:configuring-settings
+description: Configure Kata workflow toggles and model profile
+argument-hint: <description>
+version: 0.1.0
+disable-model-invocation: true
+allowed-tools:
+  - Read
+  - Write
+  - Bash
+---
+
+## Step 1: Parse Context
+
+Arguments: "$ARGUMENTS"
+
+## Step 2: Invoke Skill
+
+Run the following skill:
+`Skill("kata-configuring-settings")`

--- a/commands/kata/debugging.md
+++ b/commands/kata/debugging.md
@@ -1,0 +1,20 @@
+---
+name: kata:debugging
+description: Systematic debugging with persistent state across context resets
+argument-hint: [issue description]
+version: 0.1.0
+disable-model-invocation: true
+allowed-tools:
+  - Read
+  - Write
+  - Bash
+---
+
+## Step 1: Parse Context
+
+Arguments: "$ARGUMENTS"
+
+## Step 2: Invoke Skill
+
+Run the following skill:
+`Skill("kata-debugging")`

--- a/commands/kata/discussing-phases.md
+++ b/commands/kata/discussing-phases.md
@@ -1,0 +1,20 @@
+---
+name: kata:discussing-phases
+description: Gather phase context through adaptive questioning before planning
+argument-hint: <phase>
+version: 0.1.0
+disable-model-invocation: true
+allowed-tools:
+  - Read
+  - Write
+  - Bash
+---
+
+## Step 1: Parse Context
+
+Arguments: "$ARGUMENTS"
+
+## Step 2: Invoke Skill
+
+Run the following skill:
+`Skill("kata-discussing-phases")`

--- a/commands/kata/executing-phases.md
+++ b/commands/kata/executing-phases.md
@@ -1,0 +1,20 @@
+---
+name: kata:executing-phases
+description: Execute all plans in a phase with wave-based parallelization
+argument-hint: <phase-number> [--gaps-only]
+version: 0.1.0
+disable-model-invocation: true
+allowed-tools:
+  - Read
+  - Write
+  - Bash
+---
+
+## Step 1: Parse Context
+
+Arguments: "$ARGUMENTS"
+
+## Step 2: Invoke Skill
+
+Run the following skill:
+`Skill("kata-executing-phases")`

--- a/commands/kata/executing-quick-tasks.md
+++ b/commands/kata/executing-quick-tasks.md
@@ -1,0 +1,20 @@
+---
+name: kata:executing-quick-tasks
+description: Execute a quick task with Kata guarantees (atomic commits, state tracking) but skip optional agents
+argument-hint: <description>
+version: 0.1.0
+disable-model-invocation: true
+allowed-tools:
+  - Read
+  - Write
+  - Bash
+---
+
+## Step 1: Parse Context
+
+Arguments: "$ARGUMENTS"
+
+## Step 2: Invoke Skill
+
+Run the following skill:
+`Skill("kata-executing-quick-tasks")`

--- a/commands/kata/inserting-phases.md
+++ b/commands/kata/inserting-phases.md
@@ -1,0 +1,20 @@
+---
+name: kata:inserting-phases
+description: Insert urgent work as decimal phase (e.g., 72.1) between existing phases
+argument-hint: <after> <description>
+version: 0.1.0
+disable-model-invocation: true
+allowed-tools:
+  - Read
+  - Write
+  - Bash
+---
+
+## Step 1: Parse Context
+
+Arguments: "$ARGUMENTS"
+
+## Step 2: Invoke Skill
+
+Run the following skill:
+`Skill("kata-inserting-phases")`

--- a/commands/kata/listing-phase-assumptions.md
+++ b/commands/kata/listing-phase-assumptions.md
@@ -1,0 +1,20 @@
+---
+name: kata:listing-phase-assumptions
+description: Surface Claude's assumptions about a phase approach before planning
+argument-hint: [phase]
+version: 0.1.0
+disable-model-invocation: true
+allowed-tools:
+  - Read
+  - Write
+  - Bash
+---
+
+## Step 1: Parse Context
+
+Arguments: "$ARGUMENTS"
+
+## Step 2: Invoke Skill
+
+Run the following skill:
+`Skill("kata-listing-phase-assumptions")`

--- a/commands/kata/mapping-codebases.md
+++ b/commands/kata/mapping-codebases.md
@@ -1,0 +1,20 @@
+---
+name: kata:mapping-codebases
+description: Analyze codebase with parallel mapper agents to produce .planning/codebase/ documents
+argument-hint: [optional: specific area to map, e.g., 'api' or 'auth']
+version: 0.1.0
+disable-model-invocation: true
+allowed-tools:
+  - Read
+  - Write
+  - Bash
+---
+
+## Step 1: Parse Context
+
+Arguments: "$ARGUMENTS"
+
+## Step 2: Invoke Skill
+
+Run the following skill:
+`Skill("kata-mapping-codebases")`

--- a/commands/kata/pausing-work.md
+++ b/commands/kata/pausing-work.md
@@ -1,0 +1,20 @@
+---
+name: kata:pausing-work
+description: Create context handoff when pausing work mid-phase
+argument-hint: <description>
+version: 0.1.0
+disable-model-invocation: true
+allowed-tools:
+  - Read
+  - Write
+  - Bash
+---
+
+## Step 1: Parse Context
+
+Arguments: "$ARGUMENTS"
+
+## Step 2: Invoke Skill
+
+Run the following skill:
+`Skill("kata-pausing-work")`

--- a/commands/kata/planning-milestone-gaps.md
+++ b/commands/kata/planning-milestone-gaps.md
@@ -1,0 +1,20 @@
+---
+name: kata:planning-milestone-gaps
+description: Create phases to close all gaps identified by milestone audit
+argument-hint: <description>
+version: 0.1.0
+disable-model-invocation: true
+allowed-tools:
+  - Read
+  - Write
+  - Bash
+---
+
+## Step 1: Parse Context
+
+Arguments: "$ARGUMENTS"
+
+## Step 2: Invoke Skill
+
+Run the following skill:
+`Skill("kata-planning-milestone-gaps")`

--- a/commands/kata/planning-phases.md
+++ b/commands/kata/planning-phases.md
@@ -1,0 +1,20 @@
+---
+name: kata:planning-phases
+description: Create detailed execution plan for a phase (PLAN.md) with verification loop
+argument-hint: [phase] [--research] [--skip-research] [--gaps] [--skip-verify]
+version: 0.1.0
+disable-model-invocation: true
+allowed-tools:
+  - Read
+  - Write
+  - Bash
+---
+
+## Step 1: Parse Context
+
+Arguments: "$ARGUMENTS"
+
+## Step 2: Invoke Skill
+
+Run the following skill:
+`Skill("kata-planning-phases")`

--- a/commands/kata/providing-help.md
+++ b/commands/kata/providing-help.md
@@ -1,0 +1,20 @@
+---
+name: kata:providing-help
+description: Show available Kata commands and usage guide
+argument-hint: <description>
+version: 0.1.0
+disable-model-invocation: true
+allowed-tools:
+  - Read
+  - Write
+  - Bash
+---
+
+## Step 1: Parse Context
+
+Arguments: "$ARGUMENTS"
+
+## Step 2: Invoke Skill
+
+Run the following skill:
+`Skill("kata-providing-help")`

--- a/commands/kata/removing-phases.md
+++ b/commands/kata/removing-phases.md
@@ -1,0 +1,20 @@
+---
+name: kata:removing-phases
+description: Remove a future phase from roadmap and renumber subsequent phases
+argument-hint: <phase-number>
+version: 0.1.0
+disable-model-invocation: true
+allowed-tools:
+  - Read
+  - Write
+  - Bash
+---
+
+## Step 1: Parse Context
+
+Arguments: "$ARGUMENTS"
+
+## Step 2: Invoke Skill
+
+Run the following skill:
+`Skill("kata-removing-phases")`

--- a/commands/kata/researching-phases.md
+++ b/commands/kata/researching-phases.md
@@ -1,0 +1,20 @@
+---
+name: kata:researching-phases
+description: Research how to implement a phase (standalone - usually use /kata:planning-phases instead)
+argument-hint: [phase]
+version: 0.1.0
+disable-model-invocation: true
+allowed-tools:
+  - Read
+  - Write
+  - Bash
+---
+
+## Step 1: Parse Context
+
+Arguments: "$ARGUMENTS"
+
+## Step 2: Invoke Skill
+
+Run the following skill:
+`Skill("kata-researching-phases")`

--- a/commands/kata/resuming-work.md
+++ b/commands/kata/resuming-work.md
@@ -1,0 +1,20 @@
+---
+name: kata:resuming-work
+description: Resume work from previous session with full context restoration
+argument-hint: <description>
+version: 0.1.0
+disable-model-invocation: true
+allowed-tools:
+  - Read
+  - Write
+  - Bash
+---
+
+## Step 1: Parse Context
+
+Arguments: "$ARGUMENTS"
+
+## Step 2: Invoke Skill
+
+Run the following skill:
+`Skill("kata-resuming-work")`

--- a/commands/kata/setting-profiles.md
+++ b/commands/kata/setting-profiles.md
@@ -1,0 +1,20 @@
+---
+name: kata:setting-profiles
+description: Switch model profile for Kata agents (quality/balanced/budget)
+argument-hint: <description>
+version: 0.1.0
+disable-model-invocation: true
+allowed-tools:
+  - Read
+  - Write
+  - Bash
+---
+
+## Step 1: Parse Context
+
+Arguments: "$ARGUMENTS"
+
+## Step 2: Invoke Skill
+
+Run the following skill:
+`Skill("kata-setting-profiles")`

--- a/commands/kata/showing-whats-new.md
+++ b/commands/kata/showing-whats-new.md
@@ -1,0 +1,20 @@
+---
+name: kata:showing-whats-new
+description: See what's new in Kata since your installed version
+argument-hint: <description>
+version: 0.1.0
+disable-model-invocation: true
+allowed-tools:
+  - Read
+  - Write
+  - Bash
+---
+
+## Step 1: Parse Context
+
+Arguments: "$ARGUMENTS"
+
+## Step 2: Invoke Skill
+
+Run the following skill:
+`Skill("kata-showing-whats-new")`

--- a/commands/kata/starting-milestones.md
+++ b/commands/kata/starting-milestones.md
@@ -1,0 +1,20 @@
+---
+name: kata:starting-milestones
+description: Start a new milestone cycle — update PROJECT.md and route to requirements
+argument-hint: [milestone name, e.g., 'v1.1 Notifications']
+version: 0.1.0
+disable-model-invocation: true
+allowed-tools:
+  - Read
+  - Write
+  - Bash
+---
+
+## Step 1: Parse Context
+
+Arguments: "$ARGUMENTS"
+
+## Step 2: Invoke Skill
+
+Run the following skill:
+`Skill("kata-starting-milestones")`

--- a/commands/kata/starting-projects.md
+++ b/commands/kata/starting-projects.md
@@ -1,0 +1,20 @@
+---
+name: kata:starting-projects
+description: Initialize a new project with deep context gathering and PROJECT.md
+argument-hint: <description>
+version: 0.1.0
+disable-model-invocation: true
+allowed-tools:
+  - Read
+  - Write
+  - Bash
+---
+
+## Step 1: Parse Context
+
+Arguments: "$ARGUMENTS"
+
+## Step 2: Invoke Skill
+
+Run the following skill:
+`Skill("kata-starting-projects")`

--- a/commands/kata/tracking-progress.md
+++ b/commands/kata/tracking-progress.md
@@ -1,0 +1,20 @@
+---
+name: kata:tracking-progress
+description: Check project progress, show context, and route to next action (execute or plan)
+argument-hint: <description>
+version: 0.1.0
+disable-model-invocation: true
+allowed-tools:
+  - Read
+  - Write
+  - Bash
+---
+
+## Step 1: Parse Context
+
+Arguments: "$ARGUMENTS"
+
+## Step 2: Invoke Skill
+
+Run the following skill:
+`Skill("kata-tracking-progress")`

--- a/commands/kata/updating.md
+++ b/commands/kata/updating.md
@@ -1,0 +1,20 @@
+---
+name: kata:updating
+description: Update Kata to latest version with changelog display
+argument-hint: <description>
+version: 0.1.0
+disable-model-invocation: true
+allowed-tools:
+  - Read
+  - Write
+  - Bash
+---
+
+## Step 1: Parse Context
+
+Arguments: "$ARGUMENTS"
+
+## Step 2: Invoke Skill
+
+Run the following skill:
+`Skill("kata-updating")`

--- a/commands/kata/verifying-work.md
+++ b/commands/kata/verifying-work.md
@@ -1,0 +1,20 @@
+---
+name: kata:verifying-work
+description: Validate built features through conversational UAT
+argument-hint: [phase number, e.g., '4']
+version: 0.1.0
+disable-model-invocation: true
+allowed-tools:
+  - Read
+  - Write
+  - Bash
+---
+
+## Step 1: Parse Context
+
+Arguments: "$ARGUMENTS"
+
+## Step 2: Invoke Skill
+
+Run the following skill:
+`Skill("kata-verifying-work")`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gannonh/kata",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "type": "module",
   "description": "Spec-driven development framework for Claude Code.",
   "scripts": {
@@ -21,6 +21,7 @@
     "bin",
     "kata",
     "agents",
+    "commands",
     "hooks",
     "skills"
   ],

--- a/skills/kata-starting-milestones/SKILL.md
+++ b/skills/kata-starting-milestones/SKILL.md
@@ -43,7 +43,7 @@ Milestone name: $ARGUMENTS (optional - will prompt if not provided)
 @.planning/MILESTONES.md
 @.planning/config.json
 
-**Load milestone context (if exists, from /kata:discuss-milestone):**
+**Load milestone context (if exists):**
 @.planning/MILESTONE-CONTEXT.md
 </context>
 
@@ -54,7 +54,7 @@ Milestone name: $ARGUMENTS (optional - will prompt if not provided)
 - Read PROJECT.md (existing project, Validated requirements, decisions)
 - Read MILESTONES.md (what shipped previously)
 - Read STATE.md (pending todos, blockers)
-- Check for MILESTONE-CONTEXT.md (from /kata:discuss-milestone)
+- Check for MILESTONE-CONTEXT.md (if exists)
 
 ## Phase 2: Gather Milestone Goals
 

--- a/skills/kata-updating/SKILL.md
+++ b/skills/kata-updating/SKILL.md
@@ -149,7 +149,7 @@ Cannot run update from within the Kata source directory.
 npm resolves @gannonh/kata locally instead of fetching from registry.
 
 **Solutions:**
-1. Run `/kata:update` from a different directory
+1. Run `/kata:updating` from a different directory
 2. Run `cd ~ && npx @gannonh/kata --global` manually
 3. Run `npm install -g @gannonh/kata` for global install
 ```

--- a/tests/build.test.js
+++ b/tests/build.test.js
@@ -23,9 +23,8 @@ describe('NPM build', () => {
     assert.ok(fs.existsSync(path.join(ROOT, 'dist/npm/package.json')));
   });
 
-  test('does NOT include commands directory (Phase 2.2 - skills-only)', () => {
-    // Phase 2.2: Commands layer removed, skills are the primary interface
-    assert.ok(!fs.existsSync(path.join(ROOT, 'dist/npm/commands')));
+  test('includes commands directory', () => {
+    assert.ok(fs.existsSync(path.join(ROOT, 'dist/npm/commands')));
   });
 
   test('includes skills directory', () => {
@@ -86,9 +85,8 @@ describe('Plugin build', () => {
     assert.ok(fs.existsSync(path.join(ROOT, 'dist/plugin/.claude-plugin/plugin.json')));
   });
 
-  test('does NOT include commands directory (Phase 2.2 - skills-only)', () => {
-    // Phase 2.2: Commands layer removed, skills are the primary interface
-    assert.ok(!fs.existsSync(path.join(ROOT, 'dist/plugin/commands')));
+  test('includes commands directory', () => {
+    assert.ok(fs.existsSync(path.join(ROOT, 'dist/plugin/commands')));
   });
 
   test('includes skills directory', () => {
@@ -510,7 +508,7 @@ describe('Workflow @-reference validation', () => {
   });
 });
 
-describe('Skill validation (Phase 2.2)', () => {
+describe('Skill and command validation', () => {
   /**
    * Parse YAML frontmatter from markdown content
    */
@@ -557,11 +555,11 @@ describe('Skill validation (Phase 2.2)', () => {
     }
   });
 
-  test('no commands directory exists (Phase 2.2)', () => {
-    // Phase 2.2: Commands layer completely removed
+  test('commands directory exists with kata subdirectory', () => {
+    // Commands provide autocomplete in Claude Code /menu
     assert.ok(
-      !fs.existsSync(path.join(ROOT, 'commands')),
-      'commands/ directory should not exist (Phase 2.2 - skills-only)'
+      fs.existsSync(path.join(ROOT, 'commands/kata')),
+      'commands/kata/ directory should exist for autocomplete support'
     );
   });
 });

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -75,11 +75,10 @@ describe('NPX Install Smoke Test', () => {
     );
   });
 
-  test('does NOT create commands directory (Phase 2.2 - skills-only)', () => {
-    // Phase 2.2: Commands layer removed, skills are the primary interface
+  test('install creates commands directory', () => {
     assert.ok(
-      !fs.existsSync(path.join(npxTestDir, '.claude/commands')),
-      '.claude/commands should NOT exist (skills-only architecture)'
+      fs.existsSync(path.join(npxTestDir, '.claude/commands')),
+      '.claude/commands directory should exist for autocomplete'
     );
   });
 


### PR DESCRIPTION
## Release v1.1.3

### Summary
Restores the commands layer for autocomplete support. Skills remain the implementation; commands are thin wrappers that provide `/` menu visibility.

### Changes
- **Autocomplete fixed**: Restored 27 command files as thin wrappers for skills
- **Command naming**: Renamed all commands to new gerund form (e.g., `phase-execute.md` → `executing-phases.md`)
- **Build system**: Commands included in NPM and plugin distributions
- **Bug fixes**: Fixed command→skill mapping mismatches and stale command references

### Checklist
- [x] Version bumped in package.json (1.1.3)
- [x] Version bumped in plugin.json (1.1.3)
- [x] CHANGELOG updated
- [x] Tests passing (44 build + 18 smoke)
- [x] CI/CD workflows updated to validate commands