### PR TITLE
fix: PR workflow improvements

### DIFF
--- a/skills/configuring-settings/SKILL.md
+++ b/skills/configuring-settings/SKILL.md
@@ -256,6 +256,25 @@ Quick commands:
 - /kata:plan-phase --skip-research — skip research
 - /kata:plan-phase --skip-verify — skip plan check
 
+**If PR Workflow was just enabled (changed from Off to On), append:**
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ ⚠ RECOMMENDED: Enable Branch Protection
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+PR workflow is enabled. Protect your main branch:
+
+  https://github.com/{owner}/{repo}/settings/branches
+
+Settings for `main`:
+  ✓ Require a pull request before merging
+  ✓ Do not allow bypassing the above settings
+  ✗ Allow force pushes (uncheck)
+
+This ensures ALL changes go through PRs.
+```
+
 
 </process>
 

--- a/skills/executing-phases/SKILL.md
+++ b/skills/executing-phases/SKILL.md
@@ -413,7 +413,7 @@ PR_EOF
     **If user chooses "Merge PR":**
     1. Execute merge:
        ```bash
-       gh pr merge "$PR_NUMBER" --squash --delete-branch
+       gh pr merge "$PR_NUMBER" --merge --delete-branch
        git checkout main && git pull
        ```
     2. Set MERGED=true

--- a/skills/starting-projects/SKILL.md
+++ b/skills/starting-projects/SKILL.md
@@ -519,6 +519,30 @@ AskUserQuestion([
 
 Create `.github/workflows/release.yml`:
 
+**Branch Protection Recommendation:**
+
+After scaffolding, display:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ ⚠ RECOMMENDED: Enable GitHub Branch Protection
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Since you've enabled PR workflow, we strongly recommend
+protecting your main branch to prevent accidental direct pushes.
+
+Go to: https://github.com/{owner}/{repo}/settings/branches
+
+Enable these settings for `main`:
+  ✓ Require a pull request before merging
+  ✓ Do not allow bypassing the above settings
+  ✗ Allow force pushes (uncheck this)
+
+This ensures ALL changes go through PRs — even in emergencies,
+you can temporarily disable protection from GitHub settings.
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
 ```bash
 mkdir -p .github/workflows
 ```
@@ -728,6 +752,23 @@ fi
 | Config   | `.planning/config.json` |
 
 Ready for milestone planning ✓
+
+**If pr_workflow = Yes, append:**
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ ⚠ RECOMMENDED: Enable Branch Protection
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+PR workflow is enabled. Protect your main branch:
+
+  https://github.com/{owner}/{repo}/settings/branches
+
+Settings for `main`:
+  ✓ Require a pull request before merging
+  ✓ Do not allow bypassing the above settings
+  ✗ Allow force pushes (uncheck)
+```
 
 ───────────────────────────────────────────────────────────────
 

--- a/skills/verifying-work/SKILL.md
+++ b/skills/verifying-work/SKILL.md
@@ -207,7 +207,7 @@ Use AskUserQuestion:
 
 If user chose "Yes, merge now":
 ```bash
-gh pr merge "$PR_NUMBER" --squash --delete-branch
+gh pr merge "$PR_NUMBER" --merge --delete-branch
 git checkout main && git pull
 ```
 Set MERGED=true for output below.
@@ -263,7 +263,7 @@ Use AskUserQuestion:
 
 If user chose "Yes, merge now":
 ```bash
-gh pr merge "$PR_NUMBER" --squash --delete-branch
+gh pr merge "$PR_NUMBER" --merge --delete-branch
 git checkout main && git pull
 ```
 Set MERGED=true for output below.


### PR DESCRIPTION
## Summary

- **Branch protection guidance**: Recommend enabling GitHub branch protection when `pr_workflow` is enabled (in both new projects and settings)
- **Merge strategy**: Change from `--squash` to `--merge` to preserve atomic commit history

## Why

Squash merges were destroying the per-task commit granularity that Kata creates. With `--merge`, the original commit hashes stay valid (important for SUMMARY.md references).

## Files Changed

- `skills/starting-projects/SKILL.md` — branch protection recommendation
- `skills/configuring-settings/SKILL.md` — branch protection recommendation  
- `skills/executing-phases/SKILL.md` — `--squash` → `--merge`
- `skills/verifying-work/SKILL.md` — `--squash` → `--merge`