### PR TITLE
docs: add Mintlify documentation site

### DIFF
--- a/docs/advanced/brownfield-projects.mdx
+++ b/docs/advanced/brownfield-projects.mdx
@@ -1,0 +1,60 @@
+---
+title: 'Brownfield Projects'
+description: 'Using Kata with existing codebases'
+---
+
+## Overview
+
+Kata works with existing codebases. Use the codebase mapping skill before project initialization to help Claude understand your patterns.
+
+## Codebase Mapping
+
+<CodeGroup>
+
+```bash Plugin
+/kata:mapping-codebases
+```
+
+```bash NPX
+/kata-mapping-codebases
+```
+
+</CodeGroup>
+
+Spawns parallel agents to analyze:
+- Technology stack
+- Architecture patterns
+- Code conventions
+- Domain concerns
+
+## Workflow
+
+1. **Map codebase** — Run mapping skill
+2. **Initialize project** — Run `/kata:starting-projects`
+3. **Questions use context** — System knows your codebase
+4. **Planning loads patterns** — Agents reference your conventions
+
+## What Gets Analyzed
+
+- File structure
+- Naming conventions
+- Technology choices
+- Architectural patterns
+- Testing approach
+- Build system
+- Deployment setup
+
+## Output
+
+Creates `.planning/intel/` with:
+- `index.json` — File exports/imports
+- `conventions.json` — Detected patterns
+- `summary.md` — Concise context for injection
+
+## Auto-Indexing
+
+Kata automatically indexes code as you work:
+- **PostToolUse hook** — Updates index on file changes
+- **SessionStart hook** — Loads context on startup
+
+Brownfield setup is one-time. Ongoing work maintains intelligence automatically.

--- a/docs/advanced/context-engineering.mdx
+++ b/docs/advanced/context-engineering.mdx
@@ -1,0 +1,70 @@
+---
+title: 'Context Engineering'
+description: 'How Kata manages Claude context deliberately'
+---
+
+## The Context Problem
+
+Claude's quality degrades as context fills up. At 70%+ context usage, quality drops significantly.
+
+## Kata's Solution
+
+Manage context deliberately through:
+
+1. **Thin orchestrators** — Stay at ~30% context
+2. **Fresh agent contexts** — 200k tokens per spawn
+3. **Progressive disclosure** — Load only what's needed
+4. **Structured state** — Memory across sessions
+
+## Quality Curve
+
+| Context Level | Quality    | Strategy                  |
+| ------------- | ---------- | ------------------------- |
+| 0-30%         | Peak       | Orchestrators stay here   |
+| 30-50%        | Good       | Acceptable for light work |
+| 50-70%        | Degrading  | Time to wrap up           |
+| 70%+          | Poor       | Spawn fresh agent         |
+
+## Context Flow
+
+```
+Main Context (Orchestrator)
+    ↓ Load minimal context
+PROJECT.md + REQUIREMENTS.md + Current phase
+    ↓ Spawn agent
+Agent Context (Fresh 200k)
+    ↓ Work completes
+Results return
+    ↓
+Main Context still at ~30%
+```
+
+## File-Based Context
+
+| File | Purpose | Always Loaded? |
+| ---- | ------- | -------------- |
+| PROJECT.md | Project vision | Yes |
+| REQUIREMENTS.md | Scoped requirements | For planning/execution |
+| ROADMAP.md | Phase structure | For navigation |
+| STATE.md | Session memory | For resuming |
+| PLAN.md | Task instructions | For execution only |
+
+## Progressive Disclosure
+
+Use `@-references` to load context on demand:
+
+```markdown
+@~/.claude/kata/workflows/phase-execute.md
+@.planning/PROJECT.md
+```
+
+Only load when actually needed.
+
+## Size Constraints
+
+Based on where quality degrades:
+
+- **Plans:** 2-3 tasks max
+- **Context usage:** Orchestrators under 30%
+- **Task scope:** >5 files → split
+- **Phase scope:** >3 plans → consider splitting

--- a/docs/advanced/multi-agent-orchestration.mdx
+++ b/docs/advanced/multi-agent-orchestration.mdx
@@ -1,0 +1,70 @@
+---
+title: 'Multi-Agent Orchestration'
+description: 'How Kata uses specialized agents with fresh contexts'
+---
+
+## Pattern
+
+Kata uses a **thin orchestrator + specialized agents** pattern:
+
+```
+Orchestrator (Skill at ~30% context)
+    ↓ spawns
+Agent 1 (fresh 200k tokens)
+    ↓ completes
+Results to Orchestrator
+    ↓ spawns
+Agent 2 (fresh 200k tokens)
+    ↓ completes
+Results to Orchestrator
+```
+
+The orchestrator never does heavy lifting. It coordinates.
+
+## Orchestrators
+
+| Orchestrator (Skill) | Spawns | Purpose |
+| -------------------- | ------ | ------- |
+| `kata-planning-phases` | kata-phase-researcher, kata-planner, kata-plan-checker | Research → Plan → Verify loop |
+| `kata-executing-phases` | kata-executor (multiple in parallel) | Execute plans in waves |
+| `kata-verifying-phases` | kata-verifier, kata-debugger | Check goals, diagnose failures |
+
+## Agents
+
+Specialized subagents for focused tasks:
+
+- **kata-planner** — Creates execution plans
+- **kata-executor** — Implements tasks
+- **kata-verifier** — Checks work against goals
+- **kata-debugger** — Diagnoses failures
+- **kata-phase-researcher** — Investigates domain
+
+Each agent:
+- Works in fresh 200k context
+- Has single responsibility
+- Returns results only
+- Is stateless (orchestrator manages state)
+
+## Parallel Execution
+
+Independent agents run simultaneously:
+
+```
+Orchestrator
+    ↓
+├─ Agent 1 (wave 1)
+├─ Agent 2 (wave 1)
+└─ Agent 3 (wave 1)
+    ↓ all complete
+├─ Agent 4 (wave 2)
+└─ Agent 5 (wave 2)
+```
+
+Plans grouped into waves based on dependencies.
+
+## Benefits
+
+1. **Fresh context per task** — Quality stays high
+2. **Parallel execution** — Work completes faster
+3. **Specialization** — Each agent optimized for its purpose
+4. **Orchestrator stays lean** — Never accumulates garbage

--- a/docs/advanced/xml-prompting.mdx
+++ b/docs/advanced/xml-prompting.mdx
@@ -1,0 +1,97 @@
+---
+title: 'XML Prompting'
+description: 'Why Kata uses XML structure in plans'
+---
+
+## Plans ARE Prompts
+
+PLAN.md files are executable XML documents optimized for Claude. When an executor agent reads a plan, it's reading its instructions directly.
+
+## Why XML?
+
+1. **Semantic structure** — Tags have meaning, not just hierarchy
+2. **Claude-optimized** — Claude parses XML exceptionally well
+3. **Precise instructions** — No ambiguity in what goes where
+4. **Progressive disclosure** — Nested structure for complexity
+
+## Task Structure
+
+```xml
+<task type="auto">
+  <name>Create login endpoint</name>
+  <files>src/app/api/auth/login/route.ts</files>
+  <action>
+    POST endpoint accepting {email, password}.
+    Query User by email, compare password with bcrypt.
+    On match, create JWT with jose library, set as httpOnly cookie.
+    Return 200. On mismatch, return 401.
+  </action>
+  <verify>curl -X POST localhost:3000/api/auth/login returns 200 with Set-Cookie</verify>
+  <done>Valid credentials → 200 + cookie. Invalid → 401.</done>
+</task>
+```
+
+## Task Types
+
+### auto
+
+Standard implementation. Claude executes autonomously.
+
+### checkpoint:human-verify
+
+Human verification required.
+
+```xml
+<task type="checkpoint:human-verify" gate="blocking">
+  <what-built>Login page with form</what-built>
+  <how-to-verify>
+    1. Navigate to /login
+    2. Enter valid credentials
+    3. Verify redirect to dashboard
+  </how-to-verify>
+  <resume-signal>Reply "continue" after testing</resume-signal>
+</task>
+```
+
+### checkpoint:decision
+
+User must choose between options.
+
+```xml
+<task type="checkpoint:decision" gate="blocking">
+  <decision>Which auth library?</decision>
+  <context>Need JWT handling</context>
+  <options>
+    <option id="jose">
+      <name>jose</name>
+      <pros>Modern, ESM-friendly</pros>
+      <cons>Less examples</cons>
+    </option>
+    <option id="jwt">
+      <name>jsonwebtoken</name>
+      <pros>Popular, well-documented</pros>
+      <cons>CommonJS issues</cons>
+    </option>
+  </options>
+  <resume-signal>Select "jose" or "jwt"</resume-signal>
+</task>
+```
+
+## Conditional Logic
+
+```xml
+<if mode="yolo">
+  Auto-execute without confirmation
+</if>
+
+<if mode="interactive">
+  Wait for user approval
+</if>
+```
+
+## Benefits
+
+1. **No transformation** — Plans execute as-written
+2. **Clear structure** — No parsing ambiguity
+3. **Verification built-in** — Every task has `<verify>` and `<done>`
+4. **Machine-readable** — Can be parsed programmatically

