### PR TITLE
fix: remove agents/ directory checks from CI and tests

### DIFF
--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -76,10 +76,10 @@ jobs:
         run: |
           # Verify critical files exist
           # Note: commands directory removed in v1.3.5 (skills-first architecture)
+          # Note: agents directory removed in v1.6.0 (instructions moved to skill references/)
           test -f dist/plugin/.claude-plugin/plugin.json
           test -d dist/plugin/skills
           test -d dist/plugin/hooks
-          test -d dist/plugin/agents
           test -f dist/plugin/VERSION
           echo "✓ Plugin build validated (quick check)"
 


### PR DESCRIPTION
## Summary

The `agents/` directory was removed in v1.6.0 (instructions moved to skill `references/`). CI validation and artifact tests still expected it, causing the publish pipeline to fail.

- Remove `test -d dist/plugin/agents` from plugin-release.yml validation
- Remove `agents` from `requiredDirs` array in artifact-validation.test.js
- Remove agent reference resolution and frontmatter tests (no agents dir)
- Skip CHANGELOG.md in subagent_type prefix check (historical prose)