### PR TITLE
Release v1.1.9

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kata",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "Spec-driven development framework for Claude Code. Provides structured workflows for requirements gathering, research, planning, execution, and verification.",
   "author": {
     "name": "gannonh",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [1.1.9] - 2026-01-25
+
+### Fixed
+- **Plugin skill invocation**: Removed commands from plugin build. Commands and skills had same namespace (`kata:adding-phases`) causing conflicts. Skills now handle everything in plugin context with `user-invocable: true`.
+
 ## [1.1.8] - 2026-01-25
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gannonh/kata",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "type": "module",
   "description": "Spec-driven development framework for Claude Code.",
   "scripts": {

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -66,10 +66,11 @@ const EXCLUDES = [
 
 /**
  * Files/directories to exclude from PLUGIN distribution only
- * (these are NPM-specific and don't work in plugin context)
+ * (these are NPM-specific or cause namespace conflicts)
  */
 const PLUGIN_EXCLUDES = [
   'skills/kata-updating',
+  'commands',  // Skills handle everything in plugin context - commands conflict
 ];
 
 /**
@@ -353,14 +354,8 @@ function buildPlugin() {
     }
   }
 
-  // Handle commands specially: lift commands/kata/* to commands/*
-  // NPX uses commands/kata/ for namespacing, plugin uses commands/ (plugin name provides namespace)
-  const commandsSrc = path.join(ROOT, 'commands', 'kata');
-  const commandsDest = path.join(dest, 'commands');
-  if (fs.existsSync(commandsSrc)) {
-    copyDir(commandsSrc, commandsDest, transformPluginContent);
-    console.log(`  ${green}✓${reset} Copied commands (lifted from commands/kata/)`);
-  }
+  // Commands excluded from plugin - skills handle everything
+  // (commands create namespace conflicts with skills in plugin context)
 
   // Copy plugin-specific files
   for (const item of PLUGIN_INCLUDES) {

--- a/skills/kata-adding-phases/SKILL.md
+++ b/skills/kata-adding-phases/SKILL.md
@@ -2,7 +2,7 @@
 name: kata-adding-phases
 description: Use this skill to add planned work discovered during execution to the end of the current milestone in the roadmap. This skill appends sequential phases to the current milestone's phase list, automatically calculating the next phase number. Triggers include "add phase", "append phase", "new phase", and "create phase". This skill updates ROADMAP.md and STATE.md accordingly.
 version: 0.1.0
-user-invocable: false
+user-invocable: true
 disable-model-invocation: false
 allowed-tools:
   - Read

--- a/skills/kata-adding-todos/SKILL.md
+++ b/skills/kata-adding-todos/SKILL.md
@@ -2,7 +2,7 @@
 name: kata-adding-todos
 description: Use this skill to capture an idea, task, or issue that surfaces during a Kata session as a structured todo for later work. This skill creates markdown todo files in the .planning/todos/pending directory with relevant metadata and content extracted from the conversation. Triggers include "add todo", "capture todo", "new todo", and "create todo". 
 version: 0.1.0
-user-invocable: false
+user-invocable: true
 disable-model-invocation: false
 allowed-tools:
   - Read

--- a/skills/kata-auditing-milestones/SKILL.md
+++ b/skills/kata-auditing-milestones/SKILL.md
@@ -2,7 +2,7 @@
 name: kata-auditing-milestones
 description: Use this skill to verify milestone achievement against its definition of done, checking requirements coverage, cross-phase integration, and end-to-end flows. Triggers include "audit milestone", "verify milestone", "check milestone", and "milestone audit". This skill reads existing phase verification files, aggregates technical debt and gaps, and spawns an integration checker for cross-phase wiring.
 version: 0.1.0
-user-invocable: false
+user-invocable: true
 disable-model-invocation: false
 allowed-tools:
   - Read

--- a/skills/kata-checking-todos/SKILL.md
+++ b/skills/kata-checking-todos/SKILL.md
@@ -2,7 +2,7 @@
 name: kata-checking-todos
 description: Use this skill when reviewing pending todos, selecting a todo to work on, filtering todos by area, or deciding what to work on next. Triggers include "check todos", "list todos", "what todos", "pending todos", "show todos", "view todos", and "select todo to work on".
 version: 0.1.0
-user-invocable: false
+user-invocable: true
 disable-model-invocation: false
 allowed-tools:
   - Read

--- a/skills/kata-completing-milestones/SKILL.md
+++ b/skills/kata-completing-milestones/SKILL.md
@@ -2,7 +2,7 @@
 name: kata-completing-milestones
 description: Use this skill when archiving a completed milestone, preparing for the next version, marking a milestone complete, shipping a version, or wrapping up milestone work. Triggers include "complete milestone", "finish milestone", "archive milestone", "ship version", "mark milestone done", and "milestone complete".
 version: 0.1.0
-user-invocable: false
+user-invocable: true
 disable-model-invocation: false
 allowed-tools:
   - Read

--- a/skills/kata-configuring-settings/SKILL.md
+++ b/skills/kata-configuring-settings/SKILL.md
@@ -2,7 +2,7 @@
 name: kata-configuring-settings
 description: Use this skill when configure kata workflow toggles and model profile. Triggers include "settings".
 version: 0.1.0
-user-invocable: false
+user-invocable: true
 disable-model-invocation: false
 allowed-tools:
   - Read

--- a/skills/kata-debugging/SKILL.md
+++ b/skills/kata-debugging/SKILL.md
@@ -2,7 +2,7 @@
 name: kata-debugging
 description: Use this skill when systematically debugging issues, investigating bugs, troubleshooting problems, or tracking down errors with persistent state across context resets. Triggers include "debug", "investigate bug", "troubleshoot", "find the problem", "why isn't this working", and "debug session".
 version: 0.1.0
-user-invocable: false
+user-invocable: true
 disable-model-invocation: false
 allowed-tools:
   - Read

--- a/skills/kata-discussing-phases/SKILL.md
+++ b/skills/kata-discussing-phases/SKILL.md
@@ -2,7 +2,7 @@
 name: kata-discussing-phases
 description: Use this skill when gathering phase context through adaptive questioning before planning, clarifying implementation decisions, or exploring gray areas for a phase. Triggers include "discuss phase", "clarify phase", "gather context", "what are the gray areas", and "phase discussion".
 version: 0.1.0
-user-invocable: false
+user-invocable: true
 disable-model-invocation: false
 allowed-tools:
   - Read

--- a/skills/kata-executing-phases/SKILL.md
+++ b/skills/kata-executing-phases/SKILL.md
@@ -2,7 +2,7 @@
 name: kata-executing-phases
 description: Use this skill when executing all plans in a phase with wave-based parallelization, running phase execution, or completing phase work. Triggers include "execute phase", "run phase", "execute plans", "run the phase", and "phase execution".
 version: 0.1.0
-user-invocable: false
+user-invocable: true
 disable-model-invocation: false
 allowed-tools:
   - Read

--- a/skills/kata-executing-quick-tasks/SKILL.md
+++ b/skills/kata-executing-quick-tasks/SKILL.md
@@ -2,7 +2,7 @@
 name: kata-executing-quick-tasks
 description: Use this skill when executing small ad-hoc tasks with Kata guarantees, running quick tasks without full planning, or handling one-off work outside the roadmap. Triggers include "quick task", "quick mode", "quick fix", "ad-hoc task", "small task", and "one-off task".
 version: 0.1.0
-user-invocable: false
+user-invocable: true
 disable-model-invocation: false
 allowed-tools:
   - Read

--- a/skills/kata-inserting-phases/SKILL.md
+++ b/skills/kata-inserting-phases/SKILL.md
@@ -2,7 +2,7 @@
 name: kata-inserting-phases
 description: Use this skill when inserting urgent work as a decimal phase between existing phases, adding mid-milestone work, or creating intermediate phases. Triggers include "insert phase", "add urgent phase", "create decimal phase", "insert between phases", and "urgent work".
 version: 0.1.0
-user-invocable: false
+user-invocable: true
 disable-model-invocation: false
 allowed-tools:
   - Read

--- a/skills/kata-listing-phase-assumptions/SKILL.md
+++ b/skills/kata-listing-phase-assumptions/SKILL.md
@@ -2,7 +2,7 @@
 name: kata-listing-phase-assumptions
 description: Use this skill when surfacing Claude's assumptions about a phase approach before planning, checking what Claude thinks, or validating understanding before planning. Triggers include "list assumptions", "what are you thinking", "show assumptions", "phase assumptions", and "what's the plan".
 version: 0.1.0
-user-invocable: false
+user-invocable: true
 disable-model-invocation: false
 allowed-tools:
   - Read

--- a/skills/kata-mapping-codebases/SKILL.md
+++ b/skills/kata-mapping-codebases/SKILL.md
@@ -2,7 +2,7 @@
 name: kata-mapping-codebases
 description: Use this skill when analyzing an existing codebase with parallel mapper agents, creating codebase documentation, understanding brownfield projects, or mapping code structure. Triggers include "map codebase", "analyze codebase", "document codebase", "understand code", and "codebase map".
 version: 0.1.0
-user-invocable: false
+user-invocable: true
 disable-model-invocation: false
 allowed-tools:
   - Read

--- a/skills/kata-pausing-work/SKILL.md
+++ b/skills/kata-pausing-work/SKILL.md
@@ -2,7 +2,7 @@
 name: kata-pausing-work
 description: Use this skill when creating a context handoff file, pausing work mid-phase, stopping work temporarily, or creating a checkpoint for session resumption. Triggers include "pause work", "stop work", "create handoff", "save progress", and "pause session".
 version: 0.1.0
-user-invocable: false
+user-invocable: true
 disable-model-invocation: false
 allowed-tools:
   - Read

--- a/skills/kata-planning-milestone-gaps/SKILL.md
+++ b/skills/kata-planning-milestone-gaps/SKILL.md
@@ -2,7 +2,7 @@
 name: kata-planning-milestone-gaps
 description: Use this skill when create phases to close all gaps identified by milestone audit. Triggers include "plan milestone gaps", "plan gaps".
 version: 0.1.0
-user-invocable: false
+user-invocable: true
 disable-model-invocation: false
 allowed-tools:
   - Read

--- a/skills/kata-planning-phases/SKILL.md
+++ b/skills/kata-planning-phases/SKILL.md
@@ -2,7 +2,7 @@
 name: kata-planning-phases
 description: Use this skill when create detailed execution plan for a phase (plan.md) with verification loop. Triggers include "plan phase", "plan phase".
 version: 0.1.0
-user-invocable: false
+user-invocable: true
 disable-model-invocation: false
 allowed-tools:
   - Read

--- a/skills/kata-providing-help/SKILL.md
+++ b/skills/kata-providing-help/SKILL.md
@@ -2,7 +2,7 @@
 name: kata-providing-help
 description: Use this skill when showing available Kata commands, displaying the usage guide, explaining command reference, or when the user asks for help with Kata. Triggers include "help", "show commands", "list commands", "what commands", "kata commands", and "usage guide".
 version: 0.1.0
-user-invocable: false
+user-invocable: true
 disable-model-invocation: false
 allowed-tools:
   - Read

--- a/skills/kata-removing-phases/SKILL.md
+++ b/skills/kata-removing-phases/SKILL.md
@@ -2,7 +2,7 @@
 name: kata-removing-phases
 description: Use this skill when remove a future phase from roadmap and renumber subsequent phases. Triggers include "remove phase", "remove phase".
 version: 0.1.0
-user-invocable: false
+user-invocable: true
 disable-model-invocation: false
 allowed-tools:
   - Read

--- a/skills/kata-researching-phases/SKILL.md
+++ b/skills/kata-researching-phases/SKILL.md
@@ -2,7 +2,7 @@
 name: kata-researching-phases
 description: Use this skill when researching how to implement a phase standalone, investigating implementation approaches before planning, or re-researching after planning is complete. Triggers include "research phase", "investigate phase", "how to implement", "research implementation", and "phase research".
 version: 0.1.0
-user-invocable: false
+user-invocable: true
 disable-model-invocation: false
 allowed-tools:
   - Read

--- a/skills/kata-resuming-work/SKILL.md
+++ b/skills/kata-resuming-work/SKILL.md
@@ -2,7 +2,7 @@
 name: kata-resuming-work
 description: Use this skill when resuming work from a previous session, restoring context after a break, continuing work after /clear, or picking up where you left off. Triggers include "resume work", "continue work", "pick up where I left off", "restore context", and "resume session".
 version: 0.1.0
-user-invocable: false
+user-invocable: true
 disable-model-invocation: false
 allowed-tools:
   - Read

--- a/skills/kata-setting-profiles/SKILL.md
+++ b/skills/kata-setting-profiles/SKILL.md
@@ -2,7 +2,7 @@
 name: kata-setting-profiles
 description: Use this skill when switch model profile for kata agents (quality/balanced/budget). Triggers include "set profile", "set profile".
 version: 0.1.0
-user-invocable: false
+user-invocable: true
 disable-model-invocation: false
 allowed-tools:
   - Read

--- a/skills/kata-showing-whats-new/SKILL.md
+++ b/skills/kata-showing-whats-new/SKILL.md
@@ -2,7 +2,7 @@
 name: kata-showing-whats-new
 description: Use this skill when showing what's new in Kata since the installed version, displaying changelog entries, checking for Kata updates, or reviewing recent changes. Triggers include "what's new", "whats new", "show changes", "changelog", "recent changes", and "what changed".
 version: 0.1.0
-user-invocable: false
+user-invocable: true
 disable-model-invocation: false
 allowed-tools:
   - Read

--- a/skills/kata-starting-milestones/SKILL.md
+++ b/skills/kata-starting-milestones/SKILL.md
@@ -2,7 +2,7 @@
 name: kata-starting-milestones
 description: Use this skill when starting a new milestone cycle, beginning the next version, creating a new milestone, or planning what's next after completing a milestone. Triggers include "new milestone", "start milestone", "next milestone", "create milestone", and "milestone cycle".
 version: 0.1.0
-user-invocable: false
+user-invocable: true
 disable-model-invocation: false
 allowed-tools:
   - Read

--- a/skills/kata-starting-projects/SKILL.md
+++ b/skills/kata-starting-projects/SKILL.md
@@ -2,7 +2,7 @@
 name: kata-starting-projects
 description: Use this skill when initialize a new project with deep context gathering and project.md. Triggers include "new project", "start project", "initialize project", "create project", "begin project", "setup project".
 version: 0.1.0
-user-invocable: false
+user-invocable: true
 disable-model-invocation: false
 allowed-tools:
   - Read

--- a/skills/kata-tracking-progress/SKILL.md
+++ b/skills/kata-tracking-progress/SKILL.md
@@ -2,7 +2,7 @@
 name: kata-tracking-progress
 description: Use this skill when check project progress, show context, and route to next action (execute or plan). Triggers include "progress".
 version: 0.1.0
-user-invocable: false
+user-invocable: true
 disable-model-invocation: false
 allowed-tools:
   - Read

--- a/skills/kata-updating/SKILL.md
+++ b/skills/kata-updating/SKILL.md
@@ -2,7 +2,7 @@
 name: kata-updating
 description: Use this skill when update kata to latest version with changelog display. Triggers include "update".
 version: 0.1.0
-user-invocable: false
+user-invocable: true
 disable-model-invocation: false
 allowed-tools:
   - Read

--- a/skills/kata-verifying-work/SKILL.md
+++ b/skills/kata-verifying-work/SKILL.md
@@ -2,7 +2,7 @@
 name: kata-verifying-work
 description: Use this skill when validating built features through conversational testing, running UAT, user acceptance testing, checking if features work, or verifying implementation. Triggers include "verify work", "test features", "UAT", "user testing", "check if it works", and "validate features".
 version: 0.1.0
-user-invocable: false
+user-invocable: true
 disable-model-invocation: false
 allowed-tools:
   - Read

--- a/tests/build.test.js
+++ b/tests/build.test.js
@@ -85,8 +85,9 @@ describe('Plugin build', () => {
     assert.ok(fs.existsSync(path.join(ROOT, 'dist/plugin/.claude-plugin/plugin.json')));
   });
 
-  test('includes commands directory', () => {
-    assert.ok(fs.existsSync(path.join(ROOT, 'dist/plugin/commands')));
+  test('does NOT include commands directory (skills handle everything)', () => {
+    // Commands excluded from plugin - skills are user-invocable and handle everything
+    assert.ok(!fs.existsSync(path.join(ROOT, 'dist/plugin/commands')));
   });
 
   test('includes skills directory', () => {
@@ -528,8 +529,8 @@ describe('Skill and command validation', () => {
     return frontmatter;
   }
 
-  test('all skills are NOT user-invocable (commands provide autocomplete)', () => {
-    // Commands provide autocomplete, skills provide implementation
+  test('all skills are user-invocable (plugin has no commands)', () => {
+    // Skills are user-invocable for plugin distribution (no commands to conflict)
     const skillsDir = path.join(ROOT, 'skills');
     if (!fs.existsSync(skillsDir)) return;
 
@@ -545,21 +546,21 @@ describe('Skill and command validation', () => {
       const content = fs.readFileSync(skillFile, 'utf8');
       const frontmatter = parseFrontmatter(content);
 
-      if (frontmatter && frontmatter['user-invocable'] === 'true') {
-        errors.push(`${dir}: user-invocable should be false (commands provide autocomplete)`);
+      if (frontmatter && frontmatter['user-invocable'] === 'false') {
+        errors.push(`${dir}: user-invocable should be true (no commands in plugin)`);
       }
     }
 
     if (errors.length > 0) {
-      assert.fail(`User-invocable skills found (should use commands for autocomplete):\n${errors.join('\n')}`);
+      assert.fail(`Non-invocable skills found:\n${errors.join('\n')}`);
     }
   });
 
-  test('commands directory exists with kata subdirectory', () => {
-    // Commands provide autocomplete in Claude Code /menu
+  test('commands directory exists with kata subdirectory (for NPM)', () => {
+    // Commands exist for NPM distribution (npx @gannonh/kata)
     assert.ok(
       fs.existsSync(path.join(ROOT, 'commands/kata')),
-      'commands/kata/ directory should exist for autocomplete support'
+      'commands/kata/ directory should exist for NPM distribution'
     );
   });
 });


### PR DESCRIPTION
## Summary
- Remove commands from plugin build
- Skills handle everything with `user-invocable: true`

## Root cause
Commands and skills had same namespace (`kata:adding-phases`) causing Skill() tool to match the command (blocked by `disable-model-invocation: true`) instead of the skill.

## Fix
Plugin distribution now only has skills. No commands = no namespace conflict.