--- a/docs/api-reference/introduction.mdx
+++ b/docs/api-reference/introduction.mdx
@@ -1,0 +1,62 @@
+---
+title: 'API Reference'
+description: 'API documentation for Kata'
+---
+
+## Overview
+
+This section contains API documentation for Kata. More content coming soon.
+
+## Skills API
+
+All Kata skills can be invoked programmatically or via natural language.
+
+### Invocation Syntax
+
+| Installation | Syntax               | Example                   |
+| ------------ | -------------------- | ------------------------- |
+| Plugin       | `/kata:skill-name`   | `/kata:planning-phases 2` |
+| NPX          | `/kata-skill-name`   | `/kata-planning-phases 2` |
+
+### Natural Language
+
+```
+"Plan phase 2"
+"Execute the phase"
+"What's the status?"
+```
+
+## File Structure
+
+Kata creates and maintains these files:
+
+| File | Location | Purpose |
+| ---- | -------- | ------- |
+| PROJECT.md | .planning/ | Project vision |
+| REQUIREMENTS.md | .planning/ | Scoped requirements |
+| ROADMAP.md | .planning/ | Phase breakdown |
+| STATE.md | .planning/ | Session memory |
+| {phase}-{plan}-PLAN.md | .planning/phases/{phase}/ | Execution plans |
+| {phase}-{plan}-SUMMARY.md | .planning/phases/{phase}/ | Post-execution records |
+
+## Configuration API
+
+Configuration is stored in `.planning/config.json`:
+
+```json
+{
+  "mode": "interactive",
+  "depth": "standard",
+  "model_profile": "balanced",
+  "workflow": {
+    "research": true,
+    "plan_check": true,
+    "verifier": true
+  },
+  "parallelization": {
+    "enabled": true
+  }
+}
+```
+
+See [Configuration](/configuration/settings) for details.

--- a/docs/configuration/model-profiles.mdx
+++ b/docs/configuration/model-profiles.mdx
@@ -1,0 +1,38 @@
+---
+title: 'Model Profiles'
+description: 'Balance quality vs token spend'
+---
+
+## Overview
+
+Model profiles control which Claude model each agent uses. Balance quality vs token spend based on your needs.
+
+## Available Profiles
+
+| Profile | Planning | Execution | Verification |
+| ------- | -------- | --------- | ------------ |
+| `quality` | Opus | Opus | Sonnet |
+| `balanced` (default) | Opus | Sonnet | Sonnet |
+| `budget` | Sonnet | Sonnet | Haiku |
+
+## Switch Profiles
+
+<CodeGroup>
+
+```bash Plugin
+/kata:setting-profiles budget
+```
+
+```bash NPX
+/kata-setting-profiles budget
+```
+
+</CodeGroup>
+
+Or configure via `/kata:configuring-settings`.
+
+## Recommendations
+
+- **quality** — Critical projects, unfamiliar domains
+- **balanced** — Default, good for most use cases
+- **budget** — Well-understood work, tight token budget

--- a/docs/configuration/settings.mdx
+++ b/docs/configuration/settings.mdx
@@ -1,0 +1,82 @@
+---
+title: 'Settings'
+description: 'Configure Kata for your needs'
+---
+
+## Overview
+
+Kata stores project settings in `.planning/config.json`. Configure during project initialization or update later with `/kata:configuring-settings`.
+
+## Core Settings
+
+### Mode
+
+Controls auto-approval behavior:
+
+| Mode | Behavior |
+| ---- | -------- |
+| `yolo` | Auto-approve all steps |
+| `interactive` | Confirm at each step (default) |
+
+### Depth
+
+Controls planning thoroughness:
+
+| Depth | Plans per Phase | Use Case |
+| ----- | --------------- | -------- |
+| `quick` | 1-3 | Rapid prototyping |
+| `standard` | 3-5 | Balanced (default) |
+| `comprehensive` | 5-10 | Complex domains |
+
+## Configuration
+
+Use the configuration skill:
+
+<CodeGroup>
+
+```bash Plugin
+/kata:configuring-settings
+```
+
+```bash NPX
+/kata-configuring-settings
+```
+
+</CodeGroup>
+
+Or edit `.planning/config.json` directly:
+
+```json
+{
+  "mode": "interactive",
+  "depth": "standard",
+  "model_profile": "balanced",
+  "workflow": {
+    "research": true,
+    "plan_check": true,
+    "verifier": true
+  },
+  "parallelization": {
+    "enabled": true
+  }
+}
+```
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card
+    title="Model Profiles"
+    icon="brain"
+    href="/configuration/model-profiles"
+  >
+    Control which Claude model each agent uses
+  </Card>
+  <Card
+    title="Workflow Agents"
+    icon="robot"
+    href="/configuration/workflow-agents"
+  >
+    Toggle optional workflow agents
+  </Card>
+</CardGroup>

--- a/docs/configuration/workflow-agents.mdx
+++ b/docs/configuration/workflow-agents.mdx
@@ -1,0 +1,58 @@
+---
+title: 'Workflow Agents'
+description: 'Toggle optional workflow agents'
+---
+
+## Overview
+
+These agents spawn during planning/execution. They improve quality but add tokens and time.
+
+## Available Agents
+
+### Research Agent
+
+**Setting:** `workflow.research`
+
+**Default:** `true`
+
+**Purpose:** Investigates domain before planning each phase
+
+**Skip per-invocation:**
+```bash
+/kata:planning-phases 1 --skip-research
+```
+
+### Plan Checker
+
+**Setting:** `workflow.plan_check`
+
+**Default:** `true`
+
+**Purpose:** Verifies plans achieve phase goals before execution
+
+**Skip per-invocation:**
+```bash
+/kata:planning-phases 1 --skip-verify
+```
+
+### Verifier
+
+**Setting:** `workflow.verifier`
+
+**Default:** `true`
+
+**Purpose:** Confirms must-haves were delivered after execution
+
+## Configuration
+
+Use `/kata:configuring-settings` to toggle, or edit `.planning/config.json`:
+
+```json
+{
+  "workflow": {
+    "research": true,
+    "plan_check": true,
+    "verifier": true
+  }
+}
+```

--- a/docs/contributing/development-setup.mdx
+++ b/docs/contributing/development-setup.mdx
@@ -1,0 +1,80 @@
+---
+title: 'Development Setup'
+description: 'Set up Kata for development'
+---
+
+## Clone Repository
+
+```bash
+git clone https://github.com/gannonh/kata.git
+cd kata
+```
+
+## Install Locally
+
+```bash
+node bin/install.js --local
+```
+
+This installs to `./.claude/` for testing modifications.
+
+<Warning>
+**Never run `node bin/install.js --local` from within the kata directory itself.** Test local installs from a separate project directory.
+</Warning>
+
+## Verify Installation
+
+In Claude Code:
+
+<CodeGroup>
+
+```bash Plugin
+/kata:providing-help
+```
+
+```bash NPX
+/kata-providing-help
+```
+
+</CodeGroup>
+
+## Test Changes
+
+1. Make modifications
+2. Reinstall: `node bin/install.js --local`
+3. Test in Claude Code
+4. Verify behavior matches expectations
+
+## Project Structure
+
+```
+kata/
+├── skills/         # Primary interface
+├── agents/         # Specialized subagents
+├── kata/
+│   ├── templates/  # Structured outputs
+│   ├── workflows/  # Detailed processes
+│   └── references/ # Deep-dive docs
+├── bin/            # Installation scripts
+└── .planning/      # Kata uses Kata
+```
+
+## Key Files
+
+- **CLAUDE.md** — Project overview and guidelines
+- **KATA-STYLE.md** — Comprehensive style guide
+- **.planning/STATE.md** — Current development state
+
+## Running Tests
+
+```bash
+npm test
+```
+
+## Building
+
+```bash
+npm run build
+```
+
+This creates plugin and NPM distributions.

