### PR TITLE
v1.3.1: Fix milestone completion branch workflow

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kata",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Spec-driven development framework for Claude Code. Provides structured workflows for requirements gathering, research, planning, execution, and verification.",
   "author": {
     "name": "gannonh",

--- a/.planning/MILESTONES.md
+++ b/.planning/MILESTONES.md
@@ -1,5 +1,54 @@
 # Project Milestones: Kata
 
+## v1.3.0 Release Automation (Shipped: 2026-01-28)
+
+**Delivered:** Release workflow integrated into milestone completion with version detection and changelog generation
+
+**Phases completed:** 0, 1 (4 plans total)
+
+**Key accomplishments:**
+
+- Release workflow in milestone completion — `/kata:completing-milestones` now offers release workflow
+- Version detection reference — semantic version detection from conventional commits
+- Changelog generation reference — Keep a Changelog format with commit-to-section mapping
+- Dry-run mode — preview version bump and changelog without applying changes
+- PR workflow integration — instructions for PR merge vs direct `gh release create`
+
+**Stats:**
+
+- 16 files changed, 1413 insertions, 84 deletions
+- 2 phases, 4 plans
+- 1 day (2026-01-28)
+
+**Git range:** `v1.2.2` → `v1.3.0`
+
+**What's next:** v1.3.1 patch (milestone completion workflow fix)
+
+---
+
+## v1.2.2 (Shipped: 2026-01-28)
+
+**Delivered:** Bug fixes for skill scripts and GitHub issue updates
+
+**Phases completed:** N/A (patch release)
+
+**Key accomplishments:**
+
+- GitHub issue body updates — replaced awk with Python script for reliable multiline content
+- Skill scripts directory — plugin build now includes `skills/*/scripts/` directories
+- Script path resolution — skills use base directory from invocation header
+
+**Stats:**
+
+- 3 files modified
+- Patch release (same day as v1.2.1)
+
+**Git range:** `v1.2.1` → `v1.2.2`
+
+**What's next:** v1.3.0 Release Automation
+
+---
+
 ## v1.2.1 (Shipped: 2026-01-28)
 
 **Delivered:** VERSION file path fix for plugin distribution

--- a/.planning/milestones/v1.3.0-MILESTONE-AUDIT.md
+++ b/.planning/milestones/v1.3.0-MILESTONE-AUDIT.md
@@ -1,0 +1,177 @@
+---
+milestone: v1.3.0
+audited: 2026-01-28T21:45:00Z
+status: passed
+scores:
+  requirements: 4/4
+  phases: 2/2
+  integration: 8/8
+  flows: 2/2
+gaps:
+  requirements: []
+  integration: []
+  flows: []
+tech_debt: []
+---
+
+# Milestone v1.3.0 Audit Report
+
+**Goal:** Harden CI validation and automate the release pipeline.
+
+**Status:** PASSED
+
+**Audited:** 2026-01-28T21:45:00Z
+
+## Summary
+
+| Category | Score | Status |
+|----------|-------|--------|
+| Requirements | 4/4 | ✓ All satisfied |
+| Phases | 2/2 | ✓ All verified |
+| Integration | 8/8 | ✓ All exports wired |
+| E2E Flows | 2/2 | ✓ All complete |
+
+## Requirements Coverage
+
+| Requirement | Description | Phase | Status |
+|-------------|-------------|-------|--------|
+| REL-01 | User can auto-generate changelog entries from conventional commits | Phase 1 | ✓ SATISFIED |
+| REL-02 | User can auto-detect semantic version bump based on commit types | Phase 1 | ✓ SATISFIED |
+| REL-03 | User can trigger release workflow from milestone completion | Phase 1 | ✓ SATISFIED |
+| REL-04 | User can dry-run release to validate workflow without publishing | Phase 1 | ✓ SATISFIED |
+
+## Phase Verification Summary
+
+### Phase 0: Foundation & CI Hardening
+
+**Status:** PASSED (5/5 truths verified)
+**Verified:** 2026-01-28T18:43:25Z
+
+| Success Criteria | Status |
+|------------------|--------|
+| CI tests actual plugin artifacts from dist/plugin/ | ✓ |
+| Integration test suite validates transformed paths | ✓ |
+| Artifact verification runs before GitHub Release | ✓ |
+| Test coverage includes @./references/ path resolution | ✓ |
+| Build failures block release creation | ✓ |
+
+**Anti-patterns:** None
+**Tech debt:** None
+
+### Phase 1: Release Automation
+
+**Status:** PASSED (6/6 truths verified)
+**Verified:** 2026-01-28T21:32:24Z
+
+| Success Criteria | Status |
+|------------------|--------|
+| Auto-generate changelog from conventional commits (REL-01) | ✓ |
+| Auto-detect semantic version bump (REL-02) | ✓ |
+| Trigger release from milestone completion (REL-03) | ✓ |
+| Dry-run release validation (REL-04) | ✓ |
+| Version bump updates plugin.json | ✓ |
+| Review gate before publish | ✓ |
+
+**Anti-patterns:** None
+**Tech debt:** None
+
+## Integration Check
+
+### Cross-Phase Wiring
+
+| From | To | Via | Status |
+|------|----|----|--------|
+| Phase 0 artifact tests | Phase 1 reference files | reference resolution tests | ✓ WIRED |
+| Phase 0 CI gates | Phase 1 release | npm run test:artifacts | ✓ WIRED |
+| completing-milestones skill | version-detector.md | @-reference | ✓ WIRED |
+| completing-milestones skill | changelog-generator.md | @-reference | ✓ WIRED |
+| milestone-complete.md | gh release create | bash command | ✓ WIRED |
+| plugin-release.yml | artifact validation | test:artifacts script | ✓ WIRED |
+| plugin-release.yml | GitHub Release | gh release create | ✓ WIRED |
+| plugin-release.yml | marketplace publish | kata-marketplace repo | ✓ WIRED |
+
+**Connected:** 8/8 exports
+**Orphaned:** 0
+**Missing:** 0
+
+### E2E Flow Verification
+
+#### Flow 1: Complete Milestone with Release
+
+```
+/kata:complete-milestone
+    ↓
+Step 0.5: Offer release workflow (AskUserQuestion)
+    ↓
+Version detection (version-detector.md)
+    ↓
+Changelog generation (changelog-generator.md)
+    ↓
+User confirmation (AskUserQuestion)
+    ↓
+Update files (package.json, plugin.json, CHANGELOG.md)
+    ↓
+Commit changes
+    ↓
+Create PR (if pr_workflow=true) or direct push
+    ↓
+PR merge triggers CI
+    ↓
+CI validates artifacts (npm run test:artifacts)
+    ↓
+CI creates GitHub Release
+    ↓
+CI publishes to marketplace
+```
+
+**Status:** ✓ COMPLETE (all steps verified)
+
+#### Flow 2: Dry-Run Release Preview
+
+```
+/kata:complete-milestone
+    ↓
+Step 0.5: Select "Yes, dry-run first"
+    ↓
+Version detection (preview only)
+    ↓
+Changelog generation (preview only)
+    ↓
+Display preview (no file changes)
+    ↓
+"DRY RUN COMPLETE" message
+    ↓
+Return to main flow (no release artifacts created)
+```
+
+**Status:** ✓ COMPLETE (dry-run properly prevents all writes)
+
+## Gaps Summary
+
+**Critical gaps:** None
+**Non-critical gaps:** None
+**Tech debt:** None
+
+## Conclusion
+
+Milestone v1.3.0 Release Automation is complete and ready for release.
+
+All requirements satisfied:
+- ✓ REL-01: Changelog generation from conventional commits
+- ✓ REL-02: Semantic version detection
+- ✓ REL-03: Release workflow from milestone completion
+- ✓ REL-04: Dry-run validation
+
+All phases verified:
+- ✓ Phase 0: CI hardening with artifact validation gates
+- ✓ Phase 1: Release workflow integration
+
+All integration points wired:
+- ✓ Cross-phase dependency (Phase 0 validates Phase 1 artifacts)
+- ✓ E2E flows complete (release and dry-run)
+- ✓ No orphaned exports
+
+---
+
+*Audited: 2026-01-28T21:45:00Z*
+*Auditor: Claude (kata-integration-checker + orchestrator)*

--- a/.planning/milestones/v1.3.0-REQUIREMENTS.md
+++ b/.planning/milestones/v1.3.0-REQUIREMENTS.md
@@ -1,0 +1,42 @@
+# Requirements Archive: v1.3.0 Release Automation
+
+**Archived:** 2026-01-28
+**Status:** SHIPPED
+
+This is the archived requirements specification for v1.3.0.
+For current requirements, see `.planning/REQUIREMENTS.md` (created for next milestone).
+
+---
+
+## v1.3.0 Requirements
+
+### Release Automation
+
+- [x] **REL-01**: User can auto-generate changelog entries from conventional commits when completing a milestone
+- [x] **REL-02**: User can auto-detect semantic version bump (major/minor/patch) based on commit types
+- [x] **REL-03**: User can trigger release workflow from milestone completion (milestone → PR merge → GitHub Release → CI publish)
+- [x] **REL-04**: User can dry-run a release to validate workflow without publishing
+
+---
+
+## Traceability
+
+| Requirement | Phase   | Plan  | Status   |
+| ----------- | ------- | ----- | -------- |
+| REL-01      | Phase 1 | 01-01 | Complete |
+| REL-02      | Phase 1 | 01-01 | Complete |
+| REL-03      | Phase 1 | 01-02 | Complete |
+| REL-04      | Phase 1 | 01-02 | Complete |
+
+**Coverage:** 4/4 requirements mapped (100%)
+
+---
+
+## Milestone Summary
+
+**Shipped:** 4 of 4 v1.3.0 requirements
+**Adjusted:** None
+**Dropped:** None
+
+---
+*Archived: 2026-01-28 as part of v1.3.0 milestone completion*

--- a/.planning/milestones/v1.3.0-ROADMAP.md
+++ b/.planning/milestones/v1.3.0-ROADMAP.md
@@ -1,0 +1,72 @@
+# Milestone v1.3.0: Release Automation
+
+**Status:** SHIPPED 2026-01-28
+**Phases:** 0-1
+**Total Plans:** 4
+
+## Overview
+
+Harden CI validation and automate the release pipeline. CI validates plugin artifacts before creating GitHub Release, and users can trigger release workflow from milestone completion with version detection, changelog generation, and dry-run preview.
+
+## Phases
+
+### Phase 0: Foundation & CI Hardening
+
+**Goal**: CI validates actual plugin artifacts to prevent path resolution failures
+**Depends on**: None (foundation)
+**Plans**: 2 plans
+
+Plans:
+- [x] 00-01: Create artifact validation test suite
+- [x] 00-02: Reorder CI workflow for pre-release validation
+
+**Success Criteria:**
+1. CI tests actual plugin artifacts from `dist/plugin/` directory
+2. Integration test suite validates transformed paths
+3. Artifact verification runs in CI before creating GitHub Release
+4. Test coverage includes @./references/ path resolution
+5. Build failures block release creation
+
+---
+
+### Phase 1: Release Automation
+
+**Goal**: Users can trigger release workflow from milestone completion (milestone → PR merge → GitHub Release → CI publish)
+**Depends on**: Phase 0 complete
+**Plans**: 2 plans
+
+Plans:
+- [x] 01-01: Create version detection and changelog generation references
+- [x] 01-02: Integrate release workflow into completing-milestones skill
+
+**Success Criteria:**
+1. Auto-generate changelog from conventional commits (REL-01)
+2. Auto-detect semantic version bump (REL-02)
+3. Trigger release from milestone completion (REL-03)
+4. Dry-run release validation (REL-04)
+5. Version bump updates plugin.json
+6. Review gate before publish
+
+---
+
+## Milestone Summary
+
+**Key Decisions:**
+- Pure bash functions for version detection and changelog generation (no external dependencies)
+- jq for reliable JSON manipulation in version files
+- Review gate mandatory for changelog (human approval before write)
+- CI workflow reorder: tests → build → validate → release
+
+**Issues Resolved:**
+- v1.0.3-1.0.8 path resolution issues prevented by artifact validation gates
+- Release breakage prevented by pre-release validation
+
+**Issues Deferred:**
+- None
+
+**Technical Debt Incurred:**
+- None
+
+---
+
+_Archived: 2026-01-28 as part of v1.3.0 milestone completion_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+## [1.3.1] - 2026-01-28
+
+### Fixed
+- **Milestone completion branch workflow**: When `pr_workflow=true`, now creates release branch FIRST before any commits. Previously committed to main then offered to create branch (too late, causing lost work on reset).
+
+### Added
+- **v1.3.0 milestone archives**: Recovered and added missing milestone archive files from v1.3.0 release.
+
+---
+
 ## [1.3.0] - 2026-01-28 — Release Automation
 
 Kata v1.3.0 integrates release workflow into milestone completion: version detection, changelog generation, and GitHub Release creation.
@@ -291,7 +301,8 @@ Kata 1.0 ships with **Claude Code plugin support** as the recommended installati
 - Upstream remote and sync workflow
 - References to original project maintainer
 
-[Unreleased]: https://github.com/gannonh/kata/compare/v1.3.0...HEAD
+[Unreleased]: https://github.com/gannonh/kata/compare/v1.3.1...HEAD
+[1.3.1]: https://github.com/gannonh/kata/compare/v1.3.0...v1.3.1
 [1.3.0]: https://github.com/gannonh/kata/compare/v1.2.2...v1.3.0
 [1.2.2]: https://github.com/gannonh/kata/compare/v1.2.1...v1.2.2
 [1.2.1]: https://github.com/gannonh/kata/compare/v1.2.0...v1.2.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gannonh/kata",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "type": "module",
   "description": "Spec-driven development framework for Claude Code.",
   "scripts": {


### PR DESCRIPTION
## Summary

Fixes the milestone completion workflow to create the release branch FIRST when `pr_workflow=true`, preventing work from being committed to main and lost on branch switch.

## Problem

When `pr_workflow=true`, the completing-milestones workflow was:
1. Doing all milestone work (commits, archives, etc.) on main
2. Then offering to create a release branch (too late!)
3. When switching branches, work committed to main could be lost

## Solution

Now the workflow:
1. Checks `pr_workflow` config FIRST thing
2. If enabled AND on main, creates `release/vX.Y.Z` branch immediately
3. All milestone completion work goes to that branch
4. Creates PR at the end

## Changes

- `skills/completing-milestones/SKILL.md` — Added step 0 for branch setup
- `skills/completing-milestones/references/milestone-complete.md` — Added `ensure_release_branch` step

## Also Included

- Recovered v1.3.0 milestone archive files that were lost during the botched v1.3.0 release
- Updated MILESTONES.md with v1.3.0 and v1.2.2 completion entries

## Release Files

- `package.json` — version 1.3.1
- `.claude-plugin/plugin.json` — version 1.3.1
- `CHANGELOG.md` — v1.3.1 entry added

## After Merge

Create GitHub Release with tag `v1.3.1` to trigger CI publish to marketplace.