### PR TITLE
v1.3.2: PR workflow improvements

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kata",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Spec-driven development framework for Claude Code. Provides structured workflows for requirements gathering, research, planning, execution, and verification.",
   "author": {
     "name": "gannonh",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+## [1.3.2] - 2026-01-28
+
+### Changed
+- **PR merge strategy**: Changed from `--squash` to `--merge` to preserve atomic commit history. Squash was destroying the per-task commit granularity that Kata creates.
+
+### Added
+- **Branch protection guidance**: When `pr_workflow` is enabled, now recommends enabling GitHub branch protection on main (shown in new projects and settings).
+
+---
+
 ## [1.3.1] - 2026-01-28
 
 ### Fixed
@@ -301,7 +311,8 @@ Kata 1.0 ships with **Claude Code plugin support** as the recommended installati
 - Upstream remote and sync workflow
 - References to original project maintainer
 
-[Unreleased]: https://github.com/gannonh/kata/compare/v1.3.1...HEAD
+[Unreleased]: https://github.com/gannonh/kata/compare/v1.3.2...HEAD
+[1.3.2]: https://github.com/gannonh/kata/compare/v1.3.1...v1.3.2
 [1.3.1]: https://github.com/gannonh/kata/compare/v1.3.0...v1.3.1
 [1.3.0]: https://github.com/gannonh/kata/compare/v1.2.2...v1.3.0
 [1.2.2]: https://github.com/gannonh/kata/compare/v1.2.1...v1.2.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gannonh/kata",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "type": "module",
   "description": "Spec-driven development framework for Claude Code.",
   "scripts": {


### PR DESCRIPTION
## Summary

- PR merge strategy changed from `--squash` to `--merge` (preserves atomic commits)
- Branch protection guidance when `pr_workflow` enabled

## Release Files

- `package.json` — version 1.3.2
- `.claude-plugin/plugin.json` — version 1.3.2
- `CHANGELOG.md` — v1.3.2 entry

## After Merge

CI creates GitHub Release and publishes to marketplace.