--- a/docs/contributing/overview.mdx
+++ b/docs/contributing/overview.mdx
@@ -1,0 +1,34 @@
+---
+title: 'Contributing'
+description: 'How to contribute to Kata'
+---
+
+## Getting Started
+
+Kata welcomes contributions. Read the [development setup](/contributing/development-setup) to get started.
+
+## What to Contribute
+
+- **Skills** — New workflow skills
+- **Agents** — Specialized subagents
+- **Templates** — Structured output formats
+- **Documentation** — Guides and references
+- **Bug fixes** — Issues and improvements
+
+## Before Contributing
+
+1. Read [CLAUDE.md](https://github.com/gannonh/kata/blob/main/CLAUDE.md) — Understand project structure
+2. Read [KATA-STYLE.md](https://github.com/gannonh/kata/blob/main/KATA-STYLE.md) — Follow conventions
+3. Check existing patterns — Match the style of similar files
+
+## Pull Request Process
+
+1. Create feature branch
+2. Make changes
+3. Test locally with `node bin/install.js --local`
+4. Submit PR with clear description
+5. Reference related issues
+
+## Code of Conduct
+
+Be respectful, constructive, and collaborative.

--- a/docs/contributing/style-guide.mdx
+++ b/docs/contributing/style-guide.mdx
@@ -1,0 +1,100 @@
+---
+title: 'Style Guide'
+description: 'Conventions and patterns for contributing'
+---
+
+## Core Principles
+
+1. **Plans ARE prompts** — XML documents executed directly
+2. **Files teach Claude** — Dual purpose: runtime + teaching
+3. **Context engineering** — Manage deliberately
+4. **Solo developer + Claude** — No enterprise patterns
+
+## Naming Conventions
+
+| Type | Convention | Example |
+| ---- | ---------- | ------- |
+| Files | kebab-case | `phase-execute.md` |
+| Skills | `kata:kebab-case` | `kata:planning-phases` |
+| XML tags | kebab-case | `<execution_context>` |
+| Bash variables | CAPS_UNDERSCORES | `PHASE_ARG` |
+
+## Language & Tone
+
+### Imperative Voice
+
+✅ "Execute tasks", "Create file", "Read STATE.md"
+
+❌ "Execution is performed", "The file should be created"
+
+### No Filler
+
+Absent: "Let me", "Just", "Simply", "Basically"
+
+Present: Direct instructions, technical precision
+
+### No Sycophancy
+
+Absent: "Great!", "Awesome!", "Excellent!"
+
+Present: Factual statements, verification results
+
+## XML Conventions
+
+### Semantic Containers
+
+Use tags for semantic purposes, not generic hierarchy.
+
+✅ `<objective>`, `<verification>`, `<action>`
+
+❌ `<section>`, `<item>`, `<content>`
+
+### Task Structure
+
+```xml
+<task type="auto">
+  <name>Action-oriented name</name>
+  <files>src/path/file.ts</files>
+  <action>What to do and WHY</action>
+  <verify>Command to prove completion</verify>
+  <done>Measurable acceptance criteria</done>
+</task>
+```
+
+## File Structure
+
+### Skills
+
+```
+skills/kata-{name}/
+├── SKILL.md         # <500 lines
+└── references/      # Progressive disclosure
+    ├── {topic}.md
+    └── ...
+```
+
+### Agents
+
+```
+agents/kata-{name}.md
+```
+
+Single file per agent.
+
+## Size Constraints
+
+- **Plans:** 2-3 tasks maximum
+- **Skills:** Under 500 lines
+- **Context usage:** Orchestrators under 30%
+
+## Commit Conventions
+
+```
+{type}({phase}-{plan}): {description}
+```
+
+Types: `feat`, `fix`, `test`, `refactor`, `docs`, `chore`
+
+## Full Reference
+
+For complete style documentation, see [KATA-STYLE.md](https://github.com/gannonh/kata/blob/main/KATA-STYLE.md).

--- a/docs/core-concepts/agents.mdx
+++ b/docs/core-concepts/agents.mdx
@@ -1,0 +1,134 @@
+---
+title: 'Agents'
+description: 'Specialized subagents for focused tasks'
+---
+
+## Overview
+
+Agents are specialized subagents spawned by skills for specific tasks. Each agent works in a fresh 200k token context window, preventing context degradation that would occur if all work happened in the main orchestrator.
+
+## Core Agents
+
+### kata-planner
+
+**Purpose:** Create atomic task plans with XML structure
+
+**Spawned by:** `kata-planning-phases`
+
+**Input:**
+- Phase requirements
+- Research findings
+- Project context
+
+**Output:** `{phase}-{N}-PLAN.md` with structured tasks
+
+### kata-executor
+
+**Purpose:** Implement tasks from plans
+
+**Spawned by:** `kata-executing-phases`
+
+**Input:**
+- Single PLAN.md file
+- Project context
+- State information
+
+**Output:** Code changes, atomic commits, SUMMARY.md
+
+### kata-verifier
+
+**Purpose:** Check work against phase goals
+
+**Spawned by:** `kata-executing-phases`, `kata-verifying-phases`
+
+**Input:**
+- Phase goals
+- Completed work
+- Codebase state
+
+**Output:** Verification results, gap analysis
+
+### kata-debugger
+
+**Purpose:** Diagnose failures systematically
+
+**Spawned by:** `kata-verifying-phases`, `kata-debugging`
+
+**Input:**
+- Failure description
+- Relevant code
+- Execution context
+
+**Output:** Root cause analysis, fix plan
+
+### kata-phase-researcher
+
+**Purpose:** Investigate domain before planning
+
+**Spawned by:** `kata-planning-phases`
+
+**Input:**
+- Phase description
+- Technology stack
+- Constraints
+
+**Output:** `{phase}-RESEARCH.md` with findings
+
+## Orchestration Pattern
+
+```
+Orchestrator (Skill)
+    ↓ (spawns)
+Agent 1 (fresh 200k)
+    ↓ (completes)
+Results to Orchestrator
+    ↓ (spawns)
+Agent 2 (fresh 200k)
+    ↓ (completes)
+Results to Orchestrator
+```
+
+The orchestrator never accumulates context garbage from agent work.
+
+## Agent Constraints
+
+- **Context size:** Fresh 200k tokens per spawn
+- **Focus:** Single responsibility
+- **Communication:** Results only, no streaming
+- **State:** Stateless (orchestrator manages state)
+
+## Parallel Execution
+
+Multiple agents can run simultaneously:
+
+```
+Orchestrator
+    ↓
+├─ Agent 1 (wave 1)
+├─ Agent 2 (wave 1)
+└─ Agent 3 (wave 1)
+    ↓ (all complete)
+├─ Agent 4 (wave 2)
+└─ Agent 5 (wave 2)
+```
+
+Plans are grouped into waves based on dependencies. Independent work runs in parallel.
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card
+    title="Multi-Agent Orchestration"
+    icon="network-wired"
+    href="/advanced/multi-agent-orchestration"
+  >
+    Deep dive into orchestration patterns
+  </Card>
+  <Card
+    title="Skills"
+    icon="terminal"
+    href="/core-concepts/skills"
+  >
+    Learn about skill orchestrators
+  </Card>
+</CardGroup>

--- a/docs/core-concepts/overview.mdx
+++ b/docs/core-concepts/overview.mdx
@@ -1,0 +1,220 @@
+---
+title: 'Overview'
+description: 'Understanding the fundamentals of Kata'
+---
+
+## What Makes Kata Different
+
+Kata is a **meta-prompting and context engineering system** designed to help Claude build software systematically. It's not just a collection of prompts—it's a complete framework for managing context, orchestrating agents, and maintaining quality throughout development.
+
+## Core Principles
+
+### Plans ARE Prompts
+
+PLAN.md files are executable XML documents optimized for Claude, not prose documents to be transformed into something else. When the executor agent reads a plan, it's reading its instructions directly.
+
+```xml
+<task type="auto">
+  <name>Create login endpoint</name>
+  <files>src/app/api/auth/login/route.ts</files>
+  <action>
+    Use jose for JWT (not jsonwebtoken - CommonJS issues).
+    Validate credentials against users table.
+    Return httpOnly cookie on success.
+  </action>
+  <verify>curl -X POST localhost:3000/api/auth/login returns 200 + Set-Cookie</verify>
+  <done>Valid credentials return cookie, invalid return 401</done>
+</task>
+```
+
+### Files Teach Claude
+
+Every file in Kata serves dual purposes:
+
+1. **Runtime functionality** — Loaded by Claude during execution
+2. **Teaching material** — Shows Claude how to build software systematically
+
+When you read a Kata workflow file, you're seeing both what Claude does and how it learned to do it.
+
+### Context Engineering
+
+Claude's quality degrades as context fills up. Kata manages this deliberately:
+
+| Context Level | Quality    | Strategy                  |
+| ------------- | ---------- | ------------------------- |
+| 0-30%         | Peak       | Orchestrators stay here   |
+| 30-50%        | Good       | Acceptable for light work |
+| 50-70%        | Degrading  | Time to wrap up           |
+| 70%+          | Poor       | Spawn fresh agent         |
+
+Orchestrators coordinate. Agents execute with fresh 200k token windows.
+
+## Architecture Components
+
+### Skills
+
+Skills are the primary interface for all Kata workflows. They respond to both natural language and explicit slash command invocation.
+
+```bash
+# Natural language
+"Plan phase 2"
+
+# Explicit command (plugin)
+/kata:planning-phases 2
+
+# Explicit command (NPX)
+/kata-planning-phases 2
+```
+
+Each skill is a thin orchestrator that spawns specialized agents for heavy lifting.
+
+**Learn more:** [Skills](/core-concepts/skills)
+
+### Agents
+
+Specialized subagents spawned by skills for specific tasks:
+
+- `kata-planner` — Creates execution plans
+- `kata-executor` — Implements tasks
+- `kata-verifier` — Checks work against goals
+- `kata-debugger` — Diagnoses failures
+
+Agents work in fresh context windows. The orchestrator never accumulates garbage.
+
+**Learn more:** [Agents](/core-concepts/agents)
+
+### Templates
+
+Structured output formats that ensure consistency:
+
+- `PROJECT.md` — Project vision, always loaded
+- `PLAN.md` — Atomic task with XML structure
+- `SUMMARY.md` — What happened, committed to history
+- `STATE.md` — Decisions, blockers, memory across sessions
+
+Templates define what good output looks like.
+
+**Learn more:** [Templates](/core-concepts/templates)
+
+### Planning System
+
+Kata's planning system breaks work into phases, then phases into plans:
+
+1. **Phase** — A conceptual grouping (e.g., "User Authentication")
+2. **Plan** — 2-3 atomic tasks that fit in fresh context
+3. **Task** — Specific implementation with verification
+
+Plans are sized to keep quality high. Split triggers: >3 tasks, multiple subsystems, >5 files per task.
+
+**Learn more:** [Planning](/core-concepts/planning)
+
+## The Kata Loop
+
+Every phase follows the same pattern:
+
+```mermaid
+graph LR
+    A[Discuss] --> B[Plan]
+    B --> C[Execute]
+    C --> D[Verify]
+    D --> E{Pass?}
+    E -->|Yes| F[Next Phase]
+    E -->|No| B
+```
+
+### Discuss (Optional)
+
+Capture implementation decisions before planning. The system identifies gray areas and asks targeted questions. Output feeds directly into research and planning.
+
+### Plan
+
+Research → Plan → Verify loop. Planner creates atomic task plans, checker verifies against requirements, iterate until they pass.
+
+### Execute
+
+Run plans in parallel waves with fresh context per plan. Each task gets its own atomic commit.
+
+### Verify
+
+Manual user acceptance testing. You confirm features work as expected. Failures trigger automatic debugging and fix plan generation.
+
+## Context Flow
+
+Understanding how context flows through the system:
+
+```
+PROJECT.md (always loaded)
+    ↓
+Orchestrator spawns Agent with:
+    - PROJECT.md
+    - REQUIREMENTS.md
+    - Current phase context
+    - Specific instructions
+    ↓
+Agent works in fresh 200k window
+    ↓
+Agent returns results
+    ↓
+Orchestrator integrates
+    ↓
+Main context still at ~30%
+```
+
+**The orchestrator never does heavy lifting.** It spawns, waits, integrates.
+
+## State Management
+
+Kata maintains state across sessions:
+
+| File                   | Purpose                                     |
+| ---------------------- | ------------------------------------------- |
+| `STATE.md`             | Living memory (decisions, blockers, position) |
+| `ROADMAP.md`           | Where you're going, what's done             |
+| `agent-history.json`   | Subagent tracking for resume                |
+| `SUMMARY.md` frontmatter | Machine-readable for dependency graphs    |
+
+Read `STATE.md` first in every session. Update it when making decisions.
+
+## Quality Constraints
+
+Size limits based on where Claude's quality degrades:
+
+- **Plans:** 2-3 tasks maximum
+- **Context usage:** Orchestrators stay under 30%
+- **Task scope:** >5 files → split
+- **Phase scope:** >3 plans → consider splitting
+
+**Key insight:** Splitting isn't overhead. It's how you maintain quality.
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card
+    title="Skills"
+    icon="terminal"
+    href="/core-concepts/skills"
+  >
+    Learn about the primary interface for Kata workflows
+  </Card>
+  <Card
+    title="Agents"
+    icon="robot"
+    href="/core-concepts/agents"
+  >
+    Understand specialized subagents and orchestration
+  </Card>
+  <Card
+    title="Templates"
+    icon="file"
+    href="/core-concepts/templates"
+  >
+    Explore structured output formats
+  </Card>
+  <Card
+    title="Planning"
+    icon="diagram-project"
+    href="/core-concepts/planning"
+  >
+    Deep dive into the planning system
+  </Card>
+</CardGroup>

--- a/docs/core-concepts/planning.mdx
+++ b/docs/core-concepts/planning.mdx
@@ -1,0 +1,185 @@
+---
+title: 'Planning'
+description: 'How Kata breaks down and structures work'
+---
+
+## Planning Hierarchy
+
+Kata organizes work into three levels:
+
+```
+Milestone (e.g., "v1.0")
+    ↓
+Phase (e.g., "User Authentication")
+    ↓
+Plan (e.g., "1-1-PLAN.md: Login flow")
+    ↓
+Task (e.g., "Create JWT endpoint")
+```
+
+## Phases
+
+**Phase** = A conceptual grouping of related functionality
+
+Examples:
+- "User Authentication"
+- "Payment Processing"
+- "Admin Dashboard"
+
+Phases are defined in `ROADMAP.md` with:
+- Name and description
+- Goals (what must be delivered)
+- Status (pending, in-progress, complete)
+- Dependencies
+
+## Plans
+
+**Plan** = 2-3 atomic tasks that fit in a fresh context window
+
+Each plan:
+- Implements part of a phase
+- Has clear verification steps
+- Can execute independently (if no dependencies)
+- Creates atomic commits per task
+
+**Naming:** `{phase}-{plan}-PLAN.md` (e.g., `02-01-PLAN.md`)
+
+## Tasks
+
+**Task** = Specific implementation with verification
+
+Task structure:
+```xml
+<task type="auto">
+  <name>Create login endpoint</name>
+  <files>src/app/api/auth/login/route.ts</files>
+  <action>
+    POST endpoint accepting {email, password}.
+    Query User by email, compare password with bcrypt.
+    On match, create JWT with jose library, set as httpOnly cookie.
+    Return 200. On mismatch, return 401.
+  </action>
+  <verify>curl -X POST localhost:3000/api/auth/login returns 200 with Set-Cookie</verify>
+  <done>Valid credentials → 200 + cookie. Invalid → 401.</done>
+</task>
+```
+
+## Task Types
+
+### auto
+
+Standard implementation task. Claude executes autonomously.
+
+### checkpoint:human-verify
+
+Human verification required. Claude builds something, you test it manually.
+
+```xml
+<task type="checkpoint:human-verify" gate="blocking">
+  <what-built>Description of what was built</what-built>
+  <how-to-verify>Numbered steps for user</how-to-verify>
+  <resume-signal>Text telling user how to continue</resume-signal>
+</task>
+```
+
+### checkpoint:decision
+
+Decision point. User must choose between options.
+
+```xml
+<task type="checkpoint:decision" gate="blocking">
+  <decision>What needs deciding</decision>
+  <context>Why this matters</context>
+  <options>
+    <option id="identifier">
+      <name>Option Name</name>
+      <pros>Benefits</pros>
+      <cons>Tradeoffs</cons>
+    </option>
+  </options>
+  <resume-signal>Selection instruction</resume-signal>
+</task>
+```
+
+## Plan Sizing
+
+Plans split when:
+- More than 3 tasks
+- Multiple subsystems involved
+- More than 5 files per task
+- Context usage approaching 50%
+
+**Key principle:** Small plans maintain quality. Split aggressively.
+
+## Waves
+
+Plans are grouped into **waves** for parallel execution:
+
+```
+Wave 1 (parallel):
+  - Plan 1 (no dependencies)
+  - Plan 2 (no dependencies)
+  ↓
+Wave 2 (parallel):
+  - Plan 3 (depends on Plan 1)
+  - Plan 4 (depends on Plan 2)
+```
+
+Dependencies are tracked in SUMMARY.md frontmatter.
+
+## Decimal Phase Numbering
+
+Urgent work uses decimal phases:
+
+- Integer phases (1, 2, 3) = Roadmap phases
+- Decimal phases (1.1, 2.1) = Inserted urgent work
+
+Example: Critical bug found between phases 2 and 3 → Create phase 2.1
+
+## Depth Setting
+
+Controls planning thoroughness:
+
+| Depth          | Plans per Phase | Use Case                    |
+| -------------- | --------------- | --------------------------- |
+| Quick          | 1-3             | Rapid prototyping           |
+| Standard       | 3-5             | Balanced (default)          |
+| Comprehensive  | 5-10            | Complex domains, brownfield |
+
+**Important:** Depth controls compression tolerance, not inflation. Never pad to hit a target number.
+
+## Plan Verification
+
+Before execution, plans are checked against:
+- Phase goals achieved?
+- Requirements covered?
+- Dependencies clear?
+- Verification steps specified?
+
+Failed checks trigger planner iteration.
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card
+    title="Planning Phases"
+    icon="diagram-project"
+    href="/workflow/planning-phases"
+  >
+    See the planning workflow in action
+  </Card>
+  <Card
+    title="Executing Phases"
+    icon="play"
+    href="/workflow/executing-phases"
+  >
+    Learn how plans get executed
+  </Card>
+  <Card
+    title="XML Prompting"
+    icon="code"
+    href="/advanced/xml-prompting"
+  >
+    Deep dive into plan structure
+  </Card>
+</CardGroup>

--- a/docs/core-concepts/skills.mdx
+++ b/docs/core-concepts/skills.mdx
@@ -1,0 +1,253 @@
+---
+title: 'Skills'
+description: 'The primary interface for Kata workflows'
+---
+
+## What Are Skills?
+
+Skills are the primary interface for all Kata workflows. They're user-invocable commands that respond to both natural language and explicit slash command invocation.
+
+## Invocation Methods
+
+### Natural Language (Recommended)
+
+```
+"Plan phase 2"
+"What's the status?"
+"Execute the phase"
+"I'm done for today"
+```
+
+Kata parses intent and routes to the appropriate skill automatically.
+
+### Explicit Commands
+
+| Installation | Syntax               | Example                   |
+| ------------ | -------------------- | ------------------------- |
+| Plugin       | `/kata:skill-name`   | `/kata:planning-phases 2` |
+| NPX          | `/kata-skill-name`   | `/kata-planning-phases 2` |
+
+Use explicit commands when you need precision or want to bypass intent recognition.
+
+## Skill Architecture
+
+Skills are **thin orchestrators**. They:
+
+1. Load necessary context
+2. Spawn specialized agents
+3. Collect results
+4. Route to next step
+
+**Key principle:** Skills stay lean (~15% context). Heavy lifting happens in fresh agent contexts.
+
+```
+Skill (30% context)
+    ↓
+Spawns Agent (fresh 200k)
+    ↓
+Agent completes work
+    ↓
+Returns results
+    ↓
+Skill stays at 30%
+```
+
+## Skill Structure
+
+Each skill follows a consistent pattern:
+
+```
+skills/kata-{name}/
+├── SKILL.md         # Orchestrator workflow (<500 lines)
+└── references/      # Progressive disclosure
+    ├── {topic}.md
+    └── ...
+```
+
+The main SKILL.md file contains the orchestration logic. Detailed documentation lives in `references/` for progressive disclosure.
+
+## Core Workflow Skills
+
+### starting-projects
+
+**Purpose:** Full project initialization
+
+**Flow:**
+1. Questions → understand requirements
+2. Research → investigate domain (optional)
+3. Requirements → extract v1, v2, out of scope
+4. Roadmap → create phase structure
+
+**Creates:** `PROJECT.md`, `REQUIREMENTS.md`, `ROADMAP.md`, `STATE.md`
+
+### planning-phases
+
+**Purpose:** Research and plan a single phase
+
+**Flow:**
+1. Research → investigate implementation approach
+2. Plan → create 2-3 atomic task plans
+3. Verify → check against requirements
+
+**Creates:** `{phase}-RESEARCH.md`, `{phase}-{N}-PLAN.md`
+
+### executing-phases
+
+**Purpose:** Execute all plans in a phase
+
+**Flow:**
+1. Group plans into waves (parallel/sequential)
+2. Spawn executor per plan with fresh context
+3. Atomic commit per task
+4. Verify against phase goals
+
+**Creates:** `{phase}-{N}-SUMMARY.md`, `{phase}-VERIFICATION.md`
+
+### verifying-phases
+
+**Purpose:** Manual user acceptance testing
+
+**Flow:**
+1. Extract testable deliverables
+2. Walk through verification steps
+3. Diagnose failures automatically
+4. Create fix plans if issues found
+
+**Creates:** `{phase}-UAT.md`, fix plans if needed
+
+## Navigation Skills
+
+### tracking-progress
+
+**Purpose:** Show current position and next steps
+
+**Output:**
+- Current phase and progress
+- Blockers and decisions
+- Next recommended action
+- Available options
+
+### providing-help
+
+**Purpose:** List all skills and usage
+
+**Output:**
+- Complete skill reference
+- Invocation syntax
+- Common workflows
+
+## Phase Management Skills
+
+### adding-phases
+
+Add a new phase to the end of the roadmap.
+
+### inserting-phases
+
+Insert urgent work between existing phases. Uses decimal numbering (e.g., 2.1 between 2 and 3).
+
+### removing-phases
+
+Remove a future phase and renumber remaining phases.
+
+## Utility Skills
+
+### executing-quick-tasks
+
+Execute ad-hoc tasks without full planning overhead.
+
+**Use for:**
+- Bug fixes
+- Small features
+- Config changes
+- One-off tasks
+
+**Creates:** `.planning/quick/{NNN}-{slug}/PLAN.md`, `SUMMARY.md`
+
+### debugging
+
+Systematic debugging with persistent state tracking.
+
+### pausing-work / resuming-work
+
+Create session handoffs and restore context.
+
+## Skill Naming Conventions
+
+Skills follow strict naming patterns for autonomous invocation:
+
+1. **Gerund (verb-ing) style** — `kata-managing-todos` not `kata-todo-management`
+2. **Exhaustive trigger phrases** — List every phrase users might say
+3. **Verbose and specific** — `kata-providing-progress-and-status-updates` over `kata-status`
+
+**Why this matters:** Claude matches skills based on name and description before falling back to defaults. Better naming = better autonomous routing.
+
+## Progressive Disclosure
+
+Skills use `@-references` to load context progressively:
+
+```markdown
+@~/.claude/kata/workflows/phase-execute.md
+@~/.claude/kata/templates/plan.md
+@.planning/PROJECT.md
+```
+
+Only load what's needed. Keep the main skill file focused on orchestration.
+
+## Subagent Spawning
+
+Skills spawn agents via the Task tool:
+
+```xml
+<task>
+  <spawn agent="kata-planner">
+    <context>
+      @.planning/PROJECT.md
+      @.planning/REQUIREMENTS.md
+      Phase 2 requirements
+    </context>
+  </spawn>
+</task>
+```
+
+The agent works in a fresh 200k window. Results return to the skill for integration.
+
+## Quality Constraints
+
+- **SKILL.md:** Under 500 lines
+- **Context usage:** Stay under 30%
+- **Heavy work:** Spawn agents
+- **Documentation:** Move to `references/`
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card
+    title="Agents"
+    icon="robot"
+    href="/core-concepts/agents"
+  >
+    Learn about specialized subagents
+  </Card>
+  <Card
+    title="Skills Reference"
+    icon="list"
+    href="/skills/overview"
+  >
+    Complete list of available skills
+  </Card>
+  <Card
+    title="Workflow Guide"
+    icon="diagram-project"
+    href="/workflow/starting-projects"
+  >
+    See skills in action
+  </Card>
+  <Card
+    title="Advanced Orchestration"
+    icon="network-wired"
+    href="/advanced/multi-agent-orchestration"
+  >
+    Deep dive into orchestration patterns
+  </Card>
+</CardGroup>

--- a/docs/core-concepts/templates.mdx
+++ b/docs/core-concepts/templates.mdx
@@ -1,0 +1,130 @@
+---
+title: 'Templates'
+description: 'Structured output formats for consistency'
+---
+
+## Overview
+
+Templates define structured output formats that ensure consistency across planning, execution, and verification. They're stored in `kata/templates/` and loaded by agents as needed.
+
+## Core Templates
+
+### PROJECT.md
+
+**Purpose:** Project vision, always loaded in context
+
+**Contains:**
+- Project name and description
+- Goals and success criteria
+- Technology stack
+- Constraints and preferences
+
+**Created by:** `kata-starting-projects`
+
+### REQUIREMENTS.md
+
+**Purpose:** Scoped requirements with phase traceability
+
+**Structure:**
+- v1 (must-have)
+- v2 (nice-to-have)
+- Out of scope
+
+**Created by:** `kata-starting-projects`
+
+### ROADMAP.md
+
+**Purpose:** Phase breakdown and progress tracking
+
+**Contains:**
+- Milestones
+- Phases with goals
+- Status indicators
+- Dependencies
+
+**Created by:** `kata-starting-projects`
+
+### PLAN.md
+
+**Purpose:** Atomic task plan with XML structure
+
+**Structure:**
+```xml
+<task type="auto">
+  <name>Task name</name>
+  <files>affected files</files>
+  <action>precise instructions</action>
+  <verify>verification command</verify>
+  <done>acceptance criteria</done>
+</task>
+```
+
+**Created by:** `kata-planner`
+
+### SUMMARY.md
+
+**Purpose:** Post-execution record of what happened
+
+**Contains:**
+- Tasks completed
+- Files changed
+- Commits created
+- Issues encountered
+
+**Created by:** `kata-executor`
+
+### STATE.md
+
+**Purpose:** Living memory across sessions
+
+**Contains:**
+- Current position
+- Decisions made
+- Blockers
+- Context for resuming
+
+**Updated by:** All skills
+
+## Template Usage
+
+Agents load templates via `@-references`:
+
+```markdown
+@~/.claude/kata/templates/plan.md
+```
+
+Templates show agents what good output looks like without inflating the orchestrator's context.
+
+## Frontmatter
+
+Templates use YAML frontmatter for machine-readable metadata:
+
+```yaml
+---
+type: plan
+phase: 2
+plan: 1
+dependencies: []
+---
+```
+
+This enables dependency tracking and automated routing.
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card
+    title="Planning"
+    icon="diagram-project"
+    href="/core-concepts/planning"
+  >
+    Learn how templates structure plans
+  </Card>
+  <Card
+    title="XML Prompting"
+    icon="code"
+    href="/advanced/xml-prompting"
+  >
+    Understand XML structure in plans
+  </Card>
+</CardGroup>

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -1,0 +1,200 @@
+---
+title: 'Installation'
+description: 'Install Kata via plugin or NPM'
+---
+
+## Installation Methods
+
+### Plugin Install (Recommended)
+
+The plugin installation provides the cleanest command syntax:
+
+```bash
+/plugin marketplace add gannonh/kata-marketplace
+/plugin install kata@gannonh-kata-marketplace
+```
+
+**Verify:**
+```bash
+/kata:providing-help
+```
+
+Skills are installed to `.claude/skills/` with prefixes stripped for clean `/kata:skill-name` invocation.
+
+### NPM Install
+
+Use NPM if you prefer global installation or need CI/container support:
+
+```bash
+npx @gannonh/kata
+```
+
+**Verify:**
+```bash
+/kata-providing-help
+```
+
+Skills are installed to `~/.claude/skills/kata-*` (global) or `.claude/skills/kata-*` (local).
+
+## Non-Interactive Install
+
+For Docker, CI, or scripted environments:
+
+<CodeGroup>
+
+```bash Global Install
+npx @gannonh/kata --global
+```
+
+```bash Local Install
+npx @gannonh/kata --local
+```
+
+</CodeGroup>
+
+Use `--global` (`-g`) or `--local` (`-l`) to skip the interactive prompt.
+
+## Development Installation
+
+Clone the repository and install locally for testing modifications:
+
+```bash
+git clone https://github.com/gannonh/kata.git
+cd kata
+node bin/install.js --local
+```
+
+<Warning>
+**Never run `node bin/install.js --local` from within the kata directory itself.** This overwrites `.claude/` with Kata's own files, breaking the development environment. Test local installs from a separate project directory.
+</Warning>
+
+## Permissions Setup
+
+### Recommended: Skip Permissions Mode
+
+Kata is designed for frictionless automation. Run Claude Code with:
+
+```bash
+claude --dangerously-skip-permissions
+```
+
+<Tip>
+Kata works best this way. Approving `date` and `git commit` 50 times defeats the purpose.
+</Tip>
+
+### Alternative: Granular Permissions
+
+If you prefer not to use that flag, add this to your project's `.claude/settings.json`:
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(date:*)",
+      "Bash(echo:*)",
+      "Bash(cat:*)",
+      "Bash(ls:*)",
+      "Bash(mkdir:*)",
+      "Bash(wc:*)",
+      "Bash(head:*)",
+      "Bash(tail:*)",
+      "Bash(sort:*)",
+      "Bash(grep:*)",
+      "Bash(tr:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(git status:*)",
+      "Bash(git log:*)",
+      "Bash(git diff:*)",
+      "Bash(git tag:*)"
+    ]
+  }
+}
+```
+
+## Staying Updated
+
+Check for updates periodically:
+
+<CodeGroup>
+
+```bash Plugin
+/kata:showing-whats-new
+```
+
+```bash NPX
+/kata-showing-whats-new
+```
+
+</CodeGroup>
+
+### Update Commands
+
+<CodeGroup>
+
+```bash Plugin Update
+claude plugin update kata@gannonh-kata-marketplace
+```
+
+```bash NPM Update
+npx @gannonh/kata@latest
+```
+
+</CodeGroup>
+
+## Docker & Container Environments
+
+If file reads fail with tilde paths (`~/.claude/...`), set `CLAUDE_CONFIG_DIR` before installing:
+
+```bash
+CLAUDE_CONFIG_DIR=/home/youruser/.claude npx @gannonh/kata --global
+```
+
+This ensures absolute paths are used instead of `~` which may not expand correctly in containers.
+
+## Troubleshooting
+
+### Skills Not Found After Install
+
+- Restart Claude Code to reload skills
+- **Plugin:** Verify skills exist in `./.claude/skills/` (prefixes stripped)
+- **NPX:** Verify skills exist in `~/.claude/skills/kata-*` (global) or `./.claude/skills/kata-*` (local)
+
+### Skills Not Working as Expected
+
+<CodeGroup>
+
+```bash Plugin
+/kata:providing-help
+```
+
+```bash NPX
+/kata-providing-help
+```
+
+</CodeGroup>
+
+If issues persist, re-run the installer:
+
+```bash
+npx @gannonh/kata
+```
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card
+    title="Quickstart"
+    icon="rocket"
+    href="/quickstart"
+  >
+    Get up and running in under 5 minutes
+  </Card>
+  <Card
+    title="Configuration"
+    icon="gear"
+    href="/configuration/settings"
+  >
+    Customize Kata for your needs
+  </Card>
+</CardGroup>

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -1,0 +1,113 @@
+---
+title: Introduction
+description: 'Welcome to Kata - A spec-driven development framework for Claude Code'
+---
+
+<img
+  className="block dark:hidden"
+  src="/images/hero-light.svg"
+  alt="Hero Light"
+/>
+<img
+  className="hidden dark:block"
+  src="/images/hero-dark.svg"
+  alt="Hero Dark"
+/>
+
+## What is Kata?
+
+Kata is an **agent orchestration framework** for spec-driven development. It's a meta-prompting and context engineering system that helps Claude build software systematically through structured workflows:
+
+**Requirements gathering → Research → Planning → Execution → Verification**
+
+型 · /ˈkɑːtɑː/ · *noun* - a choreographed pattern practiced repeatedly until perfected
+
+## Core Features
+
+<CardGroup cols={2}>
+  <Card
+    title="Natural Language Interface"
+    icon="message"
+    href="/core-concepts/overview"
+  >
+    Drive your entire workflow with natural language. Say what you want, Kata routes to the right workflow.
+  </Card>
+  <Card
+    title="Multi-Agent Orchestration"
+    icon="network-wired"
+    href="/advanced/multi-agent-orchestration"
+  >
+    Thin orchestrators spawn specialized agents with fresh context windows for each task.
+  </Card>
+  <Card
+    title="Context Engineering"
+    icon="brain"
+    href="/advanced/context-engineering"
+  >
+    Deliberate context management keeps Claude performing at peak quality throughout your project.
+  </Card>
+  <Card
+    title="Atomic Git Commits"
+    icon="code-branch"
+    href="/workflow/executing-phases"
+  >
+    Every task gets its own commit immediately after completion for perfect traceability.
+  </Card>
+</CardGroup>
+
+## Key Design Principles
+
+### Plans ARE Prompts
+
+PLAN.md files are executable XML documents optimized for Claude, not prose to be transformed. Every plan is structured for direct consumption by execution agents.
+
+### Files Teach Claude
+
+Every file in Kata serves dual purposes:
+1. **Runtime functionality** — Loaded by Claude during execution
+2. **Teaching material** — Shows Claude how to build software systematically
+
+### Fresh Context Windows
+
+Orchestrators stay lean (~15% context), subagents get fresh 200k tokens each. Walk away, come back to completed work without accumulated context garbage.
+
+## Architecture
+
+**Core Components:**
+- **Skills** (`skills/kata-*/SKILL.md`) — Primary interface for all Kata workflows
+- **Agents** (`agents/kata-*.md`) — Specialized subagents spawned by skills
+- **Templates** (`kata/templates/`) — Structured output formats (PROJECT.md, PLAN.md)
+- **References** (`kata/references/`) — Deep-dive documentation on concepts
+
+## Getting Started
+
+<CardGroup cols={2}>
+  <Card
+    title="Quickstart"
+    icon="rocket"
+    href="/quickstart"
+  >
+    Get up and running in under 5 minutes
+  </Card>
+  <Card
+    title="Installation"
+    icon="download"
+    href="/installation"
+  >
+    Detailed installation instructions for plugin and NPM
+  </Card>
+  <Card
+    title="Your First Project"
+    icon="flag"
+    href="/workflow/starting-projects"
+  >
+    Learn how to initialize and build your first project with Kata
+  </Card>
+  <Card
+    title="Core Concepts"
+    icon="book"
+    href="/core-concepts/overview"
+  >
+    Understand the fundamental concepts behind Kata
+  </Card>
+</CardGroup>

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -1,0 +1,199 @@
+---
+title: 'Quickstart'
+description: 'Get started with Kata in under 5 minutes'
+---
+
+## Installation
+
+Choose your installation method:
+
+<CodeGroup>
+
+```bash Plugin Install (Recommended)
+/plugin marketplace add gannonh/kata-marketplace
+/plugin install kata@gannonh-kata-marketplace
+```
+
+```bash NPM Install
+npx @gannonh/kata
+```
+
+</CodeGroup>
+
+## Verify Installation
+
+<CodeGroup>
+
+```bash Plugin
+/kata:providing-help
+```
+
+```bash NPX
+/kata-providing-help
+```
+
+</CodeGroup>
+
+## Your First Project
+
+### 1. Start a New Project
+
+```
+"Start a new project"
+```
+
+Or use the explicit command:
+
+<CodeGroup>
+
+```bash Plugin
+/kata:starting-projects
+```
+
+```bash NPX
+/kata-starting-projects
+```
+
+</CodeGroup>
+
+The system will:
+1. Ask questions until it understands your idea completely
+2. Optionally spawn research agents to investigate the domain
+3. Extract requirements (v1, v2, out of scope)
+4. Create a roadmap with phases mapped to requirements
+
+### 2. Plan Your First Phase
+
+```
+"Plan phase 1"
+```
+
+Or explicitly:
+
+<CodeGroup>
+
+```bash Plugin
+/kata:planning-phases 1
+```
+
+```bash NPX
+/kata-planning-phases 1
+```
+
+</CodeGroup>
+
+The system will:
+1. Research how to implement the phase
+2. Create 2-3 atomic task plans with XML structure
+3. Verify plans against requirements
+
+### 3. Execute the Phase
+
+```
+"Execute phase 1"
+```
+
+Or explicitly:
+
+<CodeGroup>
+
+```bash Plugin
+/kata:executing-phases 1
+```
+
+```bash NPX
+/kata-executing-phases 1
+```
+
+</CodeGroup>
+
+The system will:
+1. Run plans in parallel waves
+2. Give each plan a fresh 200k context window
+3. Create atomic commits per task
+4. Verify work against phase goals
+
+### 4. Verify the Work
+
+```
+"Verify phase 1"
+```
+
+Or explicitly:
+
+<CodeGroup>
+
+```bash Plugin
+/kata:verifying-phases 1
+```
+
+```bash NPX
+/kata-verifying-phases 1
+```
+
+</CodeGroup>
+
+The system will:
+1. Extract testable deliverables
+2. Walk you through verification steps
+3. Diagnose failures automatically if issues found
+4. Create fix plans ready for re-execution
+
+## Natural Language Commands
+
+Kata responds to natural language. You don't need to memorize slash commands:
+
+| You say...               | Kata does...                           |
+| ------------------------ | -------------------------------------- |
+| "Start a new project"    | Launches full project initialization   |
+| "What's the status?"     | Shows progress, next steps, blockers   |
+| "Plan phase 2"           | Researches and creates execution plans |
+| "Execute the phase"      | Runs all plans with parallel agents    |
+| "I'm done for today"     | Creates handoff for session resumption |
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card
+    title="Core Concepts"
+    icon="book"
+    href="/core-concepts/overview"
+  >
+    Understand how Kata works under the hood
+  </Card>
+  <Card
+    title="Workflow Guide"
+    icon="diagram-project"
+    href="/workflow/starting-projects"
+  >
+    Deep dive into the complete Kata workflow
+  </Card>
+  <Card
+    title="Configuration"
+    icon="gear"
+    href="/configuration/settings"
+  >
+    Customize Kata for your needs
+  </Card>
+  <Card
+    title="Skills Reference"
+    icon="list"
+    href="/skills/overview"
+  >
+    Explore all available skills and commands
+  </Card>
+</CardGroup>
+
+## Recommended Setup
+
+Kata is designed for frictionless automation. Run Claude Code with:
+
+```bash
+claude --dangerously-skip-permissions
+```
+
+<Tip>
+Kata works best this way. Approving `date` and `git commit` 50 times defeats the purpose.
+</Tip>
+
+Alternatively, configure granular permissions in `.claude/settings.json`. See [Installation](/installation) for details.

--- a/docs/skills/core-workflow.mdx
+++ b/docs/skills/core-workflow.mdx
@@ -1,0 +1,50 @@
+---
+title: 'Core Workflow Skills'
+description: 'Primary workflow skills for building projects'
+---
+
+## Project Lifecycle
+
+### starting-projects
+
+Initialize a new project: questions → research → requirements → roadmap
+
+[Learn more](/workflow/starting-projects)
+
+### discussing-phases
+
+Capture implementation decisions before planning (optional)
+
+[Learn more](/workflow/discussing-phases)
+
+### planning-phases
+
+Research and create execution plans for a phase
+
+[Learn more](/workflow/planning-phases)
+
+### executing-phases
+
+Execute all plans in a phase with parallel agents
+
+[Learn more](/workflow/executing-phases)
+
+### verifying-phases
+
+Manual user acceptance testing with automatic failure diagnosis
+
+[Learn more](/workflow/verifying-phases)
+
+## Milestone Management
+
+### auditing-milestones
+
+Verify milestone achieved its definition of done
+
+### completing-milestones
+
+Archive milestone, tag release
+
+### starting-milestones
+
+Start next version: questions → research → requirements → roadmap

--- a/docs/skills/navigation.mdx
+++ b/docs/skills/navigation.mdx
@@ -1,0 +1,38 @@
+---
+title: 'Navigation Skills'
+description: 'Status, help, and progress tracking'
+---
+
+## tracking-progress
+
+**Purpose:** Show current position and next steps
+
+**Output:**
+- Current phase and progress
+- Blockers and decisions
+- Next recommended action
+- Available options
+
+## providing-help
+
+**Purpose:** Show all skills and usage guide
+
+**Output:**
+- Complete skill reference
+- Invocation syntax
+- Common workflows
+
+## showing-whats-new
+
+**Purpose:** See what changed since your installed version
+
+**Output:**
+- Changelog entries
+- New features
+- Breaking changes
+
+## updating
+
+**Purpose:** Update Kata with changelog preview (NPX only)
+
+**Note:** Plugin users use `claude plugin update kata@gannonh-kata-marketplace`

--- a/docs/skills/overview.mdx
+++ b/docs/skills/overview.mdx
@@ -1,0 +1,46 @@
+---
+title: 'Skills Overview'
+description: 'Complete reference of available skills'
+---
+
+## Invocation Syntax
+
+| Installation | Syntax | Example |
+| ------------ | ------ | ------- |
+| Plugin | `/kata:skill-name` | `/kata:planning-phases 1` |
+| NPX | `/kata-skill-name` | `/kata-planning-phases 1` |
+
+**Remember:** All skills respond to natural language. "Plan phase 2" works the same as the explicit command.
+
+## Skill Categories
+
+<CardGroup cols={2}>
+  <Card
+    title="Core Workflow"
+    icon="diagram-project"
+    href="/skills/core-workflow"
+  >
+    Primary workflow skills for building projects
+  </Card>
+  <Card
+    title="Navigation"
+    icon="compass"
+    href="/skills/navigation"
+  >
+    Status, help, and progress tracking
+  </Card>
+  <Card
+    title="Phase Management"
+    icon="list"
+    href="/skills/phase-management"
+  >
+    Add, insert, remove, and modify phases
+  </Card>
+  <Card
+    title="Utilities"
+    icon="wrench"
+    href="/skills/utilities"
+  >
+    Quick tasks, debugging, and session management
+  </Card>
+</CardGroup>

--- a/docs/skills/phase-management.mdx
+++ b/docs/skills/phase-management.mdx
@@ -1,0 +1,24 @@
+---
+title: 'Phase Management Skills'
+description: 'Add, insert, remove, and modify phases'
+---
+
+## adding-phases
+
+Add a new phase to the end of the roadmap.
+
+## inserting-phases
+
+Insert urgent work between existing phases. Uses decimal numbering (e.g., 2.1 between 2 and 3).
+
+## removing-phases
+
+Remove a future phase and renumber remaining phases.
+
+## listing-phase-assumptions
+
+See Claude's intended approach before planning a phase.
+
+## planning-milestone-gaps
+
+Create phases to close gaps identified during milestone audit.

--- a/docs/skills/utilities.mdx
+++ b/docs/skills/utilities.mdx
@@ -1,0 +1,46 @@
+---
+title: 'Utility Skills'
+description: 'Quick tasks, debugging, and session management'
+---
+
+## executing-quick-tasks
+
+Execute ad-hoc tasks without full planning overhead.
+
+[Learn more](/workflow/quick-mode)
+
+## debugging
+
+Systematic debugging with persistent state tracking.
+
+## pausing-work
+
+Create session handoff when stopping mid-phase.
+
+## resuming-work
+
+Restore context from last session.
+
+## configuring-settings
+
+Configure model profile and workflow agents.
+
+[Learn more](/configuration/settings)
+
+## setting-profiles
+
+Switch model profile (quality/balanced/budget).
+
+[Learn more](/configuration/model-profiles)
+
+## adding-todos
+
+Capture idea for later work.
+
+## checking-todos
+
+List pending todos.
+
+## mapping-codebases
+
+Analyze existing codebase before project setup (brownfield projects).

--- a/docs/workflow/discussing-phases.mdx
+++ b/docs/workflow/discussing-phases.mdx
@@ -1,0 +1,60 @@
+---
+title: 'Discussing Phases'
+description: 'Capture implementation decisions before planning'
+---
+
+## Overview
+
+The `discussing-phases` skill captures implementation decisions before research and planning. This ensures Claude understands your preferences and builds features the way you envision them.
+
+## When to Use
+
+Use this skill when:
+- You have specific preferences for how something should be built
+- The phase involves UI/UX decisions
+- Multiple valid approaches exist
+- You want to shape the implementation direction
+
+Skip it for phases where you're comfortable with Claude's defaults.
+
+## Invocation
+
+```
+"Let's discuss phase 1"
+```
+
+Or explicitly:
+
+<CodeGroup>
+
+```bash Plugin
+/kata:discussing-phases 1
+```
+
+```bash NPX
+/kata-discussing-phases 1
+```
+
+</CodeGroup>
+
+## What Gets Captured
+
+Based on what's being built, the system identifies gray areas:
+
+- **Visual features** → Layout, density, interactions, empty states
+- **APIs/CLIs** → Response format, flags, error handling, verbosity
+- **Content systems** → Structure, tone, depth, flow
+- **Organization tasks** → Grouping criteria, naming, duplicates
+
+For each area you select, it asks until you're satisfied.
+
+## Output
+
+Creates `{phase}-CONTEXT.md` which feeds into:
+1. **Researcher** — Knows what patterns to investigate
+2. **Planner** — Knows what decisions are locked
+
+## Next Steps
+
+After discussing, proceed to:
+- [Planning Phases](/workflow/planning-phases) — Research and create execution plans

--- a/docs/workflow/executing-phases.mdx
+++ b/docs/workflow/executing-phases.mdx
@@ -1,0 +1,85 @@
+---
+title: 'Executing Phases'
+description: 'Run plans with fresh context and atomic commits'
+---
+
+## Overview
+
+The `executing-phases` skill executes all plans in a phase using parallel waves, fresh context per plan, and atomic commits per task.
+
+## Invocation
+
+```
+"Execute phase 1"
+```
+
+Or explicitly:
+
+<CodeGroup>
+
+```bash Plugin
+/kata:executing-phases 1
+```
+
+```bash NPX
+/kata-executing-phases 1
+```
+
+</CodeGroup>
+
+## Workflow
+
+### 1. Wave Grouping
+
+Plans are grouped into waves based on dependencies:
+
+```
+Wave 1 (parallel):
+  - Plan 1 (no dependencies)
+  - Plan 2 (no dependencies)
+
+Wave 2 (parallel):
+  - Plan 3 (depends on Plan 1)
+  - Plan 4 (depends on Plan 2)
+```
+
+### 2. Parallel Execution
+
+Spawns `kata-executor` agent per plan with:
+- Fresh 200k token context
+- Plan instructions
+- Project context
+- State information
+
+Agents work simultaneously within each wave.
+
+### 3. Atomic Commits
+
+Each task creates its own commit immediately after completion:
+
+```bash
+abc123f feat(02-01): implement login endpoint
+def456g feat(02-01): add password hashing
+hij789k test(02-01): add login flow tests
+```
+
+Commit format: `{type}({phase}-{plan}): {description}`
+
+### 4. Verification
+
+After all plans complete, spawns `kata-verifier` agent to check:
+- Phase goals delivered?
+- Requirements satisfied?
+- Code quality acceptable?
+
+## Output Files
+
+| File | Purpose |
+| ---- | ------- |
+| {phase}-{N}-SUMMARY.md | Post-execution record |
+| {phase}-VERIFICATION.md | Goal verification results |
+
+## Next Steps
+
+After execution, proceed to:
+- [Verifying Phases](/workflow/verifying-phases) — Manual user acceptance testing

--- a/docs/workflow/planning-phases.mdx
+++ b/docs/workflow/planning-phases.mdx
@@ -1,0 +1,90 @@
+---
+title: 'Planning Phases'
+description: 'Research and create execution plans'
+---
+
+## Overview
+
+The `planning-phases` skill researches how to implement a phase, creates atomic task plans, and verifies they achieve phase goals.
+
+## Invocation
+
+```
+"Plan phase 1"
+```
+
+Or explicitly:
+
+<CodeGroup>
+
+```bash Plugin
+/kata:planning-phases 1
+```
+
+```bash NPX
+/kata-planning-phases 1
+```
+
+</CodeGroup>
+
+## Workflow
+
+### 1. Research
+
+Spawns `kata-phase-researcher` agent to investigate:
+- Technology choices
+- Implementation patterns
+- Library recommendations
+- Common pitfalls
+
+Guided by CONTEXT.md decisions from discuss phase (if it exists).
+
+### 2. Planning
+
+Spawns `kata-planner` agent to create 2-3 atomic task plans with XML structure.
+
+Each plan contains:
+- Specific tasks with verification steps
+- File paths to be modified
+- Implementation guidance
+- Success criteria
+
+### 3. Verification
+
+Spawns `kata-plan-checker` agent to verify:
+- Phase goals achieved?
+- Requirements covered?
+- Dependencies clear?
+- Verification steps specified?
+
+Loops until plans pass verification.
+
+## Options
+
+### Skip Research
+
+```bash
+/kata:planning-phases 1 --skip-research
+```
+
+Use when you're confident about the approach and don't need domain investigation.
+
+### Skip Verification
+
+```bash
+/kata:planning-phases 1 --skip-verify
+```
+
+Skip the plan checker loop. Useful for quick iterations.
+
+## Output Files
+
+| File | Purpose |
+| ---- | ------- |
+| {phase}-RESEARCH.md | Domain investigation findings |
+| {phase}-{N}-PLAN.md | Atomic task plans with XML structure |
+
+## Next Steps
+
+After planning, proceed to:
+- [Executing Phases](/workflow/executing-phases) — Run plans with fresh context

--- a/docs/workflow/quick-mode.mdx
+++ b/docs/workflow/quick-mode.mdx
@@ -1,0 +1,105 @@
+---
+title: 'Quick Mode'
+description: 'Execute ad-hoc tasks without full planning'
+---
+
+## Overview
+
+Quick mode provides Kata guarantees (atomic commits, state tracking) with a faster path for small, self-contained tasks.
+
+## When to Use
+
+**Use quick mode for:**
+- Bug fixes
+- Small features
+- Config changes
+- One-off tasks
+
+**Use full planning for:**
+- Tasks involving multiple subsystems
+- Work requiring investigation
+- Tasks that are part of larger phases
+- Complex changes
+
+## Invocation
+
+```
+"Quick task: add dark mode toggle"
+```
+
+Or explicitly:
+
+<CodeGroup>
+
+```bash Plugin
+/kata:executing-quick-tasks
+```
+
+```bash NPX
+/kata-executing-quick-tasks
+```
+
+</CodeGroup>
+
+## What's Different
+
+### Same Quality
+- Same agents (planner + executor)
+- Same atomic commits
+- Same state tracking
+
+### Faster Path
+- Skips research phase
+- Skips plan checker loop
+- Skips verifier agent
+- Separate tracking (`.planning/quick/`)
+
+## Workflow
+
+1. Get task description
+2. Spawn planner (with quick constraints)
+3. Spawn executor
+4. Update STATE.md
+5. Commit artifacts
+
+## Output Files
+
+```
+.planning/quick/
+├── 001-add-dark-mode/
+│   ├── PLAN.md
+│   └── SUMMARY.md
+├── 002-fix-login-bug/
+│   ├── PLAN.md
+│   └── SUMMARY.md
+```
+
+Numbering: 3-digit sequential (001, 002, 003...)
+
+## Tracking
+
+Quick tasks update STATE.md, NOT ROADMAP.md:
+
+```markdown
+### Quick Tasks Completed
+
+| #   | Description          | Date       | Commit  |
+| --- | -------------------- | ---------- | ------- |
+| 001 | Add dark mode toggle | 2026-01-19 | abc123f |
+```
+
+## Commit Convention
+
+```
+docs(quick-001): add dark mode toggle
+
+Quick task completed.
+
+Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
+```
+
+## Next Steps
+
+Return to regular workflow:
+- [Planning Phases](/workflow/planning-phases) — Resume phase planning
+- [Executing Phases](/workflow/executing-phases) — Resume phase execution

--- a/docs/workflow/starting-projects.mdx
+++ b/docs/workflow/starting-projects.mdx
@@ -1,0 +1,85 @@
+---
+title: 'Starting Projects'
+description: 'Initialize a new project with Kata'
+---
+
+## Overview
+
+The `starting-projects` skill launches full project initialization: questions → research → requirements → roadmap.
+
+## Invocation
+
+```
+"Start a new project"
+```
+
+Or explicitly:
+
+<CodeGroup>
+
+```bash Plugin
+/kata:starting-projects
+```
+
+```bash NPX
+/kata-starting-projects
+```
+
+</CodeGroup>
+
+## Workflow
+
+### 1. Questions
+
+The system asks until it understands your idea completely:
+- Project goals
+- Technology preferences
+- Constraints
+- Edge cases
+- User experience requirements
+
+### 2. Research (Optional)
+
+Spawns 4 parallel research agents:
+- **Stack researcher** — Investigates technology choices
+- **Feature researcher** — Explores similar product features
+- **Architecture researcher** — Evaluates structural patterns
+- **Pitfalls researcher** — Identifies common mistakes
+
+Research is optional but recommended for unfamiliar domains.
+
+### 3. Requirements
+
+Extracts and categorizes requirements:
+- **v1** — Must-have for initial release
+- **v2** — Nice-to-have for future
+- **Out of scope** — Explicitly excluded
+
+### 4. Roadmap
+
+Creates phases mapped to requirements. Each phase has:
+- Name and description
+- Goals (what must be delivered)
+- Traced requirements
+- Dependencies
+
+## Output Files
+
+| File | Purpose |
+| ---- | ------- |
+| PROJECT.md | Project vision, always loaded |
+| REQUIREMENTS.md | Scoped requirements with phase traceability |
+| ROADMAP.md | Phase breakdown and progress tracking |
+| STATE.md | Living memory across sessions |
+| research/ | Domain investigation findings (if research enabled) |
+
+## Next Steps
+
+After initialization, proceed to:
+
+1. **Discuss Phase 1** — Capture implementation decisions ([discussing-phases](/workflow/discussing-phases))
+2. **Plan Phase 1** — Research and create execution plans ([planning-phases](/workflow/planning-phases))
+3. **Execute Phase 1** — Run plans with fresh context ([executing-phases](/workflow/executing-phases))
+4. **Verify Phase 1** — Manual acceptance testing ([verifying-phases](/workflow/verifying-phases))
+
+See [Quickstart](/quickstart) for the complete workflow.

--- a/docs/workflow/verifying-phases.mdx
+++ b/docs/workflow/verifying-phases.mdx
@@ -1,0 +1,79 @@
+---
+title: 'Verifying Phases'
+description: 'Manual user acceptance testing'
+---
+
+## Overview
+
+The `verifying-phases` skill guides you through manual testing of completed work and automatically diagnoses failures.
+
+## Invocation
+
+```
+"Verify phase 1"
+```
+
+Or explicitly:
+
+<CodeGroup>
+
+```bash Plugin
+/kata:verifying-phases 1
+```
+
+```bash NPX
+/kata-verifying-phases 1
+```
+
+</CodeGroup>
+
+## Workflow
+
+### 1. Extract Deliverables
+
+System identifies testable deliverables from phase goals and VERIFICATION.md.
+
+### 2. Manual Testing
+
+Walks you through verification steps one at a time:
+- "Can you log in with email?" → Yes/No/Issue
+- "Do invalid credentials return 401?" → Yes/No/Issue
+
+### 3. Automatic Diagnosis
+
+If issues found, spawns `kata-debugger` agent to:
+- Investigate root cause
+- Propose fix
+- Create verified fix plan
+
+### 4. Fix Plan Generation
+
+Creates new plan ready for immediate execution:
+
+```bash
+/kata:executing-phases 1
+```
+
+Fix plans integrate back into the phase.
+
+## Output Files
+
+| File | Purpose |
+| ---- | ------- |
+| {phase}-UAT.md | User acceptance testing results |
+| {phase}-{N}-PLAN.md | Fix plans if issues found |
+
+## Pass Criteria
+
+Phase verified when:
+- All deliverables manually tested
+- All tests pass
+- No blocking issues remain
+
+## Next Steps
+
+If verification passes, proceed to next phase:
+- [Planning Phases](/workflow/planning-phases) — Plan the next phase
+
+If issues found, re-execute with fix plans:
+- [Executing Phases](/workflow/executing-phases) — Run fix plans

--- a/mint.json
+++ b/mint.json
@@ -1,0 +1,127 @@
+{
+  "$schema": "https://mintlify.com/schema.json",
+  "name": "Kata",
+  "logo": {
+    "dark": "/logo/dark.svg",
+    "light": "/logo/light.svg"
+  },
+  "favicon": "/favicon.svg",
+  "colors": {
+    "primary": "#0D9373",
+    "light": "#07C983",
+    "dark": "#0D9373",
+    "anchors": {
+      "from": "#0D9373",
+      "to": "#07C983"
+    }
+  },
+  "topbarLinks": [
+    {
+      "name": "Support",
+      "url": "mailto:hi@mintlify.com"
+    }
+  ],
+  "topbarCtaButton": {
+    "name": "GitHub",
+    "url": "https://github.com/gannonh/kata"
+  },
+  "tabs": [
+    {
+      "name": "API Reference",
+      "url": "api-reference"
+    }
+  ],
+  "anchors": [
+    {
+      "name": "Documentation",
+      "icon": "book-open-cover",
+      "url": "https://kata.sh"
+    },
+    {
+      "name": "Community",
+      "icon": "slack",
+      "url": "https://github.com/gannonh/kata/discussions"
+    },
+    {
+      "name": "Blog",
+      "icon": "newspaper",
+      "url": "https://kata.sh/blog"
+    }
+  ],
+  "navigation": [
+    {
+      "group": "Get Started",
+      "pages": [
+        "introduction",
+        "quickstart",
+        "installation"
+      ]
+    },
+    {
+      "group": "Core Concepts",
+      "pages": [
+        "core-concepts/overview",
+        "core-concepts/skills",
+        "core-concepts/agents",
+        "core-concepts/templates",
+        "core-concepts/planning"
+      ]
+    },
+    {
+      "group": "Workflow",
+      "pages": [
+        "workflow/starting-projects",
+        "workflow/discussing-phases",
+        "workflow/planning-phases",
+        "workflow/executing-phases",
+        "workflow/verifying-phases",
+        "workflow/quick-mode"
+      ]
+    },
+    {
+      "group": "Configuration",
+      "pages": [
+        "configuration/settings",
+        "configuration/model-profiles",
+        "configuration/workflow-agents"
+      ]
+    },
+    {
+      "group": "Skills Reference",
+      "pages": [
+        "skills/overview",
+        "skills/core-workflow",
+        "skills/navigation",
+        "skills/phase-management",
+        "skills/utilities"
+      ]
+    },
+    {
+      "group": "API Documentation",
+      "pages": [
+        "api-reference/introduction"
+      ]
+    },
+    {
+      "group": "Advanced",
+      "pages": [
+        "advanced/context-engineering",
+        "advanced/multi-agent-orchestration",
+        "advanced/xml-prompting",
+        "advanced/brownfield-projects"
+      ]
+    },
+    {
+      "group": "Contributing",
+      "pages": [
+        "contributing/overview",
+        "contributing/development-setup",
+        "contributing/style-guide"
+      ]
+    }
+  ],
+  "footerSocials": {
+    "github": "https://github.com/gannonh/kata",
+    "website": "https://kata.sh"
+  }
+}


### PR DESCRIPTION
Closes #33

Created a comprehensive Mintlify documentation site for Kata with:

- Complete mint.json configuration
- 31 documentation pages covering all aspects of Kata
- Getting started, core concepts, workflow guides, configuration, skills reference, advanced topics, and contributing guides
- 3020+ lines of documentation

Generated with [Claude Code](https://claude.ai/code)