### PR TITLE
fix: remove kata: plugin namespace prefix

### DIFF
--- a/.claude/skills/releasing-kata/SKILL.md
+++ b/.claude/skills/releasing-kata/SKILL.md
@@ -202,14 +202,14 @@ claude
 In Claude Code:
 ```
 /plugin install kata@kata-marketplace
-/kata:kata-help
-/kata:kata-whats-new
+/kata-help
+/kata-whats-new
 ```
 
 **Verify:**
 - Plugin installs without errors
-- `/kata:kata-help` shows all commands
-- `/kata:kata-whats-new` shows new version changelog
+- `/kata-help` shows all commands
+- `/kata-whats-new` shows new version changelog
 - No path resolution errors
 
 ```bash
@@ -239,4 +239,4 @@ See `./release-troubleshooting.md` for common issues:
 **Post-release verification:**
 - [ ] GitHub Release created with tag (`gh release view vX.Y.Z`)
 - [ ] Marketplace shows new version (`gh api` check)
-- [ ] Manual plugin test passes (`/plugin install kata@kata-marketplace` + `/kata:kata-help`)
+- [ ] Manual plugin test passes (`/plugin install kata@kata-marketplace` + `/kata-help`)

--- a/.docs/USER-JOURNEYS.md
+++ b/.docs/USER-JOURNEYS.md
@@ -25,7 +25,7 @@ This is the fundamental architecture of Kata Orchestrator. Users interact with *
 ```mermaid
 flowchart LR
     subgraph User["User Interface"]
-        CMD["/kata:kata-skill-name"]
+        CMD["/kata-skill-name"]
         NL["Natural Language"]
     end
 
@@ -68,13 +68,13 @@ flowchart LR
 **Natural invocation:**
 ```
 User: "plan phase 2"
-Assistant: [Invokes /kata:kata-planning-phases 2]
+Assistant: [Invokes /kata-planning-phases 2]
 
 User: "execute the foundation phase"
-Assistant: [Invokes /kata:kata-executing-phases 1]
+Assistant: [Invokes /kata-executing-phases 1]
 
 User: "run UAT on phase 3"
-Assistant: [Invokes /kata:kata-verifying-work 3]
+Assistant: [Invokes /kata-verifying-work 3]
 ```
 
 ---
@@ -88,29 +88,29 @@ This state machine shows the complete development lifecycle managed by Kata.
 ```mermaid
 flowchart TD
     subgraph Init["Project Initialization"]
-        NP["/kata:kata-starting-projects"]
+        NP["/kata-starting-projects"]
         PROJ["PROJECT.md"]
         CFG["config.json"]
     end
 
     subgraph Milestone["Milestone Definition"]
-        AMI["/kata:kata-adding-milestones"]
+        AMI["/kata-adding-milestones"]
         REQ["REQUIREMENTS.md"]
         ROAD["ROADMAP.md"]
     end
 
     subgraph Phase["Phase Work"]
-        PLN["/kata:kata-planning-phases"]
+        PLN["/kata-planning-phases"]
         PLAN["PLAN.md files"]
-        EXE["/kata:kata-executing-phases"]
+        EXE["/kata-executing-phases"]
         SUM["SUMMARY.md files"]
-        VER["/kata:kata-verifying-work"]
+        VER["/kata-verifying-work"]
         UAT["UAT.md"]
     end
 
     subgraph Complete["Completion"]
-        AUD["/kata:kata-auditing-milestones"]
-        CMP["/kata:kata-completing-milestones"]
+        AUD["/kata-auditing-milestones"]
+        CMP["/kata-completing-milestones"]
         TAG["Git tag + Release"]
     end
 
@@ -149,14 +149,14 @@ Each stage produces traceable artifacts in `.planning/`:
 
 ## 3. Planning Flow
 
-**Skill:** `/kata:kata-planning-phases N`  
+**Skill:** `/kata-planning-phases N`  
 **Purpose:** Create executable PLAN.md files for a phase with optional research and mandatory verification
 
 This workflow ensures every phase has thoroughly researched, validated plans before execution begins.
 
 ```mermaid
 flowchart TD
-    START["/kata:kata-planning-phases N"]
+    START["/kata-planning-phases N"]
 
     subgraph Validate["Validation"]
         CHK{"Phase exists?"}
@@ -219,14 +219,14 @@ flowchart TD
 
 ## 4. Execution Flow
 
-**Skill:** `/kata:kata-executing-phases N`  
+**Skill:** `/kata-executing-phases N`  
 **Purpose:** Execute all plans in a phase with wave-based parallelization, checkpointing, and verification
 
 This is the execution engine of Kata, orchestrating parallel agents with automatic dependency resolution.
 
 ```mermaid
 flowchart TD
-    START["/kata:kata-executing-phases N"]
+    START["/kata-executing-phases N"]
 
     subgraph Setup["Setup"]
         VAL["Validate phase exists"]
@@ -287,7 +287,7 @@ flowchart TD
     UPD --> COMMIT
     COMMIT --> PRREADY
     PRREADY --> OFFER
-    GAPS -->|"/kata:kata-planning-phases --gaps"| START
+    GAPS -->|"/kata-planning-phases --gaps"| START
     HUMAN --> OFFER
 ```
 
@@ -295,14 +295,14 @@ flowchart TD
 
 ## 5. Verification Flow
 
-**Skill:** `/kata:kata-verifying-work N`  
+**Skill:** `/kata-verifying-work N`  
 **Purpose:** Conversational UAT (User Acceptance Testing) with automated gap diagnosis and fix planning
 
 This workflow transforms deliverables into testable assertions and guides users through validation.
 
 ```mermaid
 flowchart TD
-    START["/kata:kata-verifying-work N"]
+    START["/kata-verifying-work N"]
 
     subgraph Extract["Extract Tests"]
         FIND["Find SUMMARY.md files"]
@@ -341,9 +341,9 @@ flowchart TD
     end
 
     subgraph Output["Completion"]
-        ROUTE_A["/kata:kata-planning-phases (next)"]
-        ROUTE_B["/kata:kata-auditing-milestones"]
-        ROUTE_C["/kata:kata-executing-phases --gaps-only"]
+        ROUTE_A["/kata-planning-phases (next)"]
+        ROUTE_B["/kata-auditing-milestones"]
+        ROUTE_C["/kata-executing-phases --gaps-only"]
         ROUTE_D["Manual intervention"]
     end
 
@@ -393,7 +393,7 @@ flowchart TD
     end
 
     subgraph PhaseStart["Phase Start"]
-        EXEC["/kata:kata-executing-phases N"]
+        EXEC["/kata-executing-phases N"]
         BRANCH["Create branch: feat/vX.Y-N-slug"]
         CHECKOUT["Checkout branch"]
     end
@@ -414,8 +414,8 @@ flowchart TD
     end
 
     subgraph Review["Review Options"]
-        UAT["/kata:kata-verifying-work (UAT)"]
-        PRREV["/kata:kata-reviewing-pull-requests"]
+        UAT["/kata-verifying-work (UAT)"]
+        PRREV["/kata-reviewing-pull-requests"]
         AGENTS["6 specialized review agents"]
         FINDINGS["Aggregate findings"]
         FIX["Fix critical/important"]
@@ -431,7 +431,7 @@ flowchart TD
 
     subgraph Release["Release (Milestone Complete)"]
         ALL_MERGED["All phase PRs merged"]
-        COMPLETE["/kata:kata-completing-milestones"]
+        COMPLETE["/kata-completing-milestones"]
         TAG["Create Git tag"]
         RELEASE["GitHub Release"]
         NOTES["Auto-generate release notes"]
@@ -476,44 +476,44 @@ flowchart TD
 ### All Skills (27)
 
 **Project Lifecycle:**
-- `/kata:kata-starting-projects` - Initialize PROJECT.md with deep questioning
-- `/kata:kata-adding-milestones` - Create requirements + roadmap
-- `/kata:kata-planning-phases` - Create PLAN.md files with research
-- `/kata:kata-executing-phases` - Wave-based execution
-- `/kata:kata-verifying-work` - Conversational UAT
-- `/kata:kata-auditing-milestones` - Pre-completion audit
-- `/kata:kata-completing-milestones` - Archive + release
+- `/kata-starting-projects` - Initialize PROJECT.md with deep questioning
+- `/kata-adding-milestones` - Create requirements + roadmap
+- `/kata-planning-phases` - Create PLAN.md files with research
+- `/kata-executing-phases` - Wave-based execution
+- `/kata-verifying-work` - Conversational UAT
+- `/kata-auditing-milestones` - Pre-completion audit
+- `/kata-completing-milestones` - Archive + release
 
 **Phase Operations:**
-- `/kata:kata-discussing-phases` - Phase definition conversation
-- `/kata:kata-researching-phases` - Deep research only
-- `/kata:kata-archiving-phases` - Move phase to archive
-- `/kata:kata-canceling-phases` - Cancel in-progress phase
-- `/kata:kata-inserting-phases` - Insert new phase in roadmap
-- `/kata:kata-moving-phases` - Reorder phases
-- `/kata:kata-renaming-phases` - Rename phase
+- `/kata-discussing-phases` - Phase definition conversation
+- `/kata-researching-phases` - Deep research only
+- `/kata-archiving-phases` - Move phase to archive
+- `/kata-canceling-phases` - Cancel in-progress phase
+- `/kata-inserting-phases` - Insert new phase in roadmap
+- `/kata-moving-phases` - Reorder phases
+- `/kata-renaming-phases` - Rename phase
 
 **Pull Request:**
-- `/kata:kata-reviewing-pull-requests` - Spawn 6 review agents
+- `/kata-reviewing-pull-requests` - Spawn 6 review agents
 
 **Debugging:**
-- `/kata:kata-debugging` - General debugging with kata-debugger
-- `/kata:kata-finding-silent-failures` - Detect subtle bugs
+- `/kata-debugging` - General debugging with kata-debugger
+- `/kata-finding-silent-failures` - Detect subtle bugs
 
 **Todo Management:**
-- `/kata:kata-adding-todos` - Add structured todos
-- `/kata:kata-completing-todos` - Mark todos complete
-- `/kata:kata-listing-todos` - Show all todos
-- `/kata:kata-prioritizing-todos` - Reorder by priority
+- `/kata-adding-todos` - Add structured todos
+- `/kata-completing-todos` - Mark todos complete
+- `/kata-listing-todos` - Show all todos
+- `/kata-prioritizing-todos` - Reorder by priority
 
 **Tracking:**
-- `/kata:kata-tracking-progress` - Status reports
-- `/kata:kata-tracking-requirements` - Requirement coverage
+- `/kata-tracking-progress` - Status reports
+- `/kata-tracking-requirements` - Requirement coverage
 
 **Utility:**
-- `/kata:kata-continuing-work` - Resume after checkpoint
-- `/kata:kata-mapping-codebase` - Generate codebase map
-- `/kata:kata-reviewing-docs` - Documentation review
+- `/kata-continuing-work` - Resume after checkpoint
+- `/kata-mapping-codebase` - Generate codebase map
+- `/kata-reviewing-docs` - Documentation review
 
 ### All Agents (19)
 
@@ -653,7 +653,7 @@ Wave 3 (depends on wave 2):
 
 **Solution:** Skills stay lean (~15% context), delegating to fresh agents (100% context per spawn).
 
-**Example:** `/kata:kata-executing-phases 3`
+**Example:** `/kata-executing-phases 3`
 
 ```
 Skill context budget (~30k tokens):

--- a/.docs/diagrams/FLOWS.md
+++ b/.docs/diagrams/FLOWS.md
@@ -10,7 +10,7 @@ How users interact with skills, which orchestrate agents.
 %%{init: {'theme': 'dark'}}%%
 flowchart LR
     subgraph User["User Interface"]
-        CMD["/kata:kata-skill-name"]
+        CMD["/kata-skill-name"]
         NL["Natural Language"]
     end
 
@@ -47,29 +47,29 @@ State machine from project creation to milestone completion.
 %%{init: {'theme': 'dark'}}%%
 flowchart TD
     subgraph Init["Project Initialization"]
-        NP["/kata:kata-new-project"]
+        NP["/kata-new-project"]
         PROJ["PROJECT.md"]
         CFG["config.json"]
     end
 
     subgraph Milestone["Milestone Definition"]
-        AMI["/kata:kata-add-milestone"]
+        AMI["/kata-add-milestone"]
         REQ["REQUIREMENTS.md"]
         ROAD["ROADMAP.md"]
     end
 
     subgraph Phase["Phase Work"]
-        PLN["/kata:kata-plan-phase"]
+        PLN["/kata-plan-phase"]
         PLAN["PLAN.md files"]
-        EXE["/kata:kata-execute-phase"]
+        EXE["/kata-execute-phase"]
         SUM["SUMMARY.md files"]
-        VER["/kata:kata-verify-work"]
+        VER["/kata-verify-work"]
         UAT["UAT.md"]
     end
 
     subgraph Complete["Completion"]
-        AUD["/kata:kata-audit-milestone"]
-        CMP["/kata:kata-complete-milestone"]
+        AUD["/kata-audit-milestone"]
+        CMP["/kata-complete-milestone"]
         TAG["Git tag + Release"]
     end
 
@@ -98,7 +98,7 @@ The planning-phases skill workflow with research and verification loop.
 ```mermaid
 %%{init: {'theme': 'dark'}}%%
 flowchart TD
-    START["/kata:kata-plan-phase N"]
+    START["/kata-plan-phase N"]
 
     subgraph Validate["Validation"]
         CHK{"Phase exists?"}
@@ -164,7 +164,7 @@ The executing-phases skill workflow with wave parallelization.
 ```mermaid
 %%{init: {'theme': 'dark'}}%%
 flowchart TD
-    START["/kata:kata-execute-phase N"]
+    START["/kata-execute-phase N"]
 
     subgraph Setup["Setup"]
         VAL["Validate phase exists"]
@@ -225,7 +225,7 @@ flowchart TD
     UPD --> COMMIT
     COMMIT --> PRREADY
     PRREADY --> OFFER
-    GAPS -->|"/kata:kata-plan-phase --gaps"| START
+    GAPS -->|"/kata-plan-phase --gaps"| START
     HUMAN --> OFFER
 ```
 
@@ -236,7 +236,7 @@ The verifying-work skill workflow for UAT and gap closure.
 ```mermaid
 %%{init: {'theme': 'dark'}}%%
 flowchart TD
-    START["/kata:kata-verify-work N"]
+    START["/kata-verify-work N"]
 
     subgraph Extract["Extract Tests"]
         FIND["Find SUMMARY.md files"]
@@ -275,9 +275,9 @@ flowchart TD
     end
 
     subgraph Output["Completion"]
-        ROUTE_A["/kata:kata-execute-phase (next)"]
-        ROUTE_B["/kata:kata-audit-milestone"]
-        ROUTE_C["/kata:kata-execute-phase --gaps-only"]
+        ROUTE_A["/kata-execute-phase (next)"]
+        ROUTE_B["/kata-audit-milestone"]
+        ROUTE_C["/kata-execute-phase --gaps-only"]
         ROUTE_D["Manual intervention"]
     end
 
@@ -323,7 +323,7 @@ flowchart TD
     end
 
     subgraph PhaseStart["Phase Start"]
-        EXEC["/kata:kata-execute-phase N"]
+        EXEC["/kata-execute-phase N"]
         BRANCH["Create branch: feat/vX.Y-N-slug"]
         CHECKOUT["Checkout branch"]
     end
@@ -344,8 +344,8 @@ flowchart TD
     end
 
     subgraph Review["Review Options"]
-        UAT["/kata:kata-verify-work (UAT)"]
-        PRREV["/kata:kata-reviewing-pull-requests"]
+        UAT["/kata-verify-work (UAT)"]
+        PRREV["/kata-reviewing-pull-requests"]
         AGENTS["6 specialized review agents"]
         FINDINGS["Aggregate findings"]
         FIX["Fix critical/important"]
@@ -361,7 +361,7 @@ flowchart TD
 
     subgraph Release["Release (Milestone Complete)"]
         ALL_MERGED["All phase PRs merged"]
-        COMPLETE["/kata:kata-complete-milestone"]
+        COMPLETE["/kata-complete-milestone"]
         TAG["Create Git tag"]
         RELEASE["GitHub Release"]
         NOTES["Auto-generate release notes"]

--- a/.docs/diagrams/README.md
+++ b/.docs/diagrams/README.md
@@ -25,7 +25,7 @@ These diagrams help users and future Claude instances understand how Kata orches
 
 Kata uses a **thin orchestrator + specialized agents** pattern:
 
-1. **User** invokes skills via `/kata:kata-skill-name` or natural language
+1. **User** invokes skills via `/kata-skill-name` or natural language
 2. **Skills** (orchestrators) parse arguments, validate state, spawn subagents
 3. **Subagents** execute specialized tasks with fresh context (via Task tool)
 4. **Artifacts** (PLAN.md, SUMMARY.md, etc.) persist state across sessions

--- a/.docs/glossary/GLOSSARY.md
+++ b/.docs/glossary/GLOSSARY.md
@@ -11,7 +11,7 @@ Authoritative terminology reference for Kata. This document defines key terms, s
 | Phase | A logical unit of work within a milestone, becomes a GitHub Issue |
 | Plan | An executable task specification within a phase, 2-3 tasks maximum |
 | Task | A single atomic unit of work within a plan |
-| Skill | A user-invocable orchestrator workflow (via `/kata:kata-skill-name`) |
+| Skill | A user-invocable orchestrator workflow (via `/kata-skill-name`) |
 | Agent | A specialized subagent spawned by skills for specific work |
 | Checkpoint | A pause point requiring user verification or decision |
 | Wave | A pre-computed dependency group for parallel plan execution |
@@ -405,7 +405,7 @@ flowchart TB
 
 **Definition:** A user-invocable orchestrator workflow that coordinates complex operations by spawning agents.
 
-**Invocation:** `/kata:kata-skill-name` (e.g., `/kata:kata-planning-phases 1`)
+**Invocation:** `/kata-skill-name` (e.g., `/kata-planning-phases 1`)
 
 **Relationships:**
 - Invoked by: User (via slash command or natural language)
@@ -488,7 +488,7 @@ flowchart TB
 
 **Definition:** The workflow for creating executable plans from phase requirements.
 
-**Skill:** `/kata:kata-planning-phases [phase-number]`
+**Skill:** `/kata-planning-phases [phase-number]`
 
 **Agents:** kata-phase-researcher, kata-planner, kata-plan-checker
 
@@ -506,7 +506,7 @@ flowchart TB
 
 **Definition:** The workflow for executing plans and producing working code.
 
-**Skill:** `/kata:kata-executing-phases [phase-number]`
+**Skill:** `/kata-executing-phases [phase-number]`
 
 **Agent:** kata-executor
 
@@ -525,7 +525,7 @@ flowchart TB
 
 **Definition:** The workflow for verifying that phase work meets requirements.
 
-**Skill:** `/kata:kata-verifying-work [phase-number]`
+**Skill:** `/kata-verifying-work [phase-number]`
 
 **Agents:** kata-verifier, kata-debugger
 
@@ -544,7 +544,7 @@ flowchart TB
 
 **Definition:** User verification that delivered work meets expectations.
 
-**Skill:** `/kata:kata-verifying-work` (with user interaction)
+**Skill:** `/kata-verifying-work` (with user interaction)
 
 **Purpose:** Ensure the implementation matches user intent, not just technical requirements.
 
@@ -562,7 +562,7 @@ flowchart TB
 
 **Definition:** Creating additional plans to address issues found during verification or UAT.
 
-**Skill:** `/kata:kata-planning-milestone-gaps`
+**Skill:** `/kata-planning-milestone-gaps`
 
 **Purpose:** Fix defects or add missing functionality discovered after initial execution.
 

--- a/.planning/MILESTONES.md
+++ b/.planning/MILESTONES.md
@@ -38,7 +38,7 @@
 
 - Universal phase discovery pattern with state-aware `find` across all skills and agents
 - Phase state directories (`pending/`, `active/`, `completed/`) with automatic transitions
-- `/kata:kata-move-phase` for cross-milestone moves and within-milestone reordering
+- `/kata-move-phase` for cross-milestone moves and within-milestone reordering
 - Per-milestone phase numbering starting at 1 (independent per milestone)
 - Roadmap format standardization with Planned Milestones section
 - Format conventions propagated to milestone completion, add-milestone, and roadmapper agents

--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -158,7 +158,7 @@ Teams get reliable AI-driven development without abandoning their existing GitHu
 **Key accomplishments:**
 - Universal phase discovery pattern with state-aware `find` across all skills and agents
 - Phase state directories (`pending/`, `active/`, `completed/`) with automatic transitions
-- `/kata:kata-move-phase` for cross-milestone moves and within-milestone reordering
+- `/kata-move-phase` for cross-milestone moves and within-milestone reordering
 - Per-milestone phase numbering starting at 1 (independent per milestone)
 - Roadmap format standardization with Planned Milestones section
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -100,4 +100,4 @@ None.
 Last session: 2026-02-06
 Stopped at: v1.6.0 milestone shipped
 Resume file: None
-Next action: Define next milestone with /kata:kata-add-milestone
+Next action: Define next milestone with /kata-add-milestone

--- a/.planning/issues/closed/2026-02-02-add-kata-prefix-to-skill-names.md
+++ b/.planning/issues/closed/2026-02-02-add-kata-prefix-to-skill-names.md
@@ -12,7 +12,7 @@ files:
 Skills currently use bare names like `add-milestone`, `plan-phase`, `execute-phase` in their directory and `name` frontmatter fields. The CLAUDE.md documents that skills should use `kata-` prefix (e.g., `kata-plan-phase`), but the actual skill directories and SKILL.md `name` fields don't follow this convention.
 
 This creates inconsistency between:
-- Documentation showing `/kata:kata-plan-phase` style invocations
+- Documentation showing `/kata-plan-phase` style invocations
 - Actual invocations being `/kata:plan-phase`
 
 27 skills need updating:

--- a/.planning/issues/closed/2026-02-06-phase-lookup-ignores-milestone-scope.md
+++ b/.planning/issues/closed/2026-02-06-phase-lookup-ignores-milestone-scope.md
@@ -10,11 +10,11 @@ files:
 
 ## Problem
 
-When a user runs `/kata:kata-plan-phase 1` on a new milestone, the phase directory lookup scans all of `.planning/phases/{active,pending,completed}/` without filtering by current milestone. If a previous milestone also had a Phase 1 (e.g., `01-foundation` from v0.1.0), the lookup matches the old phase instead of creating a new one for the current milestone.
+When a user runs `/kata-plan-phase 1` on a new milestone, the phase directory lookup scans all of `.planning/phases/{active,pending,completed}/` without filtering by current milestone. If a previous milestone also had a Phase 1 (e.g., `01-foundation` from v0.1.0), the lookup matches the old phase instead of creating a new one for the current milestone.
 
 This breaks per-milestone phase numbering (adopted 2026-02-03). Completed phases from earlier milestones remain in `.planning/phases/completed/` with the same `01-*` prefix, causing name collisions.
 
-Observed in kata-context project: `/kata:kata-plan-phase 1` for v0.3.0 matched `01-foundation` from v0.1.0 instead of creating v0.3.0's Phase 1 (Infrastructure + Policy Foundation).
+Observed in kata-context project: `/kata-plan-phase 1` for v0.3.0 matched `01-foundation` from v0.1.0 instead of creating v0.3.0's Phase 1 (Infrastructure + Policy Foundation).
 
 ## Solution
 

--- a/.planning/milestones/v1.4.1-REQUIREMENTS.md
+++ b/.planning/milestones/v1.4.1-REQUIREMENTS.md
@@ -23,7 +23,7 @@ This is the archived requirements specification for v1.4.1.
 
 ### Issue → Roadmap Integration
 
-- [x] **INTEG-01**: Pull backlog issues into a milestone's scope via `/kata:kata-add-milestone` or dedicated skill
+- [x] **INTEG-01**: Pull backlog issues into a milestone's scope via `/kata-add-milestone` or dedicated skill
 - [x] **INTEG-02**: Pull issues into a phase (becomes a task/plan within the phase)
 - [x] **INTEG-03**: Phase plans can reference their source issue number for traceability
 

--- a/.planning/milestones/v1.4.1-ROADMAP.md
+++ b/.planning/milestones/v1.4.1-ROADMAP.md
@@ -78,7 +78,7 @@ Plans:
 **Key Decisions:**
 - INTEG-03 closed — plan-phase extracts issue context from STATE.md for kata-planner
 - v1.4.1 inserted — Continue issue work before phase management
-- Commands deprecated — Skills are user-invocable directly via /kata:kata-skill-name
+- Commands deprecated — Skills are user-invocable directly via /kata-skill-name
 
 **Issues Resolved:**
 - Complete issue lifecycle from creation to PR auto-closure

--- a/.planning/milestones/v1.5.0-MILESTONE-AUDIT.md
+++ b/.planning/milestones/v1.5.0-MILESTONE-AUDIT.md
@@ -26,7 +26,7 @@ tech_debt: []
 | ----------- | ----------- | ----- | ------ |
 | PHASE-01 | Phase directories organized under pending/, active/, completed/ | 1 | ✓ Satisfied |
 | PHASE-05 | Completion validates PLAN.md, SUMMARY.md; non-gap phases require VERIFICATION.md | 1 | ✓ Satisfied |
-| PHASE-02 | Move phase to different milestone via /kata:kata-move-phase | 2 | ✓ Satisfied |
+| PHASE-02 | Move phase to different milestone via /kata-move-phase | 2 | ✓ Satisfied |
 | PHASE-03 | Reorder phases within milestone with automatic renumbering | 2 | ✓ Satisfied |
 | PHASE-04 | Each milestone starts phase numbering at 1 | 2 | ✓ Satisfied |
 | ROAD-01 | ROADMAP.md displays future planned milestones | 3 | ✓ Satisfied |

--- a/.planning/milestones/v1.5.0-REQUIREMENTS.md
+++ b/.planning/milestones/v1.5.0-REQUIREMENTS.md
@@ -15,7 +15,7 @@ For current requirements, see `.planning/REQUIREMENTS.md` (created for next mile
 
 ## Phase Movement
 
-- [x] **PHASE-02**: User can move a phase to a different milestone via `/kata:kata-move-phase`
+- [x] **PHASE-02**: User can move a phase to a different milestone via `/kata-move-phase`
 - [x] **PHASE-03**: User can reorder phases within a milestone with automatic renumbering
 - [x] **PHASE-04**: Each milestone starts phase numbering at 1 (not cumulative across milestones)
 

--- a/.planning/milestones/v1.5.0-ROADMAP.md
+++ b/.planning/milestones/v1.5.0-ROADMAP.md
@@ -37,7 +37,7 @@ Plans:
 - [x] 02-02: Add within-milestone reorder capability, help listing, and requirements traceability
 
 **Details:**
-Created `/kata:kata-move-phase` skill supporting cross-milestone moves and within-milestone reordering. Enforced per-milestone phase numbering starting at 1 (independent, not cumulative). Updated help listing and requirements traceability table.
+Created `/kata-move-phase` skill supporting cross-milestone moves and within-milestone reordering. Enforced per-milestone phase numbering starting at 1 (independent, not cumulative). Updated help listing and requirements traceability table.
 
 ### Phase 3: Roadmap Enhancements
 

--- a/.planning/phases/completed/11-normalize-on-skills/02.2-02-PLAN.md
+++ b/.planning/phases/completed/11-normalize-on-skills/02.2-02-PLAN.md
@@ -28,7 +28,7 @@ must_haves:
 <objective>
 Update build.js to strip `kata-` prefix from skill directories and `name` field for plugin distribution.
 
-Purpose: Plugin namespace adds `kata:` prefix to skills automatically. With `kata-` in skill names, users would invoke `/kata:kata-planning-phases` (redundant). Stripping the prefix yields clean `/kata:planning-phases`.
+Purpose: Plugin namespace adds `kata:` prefix to skills automatically. With `kata-` in skill names, users would invoke `/kata-planning-phases` (redundant). Stripping the prefix yields clean `/kata:planning-phases`.
 
 Output: build.js updated to transform skill directories and names during plugin build.
 </objective>
@@ -40,7 +40,7 @@ Output: build.js updated to transform skill directories and names during plugin 
 **Current plugin behavior:**
 - Skills copied as-is: `skills/kata-planning-phases/` -> `dist/plugin/skills/kata-planning-phases/`
 - Name in SKILL.md frontmatter: `name: kata-planning-phases`
-- Plugin invocation: `/kata:kata-planning-phases` (double kata)
+- Plugin invocation: `/kata-planning-phases` (double kata)
 
 **Target plugin behavior:**
 - Skills transformed: `skills/kata-planning-phases/` -> `dist/plugin/skills/planning-phases/`
@@ -74,7 +74,7 @@ Add after `transformPluginPaths()`:
  *
  * Plugin skills are namespaced as pluginname:skillname.
  * Source skills are named kata-* (e.g., kata-planning-phases).
- * Without transformation: /kata:kata-planning-phases (redundant)
+ * Without transformation: /kata-planning-phases (redundant)
  * With transformation: /kata:planning-phases (clean)
  *
  * This function:

--- a/.planning/phases/completed/11-normalize-on-skills/02.2-02-SUMMARY.md
+++ b/.planning/phases/completed/11-normalize-on-skills/02.2-02-SUMMARY.md
@@ -9,7 +9,7 @@ requires:
   - phase: 02.2-01
     provides: Skills are now user-invocable
 provides:
-  - Plugin skills namespaced cleanly: /kata:planning-phases (not /kata:kata-planning-phases)
+  - Plugin skills namespaced cleanly: /kata:planning-phases (not /kata-planning-phases)
   - NPX skills unchanged: /kata-planning-phases
   - transformSkillName() for name field transformation
   - renameSkillDir() for directory transformation

--- a/.planning/phases/completed/30-proof-of-concept/01-03-PLAN.md
+++ b/.planning/phases/completed/30-proof-of-concept/01-03-PLAN.md
@@ -94,7 +94,7 @@ Key factors for the decision:
 - Structural validation confirms correct prompt assembly
 - The core unknown is behavioral equivalence: whether inlined instructions (task prompt) produce the same quality output as system prompt instructions. This can only be fully validated by running the skills in a real project.
 
-Recommendation: If automated checks pass, try running `/kata:kata-plan-phase` on a test phase in a separate project to observe output quality before deciding.
+Recommendation: If automated checks pass, try running `/kata-plan-phase` on a test phase in a separate project to observe output quality before deciding.
   </context>
   <options>
     <option id="go">

--- a/.planning/phases/completed/30-proof-of-concept/01-03-SUMMARY.md
+++ b/.planning/phases/completed/30-proof-of-concept/01-03-SUMMARY.md
@@ -69,14 +69,14 @@ All automated validation checks passed:
 
 Tested in `kata-burner/test-greenfield-20260205-131424`:
 
-**Planner test** (`/kata:kata-plan-phase 1`):
+**Planner test** (`/kata-plan-phase 1`):
 - Research phase spawned correctly
 - Planner produced well-structured PLAN.md with proper frontmatter, tasks, wave assignments
 - Plan checker verified output
 - GitHub issue integration worked
 - Full workflow completed in ~8 minutes
 
-**Executor test** (`/kata:kata-execute-phase 1`):
+**Executor test** (`/kata-execute-phase 1`):
 - Executor spawned as general-purpose with inlined instructions
 - 2/2 tasks completed, 3 commits with correct format
 - SUMMARY.md created with proper structure

--- a/.planning/phases/completed/34-cleanup/34-VERIFICATION.md
+++ b/.planning/phases/completed/34-cleanup/34-VERIFICATION.md
@@ -93,8 +93,8 @@ Skills are orchestrators that spawn general-purpose subagents with instructions 
 ```markdown
 | Skill                 | Invocation                  | Purpose                                        |
 | --------------------- | --------------------------- | ---------------------------------------------- |
-| `kata-plan-phase`     | `/kata:kata-plan-phase`     | Phase planning, task breakdown                 |
-| `kata-execute-phase`  | `/kata:kata-execute-phase`  | Plan execution, checkpoints                    |
+| `kata-plan-phase`     | `/kata-plan-phase`     | Phase planning, task breakdown                 |
+| `kata-execute-phase`  | `/kata-execute-phase`  | Plan execution, checkpoints                    |
 ...
 ```
 ✅ No "Sub-agents Spawned" column

--- a/.planning/research/SUBAGENT-MIGRATION.md
+++ b/.planning/research/SUBAGENT-MIGRATION.md
@@ -164,7 +164,7 @@ kata-orchestrator/
 ```yaml
 ---
 name: kata-planner
-description: Creates executable phase plans with task breakdown, dependency analysis, and goal-backward verification. Spawned by /kata:kata-plan-phase orchestrator.
+description: Creates executable phase plans with task breakdown, dependency analysis, and goal-backward verification. Spawned by /kata-plan-phase orchestrator.
 tools: Read, Write, Bash, Glob, Grep, WebFetch, mcp__context7__*
 model: inherit
 metadata:
@@ -290,7 +290,7 @@ The existing architecture already works. Migration is additive, not destructive.
 
 ### Manual Verification
 
-1. Run `/kata:kata-plan-phase` and verify agent spawns
+1. Run `/kata-plan-phase` and verify agent spawns
 2. Check agent appears in `/agents` command
 3. Verify agent description shown correctly
 4. Test model override from orchestrator

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Kata v1.6.0 ships **Skills-Native Subagents**: all 19 custom agent types migrate
 - **skills-sh build target**: `npm run build:skills-sh` produces cross-platform skill distribution
 - **CI dual-publish**: Release pipeline publishes to both marketplace and skills.sh registry
 - **Agent Skills spec compliance**: All 29 SKILL.md files normalized to Agent Skills spec with automated validation
-- **Phase migration skill**: `/kata:kata-migrate-phases` fixes duplicate phase numbering with collision detection
+- **Phase migration skill**: `/kata-migrate-phases` fixes duplicate phase numbering with collision detection
 - **Globally sequential phase numbering**: Phase numbers are unique across all milestones
 
 ### Changed
@@ -41,8 +41,8 @@ Kata v1.5.0 ships **Phase Management**: organized phase directories, cross-miles
 ### Added
 - **Phase state directories**: Phases organized under `pending/`, `active/`, `completed/` subdirectories
 - **Phase completion validation**: Validates PLAN.md and SUMMARY.md exist; non-gap phases require VERIFICATION.md
-- **Phase movement skill**: `/kata:kata-move-phase` moves phases between milestones with automatic renumbering
-- **Within-milestone reorder**: Reorder phases within a milestone via `/kata:kata-move-phase`
+- **Phase movement skill**: `/kata-move-phase` moves phases between milestones with automatic renumbering
+- **Within-milestone reorder**: Reorder phases within a milestone via `/kata-move-phase`
 - **Per-milestone phase numbering**: Each milestone starts numbering at 1 (independent, not cumulative)
 - **Planned milestones in roadmap**: ROADMAP.md displays future planned milestones with placeholder goals
 - **Roadmap format conventions**: Standardized formatting propagated to milestone completion, add-milestone, and roadmapper agents
@@ -67,12 +67,12 @@ Kata v1.4.1 completes the **issue lifecycle**: execution workflows, PR integrati
 - **Issue execution workflow**: "Work on it now" offers mode selection (quick task vs planned) with full PR lifecycle
 - **Quick task issue execution**: Creates plan, executes with commits, creates PR with `Closes #X` for source issue
 - **Planned execution routing**: Links issues to new or existing phases for structured execution
-- **Issue → milestone integration**: Pull backlog issues into milestone scope via `/kata:kata-add-milestone`
+- **Issue → milestone integration**: Pull backlog issues into milestone scope via `/kata-add-milestone`
 - **Issue → phase integration**: Pull issues into phases as tasks/plans with source issue traceability
 - **Source issue in plans**: `source_issue` frontmatter in PLAN.md files for traceability from issue to execution
 - **Plan-phase issue context**: plan-phase reads STATE.md issue sections and passes context to kata-planner
 - **Multi-issue PR closure**: Milestone completion PRs include `Closes #X` for all phase issues in the milestone
-- **Repo creation prompt**: When GitHub enabled but no remote, offer to create repository during `/kata:kata-new-project`
+- **Repo creation prompt**: When GitHub enabled but no remote, offer to create repository during `/kata-new-project`
 
 ### Changed
 - All skill names prefixed with `kata-` for consistent namespacing (`add-issue` → `kata-add-issue`)
@@ -90,8 +90,8 @@ Kata v1.4.1 completes the **issue lifecycle**: execution workflows, PR integrati
 Kata v1.4.0 ships **GitHub Issue Sync**: bidirectional GitHub Issue integration with automatic labeling, assignment, and lifecycle management.
 
 ### Added
-- **GitHub Issue creation**: Issues created via `/kata:kata-add-issue` automatically sync to GitHub with `backlog` label
-- **GitHub Issue pull**: `/kata:kata-check-issues` pulls existing GitHub Issues with `backlog` label for selection
+- **GitHub Issue creation**: Issues created via `/kata-add-issue` automatically sync to GitHub with `backlog` label
+- **GitHub Issue pull**: `/kata-check-issues` pulls existing GitHub Issues with `backlog` label for selection
 - **Execution linking**: Kata execution can reference and auto-close GitHub Issues on completion
 - **In-progress label sync**: When starting work, adds `in-progress` label and removes `backlog`
 - **Self-assignment**: When starting work on GitHub-linked issue, auto-assigns to `@me`
@@ -112,11 +112,11 @@ Kata v1.4.0 ships **GitHub Issue Sync**: bidirectional GitHub Issue integration 
 **Issue Model Foundation** — Kata now uses "issues" vocabulary consistently:
 - Renamed all references from "todos" to "issues" throughout skills and UI
 - Migrated storage from `.planning/todos/` to `.planning/issues/` with auto-archive
-- `/kata:kata-add-issue` and `/kata:kata-check-issues` replace todo equivalents
+- `/kata-add-issue` and `/kata-check-issues` replace todo equivalents
 
 **Skills-First Architecture** — Simplified invocation layer:
 - Removed commands wrapper layer (29 files deleted)
-- Skills are now directly user-invocable via `/kata:kata-skill-name`
+- Skills are now directly user-invocable via `/kata-skill-name`
 - Cleaner skill names: `help`, `add-issue`, `execute-phase` (not gerund style)
 
 ### Changed
@@ -178,7 +178,7 @@ Kata v1.3.3 ships **Internal Documentation**: workflow diagrams, terminology glo
 Kata v1.3.0 integrates release workflow into milestone completion: version detection, changelog generation, and GitHub Release creation.
 
 ### Added
-- **Release workflow in milestone completion**: `/kata:kata-completing-milestones` now offers release workflow before verification
+- **Release workflow in milestone completion**: `/kata-completing-milestones` now offers release workflow before verification
 - **Version detection reference**: `version-detector.md` with semantic version detection from conventional commits
 - **Changelog generation reference**: `changelog-generator.md` with Keep a Changelog format and commit-to-section mapping
 - **Dry-run mode**: Preview version bump and changelog without applying changes
@@ -239,12 +239,12 @@ Kata v1.1.0 ships **GitHub Integration**: config-driven GitHub Milestone, Issue,
 
 ### Added
 - **GitHub config namespace**: `.planning/config.json` now includes `github.enabled` and `github.issueMode` settings
-- **GitHub Milestone creation**: `/kata:kata-adding-milestones` creates GitHub Milestones via `gh api`
+- **GitHub Milestone creation**: `/kata-adding-milestones` creates GitHub Milestones via `gh api`
 - **Phase issue creation**: Phases become GitHub Issues with `phase` label, assigned to milestone
 - **Plan checklist sync**: Plans shown as checklist items in phase issues, checked as plans complete
-- **PR integration**: `/kata:kata-executing-phases` creates branches, draft PRs with "Closes #X" linking, marks ready on completion
-- **PR status display**: `/kata:kata-tracking-progress` shows PR status (Draft/Ready/Merged)
-- **PR review workflow**: `/kata:kata-review-pr` command with 6 specialized review agents
+- **PR integration**: `/kata-executing-phases` creates branches, draft PRs with "Closes #X" linking, marks ready on completion
+- **PR status display**: `/kata-tracking-progress` shows PR status (Draft/Ready/Merged)
+- **PR review workflow**: `/kata-review-pr` command with 6 specialized review agents
 - **Test harness**: 27 skill tests with affected-test detection and CI/CD integration
 
 ### Changed
@@ -372,7 +372,7 @@ Kata 1.0 ships with **Claude Code plugin support** as the recommended installati
 
 ### Changed
 - **Plugin install is now recommended**: Getting Started section leads with marketplace install, NPM moved to collapsible alternative
-- **Command namespace**: All commands now use `kata:` prefix (e.g., `/kata:kata-providing-help`, `/kata:kata-planning-phases`)
+- **Command namespace**: All commands now use `kata:` prefix (e.g., `/kata-providing-help`, `/kata-planning-phases`)
 - **Hook scripts converted to ES modules**: All hooks now use ESM syntax
 - **Staying Updated section**: Split into separate commands for plugin and NPM users
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 Kata is a **spec-driven development framework** for Claude Code. It's a meta-prompting and context engineering system that helps Claude build software systematically through structured workflows: requirements gathering → research → planning → execution → verification.
 
 **Core Architecture:**
-- **Skills** (`skills/kata-*/SKILL.md`) — Primary interface for all Kata workflows, invoked via `/kata:kata-skill-name`
+- **Skills** (`skills/kata-*/SKILL.md`) — Primary interface for all Kata workflows, invoked via `/kata-skill-name`
 - **Skill Resources** (`skills/kata-*/references/`) — Agent instructions inlined into subagent prompts at spawn time
 - **Templates** (`kata/templates/`) — Structured output formats (PROJECT.md, PLAN.md, etc.)
 - **References** (`kata/references/`) — Deep-dive documentation on concepts and patterns
@@ -29,7 +29,7 @@ cd /path/to/test-project
 claude --plugin-dir /path/to/kata/dist/plugin
 
 # Verify skills load
-/kata:kata-help
+/kata-help
 ```
 
 Alternative: manually copy to test project's plugin directory:
@@ -62,10 +62,10 @@ ls .planning/phases/pending/
 ```
 
 **Common workflow when working on Kata:**
-1. Check progress: "What's the status?" or `/kata:kata-track-progress`
-2. Plan phase: "Plan phase [N]" or `/kata:kata-plan-phase [N]`
-3. Execute: "Execute phase [N]" or `/kata:kata-execute-phase [N]`
-4. Verify: "Verify phase [N]" or `/kata:kata-verify-work [N]`
+1. Check progress: "What's the status?" or `/kata-track-progress`
+2. Plan phase: "Plan phase [N]" or `/kata-plan-phase [N]`
+3. Execute: "Execute phase [N]" or `/kata-execute-phase [N]`
+4. Verify: "Verify phase [N]" or `/kata-verify-work [N]`
 
 ## Architecture: Files Teach Claude
 
@@ -85,7 +85,7 @@ Skills are the primary interface for all Kata workflows. They respond to both na
 
 | Syntax                  | Example                   |
 | ----------------------- | ------------------------- |
-| `/kata:kata-skill-name` | `/kata:kata-plan-phase 1` |
+| `/kata-skill-name` | `/kata-plan-phase 1` |
 
 **Key points:**
 - **Natural language works:** "plan phase 2", "what's the status", "execute the phase"
@@ -94,17 +94,17 @@ Skills are the primary interface for all Kata workflows. They respond to both na
 
 ### Available Skills
 
-Skills are installed to `.claude/skills/` and invoked via `/kata:kata-skill-name`.
+Skills are installed to `.claude/skills/` and invoked via `/kata-skill-name`.
 
 | Skill                 | Invocation                  | Purpose                                        |
 | --------------------- | --------------------------- | ---------------------------------------------- |
-| `kata-plan-phase`     | `/kata:kata-plan-phase`     | Phase planning, task breakdown                 |
-| `kata-execute-phase`  | `/kata:kata-execute-phase`  | Plan execution, checkpoints                    |
-| `kata-verify-work`    | `/kata:kata-verify-work`    | Goal verification, UAT                         |
-| `kata-new-project`    | `/kata:kata-new-project`    | New project setup                              |
-| `kata-add-milestone`  | `/kata:kata-add-milestone`  | Add milestone, research, requirements, roadmap |
-| `kata-research-phase` | `/kata:kata-research-phase` | Domain research                                |
-| `kata-track-progress` | `/kata:kata-track-progress` | Progress, debug, mapping                       |
+| `kata-plan-phase`     | `/kata-plan-phase`     | Phase planning, task breakdown                 |
+| `kata-execute-phase`  | `/kata-execute-phase`  | Plan execution, checkpoints                    |
+| `kata-verify-work`    | `/kata-verify-work`    | Goal verification, UAT                         |
+| `kata-new-project`    | `/kata-new-project`    | New project setup                              |
+| `kata-add-milestone`  | `/kata-add-milestone`  | Add milestone, research, requirements, roadmap |
+| `kata-research-phase` | `/kata-research-phase` | Domain research                                |
+| `kata-track-progress` | `/kata-track-progress` | Progress, debug, mapping                       |
 
 ### Skill Naming Best Practices
 

--- a/KATA-STYLE.md
+++ b/KATA-STYLE.md
@@ -18,7 +18,7 @@ Kata is a **meta-prompting system** where every file is both implementation and 
 
 ### Skills (`skills/kata-*/SKILL.md`)
 
-Skills are the primary interface for all Kata workflows. Users invoke skills directly via `/kata:kata-skill-name`.
+Skills are the primary interface for all Kata workflows. Users invoke skills directly via `/kata-skill-name`.
 
 ```yaml
 ---
@@ -565,11 +565,11 @@ Kata includes an automatic codebase learning system that indexes code and detect
 
 ### Commands
 
-**`/kata:kata-map-codebase`** — Bulk scan for brownfield projects:
+**`/kata-map-codebase`** — Bulk scan for brownfield projects:
 - Creates .planning/intel/ directory
 - Scans all JS/TS files (excludes node_modules, dist, build, .git, vendor, coverage)
 - Uses same extraction logic as PostToolUse hook
-- Works standalone (no /kata:kata-new-project required)
+- Works standalone (no /kata-new-project required)
 
 ---
 
@@ -577,7 +577,7 @@ Kata includes an automatic codebase learning system that indexes code and detect
 
 1. **XML for semantic structure, Markdown for content**
 2. **@-references are lazy loading signals**
-3. **Skills are orchestrators** — invoke via `/kata:kata-skill-name`
+3. **Skills are orchestrators** — invoke via `/kata-skill-name`
 4. **Progressive disclosure hierarchy**
 5. **Imperative, brief, technical** — no filler, no sycophancy
 6. **Solo developer + Claude** — no enterprise patterns

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ npx skills add gannonh/kata-skills
 <summary><strong>v1.5.0: Phase Management</strong></summary>
 
 **Reorganize your roadmap without starting over:**
-- **Move phases** — `/kata:kata-move-phase 3 to v2.0` moves a phase between milestones
-- **Reorder phases** — `/kata:kata-move-phase 3 before 1` changes phase order within a milestone
+- **Move phases** — `/kata-move-phase 3 to v2.0` moves a phase between milestones
+- **Reorder phases** — `/kata-move-phase 3 before 1` changes phase order within a milestone
 - **Global phase numbering** — Phase numbers are globally sequential across milestones (they never reset)
 - **Phase state directories** — Phases organized into `pending/`, `active/`, `completed/`
 
@@ -79,7 +79,7 @@ npx skills add gannonh/kata-skills
 
 </details>
 
-**All features are optional.** Enable what you need via `/kata:kata-configure-settings`.
+**All features are optional.** Enable what you need via `/kata-configure-settings`.
 
 <p align="center">
 <img src="assets/project-config-flow.gif" alt="GitHub Integration Setup">
@@ -105,7 +105,7 @@ Drive your entire workflow with **natural language**.
 | "Reorder phase 3 before 1" | Reorder → Renumber all affected → Commit             |
 | "What's the status?"       | Progress report → Routes to next action              |
 
-Slash commands exist for precision (`/kata:kata-plan-phase 2`), but natural language always works.
+Slash commands exist for precision (`/kata-plan-phase 2`), but natural language always works.
 
 ---
 
@@ -124,7 +124,7 @@ Slash commands exist for precision (`/kata:kata-plan-phase 2`), but natural lang
 npx skills add gannonh/kata-skills
 ```
 
-Verify with `/kata:kata-help`.
+Verify with `/kata-help`.
 
 ### Update
 
@@ -132,7 +132,7 @@ Verify with `/kata:kata-help`.
 claude plugin update kata@gannonh-kata-marketplace
 ```
 
-Check what's new: `/kata:kata-whats-new`
+Check what's new: `/kata-whats-new`
 
 ### Recommended: Skip Permissions
 
@@ -353,7 +353,7 @@ For ad-hoc work that doesn't need full planning:
 Settings live in `.planning/config.json`. Configure during project init or update anytime:
 
 ```
-/kata:kata-configure-settings
+/kata-configure-settings
 ```
 
 ### Core Settings
@@ -373,7 +373,7 @@ Balance quality vs cost:
 | `balanced` | Opus     | Sonnet    | Sonnet       |
 | `budget`   | Sonnet   | Sonnet    | Haiku        |
 
-Switch: `/kata:kata-set-profile quality`
+Switch: `/kata-set-profile quality`
 
 ### Workflow Agents
 
@@ -385,11 +385,11 @@ Toggle agents that run during planning/execution:
 | `workflow.plan_check` | `true`  | Verify plans achieve phase goals     |
 | `workflow.verifier`   | `true`  | Confirm deliverables after execution |
 
-Override per-invocation: `/kata:kata-plan-phase --skip-research`
+Override per-invocation: `/kata-plan-phase --skip-research`
 
 ### GitHub Integration (Optional)
 
-**All GitHub features are off by default.** Enable via `/kata:kata-configure-settings`:
+**All GitHub features are off by default.** Enable via `/kata-configure-settings`:
 
 | Setting            | Options              | Default | What it enables                               |
 | ------------------ | -------------------- | ------- | --------------------------------------------- |

--- a/skills/kata-add-issue/SKILL.md
+++ b/skills/kata-add-issue/SKILL.md
@@ -22,7 +22,7 @@ Enables "thought -> capture -> continue" flow without losing context or derailin
 
 Display:
 
-> **Note:** "todos" are now "issues". Using `/kata:kata-add-issue`.
+> **Note:** "todos" are now "issues". Using `/kata-add-issue`.
 
 Then proceed with the action (non-blocking).
 </step>
@@ -69,7 +69,7 @@ Note existing areas for consistency in infer_area step.
 
 <step name="extract_content">
 **With arguments:** Use as the title/focus.
-- `/kata:kata-add-issue Add auth token refresh` -> title = "Add auth token refresh"
+- `/kata-add-issue Add auth token refresh` -> title = "Add auth token refresh"
 
 **Without arguments:** Analyze recent conversation to extract:
 - The specific problem, idea, or task discussed
@@ -182,7 +182,7 @@ GITHUB_ENABLED=$(cat .planning/config.json 2>/dev/null | grep -o '"enabled"[[:sp
    [solution section from local file]
 
    ---
-   *Created via Kata `/kata:kata-add-issue`*
+   *Created via Kata `/kata-add-issue`*
    ```
 
 4. **Create GitHub Issue:**
@@ -267,7 +267,7 @@ Would you like to:
 
 1. Continue with current work
 2. Add another issue
-3. View all issues (/kata:kata-check-issues)
+3. View all issues (/kata-check-issues)
 ```
 </step>
 

--- a/skills/kata-add-milestone/SKILL.md
+++ b/skills/kata-add-milestone/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: Read Write Bash Task AskUserQuestion
 <objective>
 Add a milestone to the project through unified flow: questioning → research (optional) → requirements → roadmap.
 
-This works for both first milestone (after /kata:kata-new-project) and subsequent milestones (after completing a milestone).
+This works for both first milestone (after /kata-new-project) and subsequent milestones (after completing a milestone).
 
 **Creates/Updates:**
 - `.planning/PROJECT.md` — updated with new milestone goals
@@ -17,7 +17,7 @@ This works for both first milestone (after /kata:kata-new-project) and subsequen
 - `.planning/ROADMAP.md` — phase structure (creates if first, continues if subsequent)
 - `.planning/STATE.md` — reset for new milestone (creates if first)
 
-**After this command:** Run `/kata:kata-plan-phase [N]` to start execution.
+**After this command:** Run `/kata-plan-phase [N]` to start execution.
 </objective>
 
 <execution_context>
@@ -571,7 +571,7 @@ Issues pulled into current milestone scope:
 - Selected issues become formally tracked as part of the milestone scope
 - They appear in STATE.md under "### Milestone Scope Issues" for the current milestone
 - They inform requirements generation in Phase 8 (planner should consider these issues when generating requirements)
-- They will be visible in progress tracking commands like /kata:kata-track-progress
+- They will be visible in progress tracking commands like /kata-track-progress
 - User still defines formal requirements through Phase 8, but selected issues provide explicit scope context
 
 **If BACKLOG_COUNT = 0:**
@@ -749,7 +749,7 @@ Use AskUserQuestion:
 
 **If "Migrate now":**
 
-Run the migration logic from `/kata:kata-migrate-phases` inline:
+Run the migration logic from `/kata-migrate-phases` inline:
 1. Build chronology from ROADMAP.md (completed milestone `<details>` blocks + current milestone phases)
 2. Map directories to globally sequential numbers
 3. Execute two-pass rename (tmp- prefix, then final)
@@ -761,7 +761,7 @@ Run the migration logic from `/kata:kata-migrate-phases` inline:
 Display:
 
 ```
-⚠ Skipping migration. Run `/kata:kata-migrate-phases` to fix collisions later.
+⚠ Skipping migration. Run `/kata-migrate-phases` to fix collisions later.
 ```
 
 Continue to Phase 9.
@@ -1082,7 +1082,7 @@ ${REQUIREMENT_IDS}")
 
 ## Plans
 
-<!-- Checklist added by /kata:kata-plan-phase (Phase 4) -->
+<!-- Checklist added by /kata-plan-phase (Phase 4) -->
 _Plans will be added after phase planning completes._
 
 ---
@@ -1140,14 +1140,14 @@ Present completion with next steps:
 
 **Phase [N]: [Phase Name]** — [Goal from ROADMAP.md]
 
-`/kata:kata-discuss-phase [N]` — gather context and clarify approach
+`/kata-discuss-phase [N]` — gather context and clarify approach
 
 <sub>`/clear` first → fresh context window</sub>
 
 ---
 
 **Also available:**
-- `/kata:kata-plan-phase [N]` — skip discussion, plan directly
+- `/kata-plan-phase [N]` — skip discussion, plan directly
 
 ───────────────────────────────────────────────────────────────
 
@@ -1167,7 +1167,7 @@ Present completion with next steps:
 - [ ] User feedback incorporated (if any)
 - [ ] ROADMAP.md created with globally sequential phase numbers (continuing from highest existing)
 - [ ] All commits made (if planning docs committed)
-- [ ] User knows next step is `/kata:kata-discuss-phase [N]`
+- [ ] User knows next step is `/kata-discuss-phase [N]`
 
 **Atomic commits:** Each phase commits its artifacts immediately. If context is lost, artifacts persist.
 </success_criteria>

--- a/skills/kata-add-milestone/references/github-mapping.md
+++ b/skills/kata-add-milestone/references/github-mapping.md
@@ -122,7 +122,7 @@ gh issue create \
 
 ## Plans
 
-<!-- Checklist added by /kata:kata-plan-phase (Phase 4) -->
+<!-- Checklist added by /kata-plan-phase (Phase 4) -->
 _Plans will be added after phase planning completes._
 
 ---

--- a/skills/kata-add-milestone/references/project-researcher-instructions.md
+++ b/skills/kata-add-milestone/references/project-researcher-instructions.md
@@ -4,8 +4,8 @@ You are a Kata project researcher. You research the domain ecosystem before road
 
 You are spawned by:
 
-- `/kata:kata-new-project` orchestrator (Phase 6: Research)
-- `/kata:kata-add-milestone` orchestrator (Phase 6: Research)
+- `/kata-new-project` orchestrator (Phase 6: Research)
+- `/kata-add-milestone` orchestrator (Phase 6: Research)
 
 Your job: Answer "What does this domain ecosystem look like?" Produce research files that inform roadmap creation.
 

--- a/skills/kata-add-milestone/references/project-template.md
+++ b/skills/kata-add-milestone/references/project-template.md
@@ -147,7 +147,7 @@ PROJECT.md evolves throughout the project lifecycle.
 
 For existing codebases:
 
-1. **Map codebase first** via `/kata:kata-map-codebase`
+1. **Map codebase first** via `/kata-map-codebase`
 
 2. **Infer Validated requirements** from existing code:
    - What does the codebase actually do?

--- a/skills/kata-add-milestone/references/research-synthesizer-instructions.md
+++ b/skills/kata-add-milestone/references/research-synthesizer-instructions.md
@@ -4,7 +4,7 @@ You are a Kata research synthesizer. You read the outputs from 4 parallel resear
 
 You are spawned by:
 
-- `/kata:kata-new-project` orchestrator (after STACK, FEATURES, ARCHITECTURE, PITFALLS research completes)
+- `/kata-new-project` orchestrator (after STACK, FEATURES, ARCHITECTURE, PITFALLS research completes)
 
 Your job: Create a unified research summary that informs roadmap creation. Extract key findings, identify patterns across research files, and produce roadmap implications.
 
@@ -100,7 +100,7 @@ This is the most important section. Based on combined research:
 - Which pitfalls it must avoid
 
 **Add research flags:**
-- Which phases likely need `/kata:kata-research-phase` during planning?
+- Which phases likely need `/kata-research-phase` during planning?
 - Which phases have well-documented patterns (skip research)?
 
 ## Step 5: Assess Confidence

--- a/skills/kata-add-milestone/references/roadmapper-instructions.md
+++ b/skills/kata-add-milestone/references/roadmapper-instructions.md
@@ -4,7 +4,7 @@ You are a Kata roadmapper. You create project roadmaps that map requirements to 
 
 You are spawned by:
 
-- `/kata:kata-new-project` orchestrator (unified project initialization)
+- `/kata-new-project` orchestrator (unified project initialization)
 
 Your job: Transform requirements into a phase structure that delivers the project. Every v1 requirement maps to exactly one phase. Every phase has observable success criteria.
 
@@ -18,7 +18,7 @@ Your job: Transform requirements into a phase structure that delivers the projec
 </role>
 
 <downstream_consumer>
-Your ROADMAP.md is consumed by `/kata:kata-plan-phase` which uses it to:
+Your ROADMAP.md is consumed by `/kata-plan-phase` which uses it to:
 
 | Output               | How phase-plan Uses It           |
 | -------------------- | -------------------------------- |
@@ -176,7 +176,7 @@ Track coverage as you go.
 **Integer phases (1, 2, 3):** Planned milestone work.
 
 **Decimal phases (2.1, 2.2):** Urgent insertions after planning.
-- Created via `/kata:kata-insert-phase`
+- Created via `/kata-insert-phase`
 - Execute between integers: 1 → 1.1 → 1.2 → 2
 
 **Starting number:** Continue from the highest existing phase number + 1 (globally sequential across milestones). The orchestrator provides the starting number as NEXT_PHASE.
@@ -510,7 +510,7 @@ After incorporating user feedback and updating files:
 
 ### Ready for Planning
 
-Next: `/kata:kata-plan-phase 1`
+Next: `/kata-plan-phase 1`
 ```
 
 ## Roadmap Blocked

--- a/skills/kata-add-milestone/references/ui-brand.md
+++ b/skills/kata-add-milestone/references/ui-brand.md
@@ -113,8 +113,8 @@ Always at end of major completions.
 ───────────────────────────────────────────────────────────────
 
 **Also available:**
-- `/kata:kata-alternative-1` — description
-- `/kata:kata-alternative-2` — description
+- `/kata-alternative-1` — description
+- `/kata-alternative-2` — description
 
 ───────────────────────────────────────────────────────────────
 ```

--- a/skills/kata-add-phase/SKILL.md
+++ b/skills/kata-add-phase/SKILL.md
@@ -12,7 +12,7 @@ This command appends sequential phases to the current milestone's phase list, au
 
 Purpose: Add planned work discovered during execution that belongs at the end of current milestone.
 
-IMPORTANT: When showing examples to users, always use `/kata:kata-add-phase` (the command), not the skill name.
+IMPORTANT: When showing examples to users, always use `/kata-add-phase` (the command), not the skill name.
 </objective>
 
 <execution_context>
@@ -26,7 +26,7 @@ IMPORTANT: When showing examples to users, always use `/kata:kata-add-phase` (th
 Parse the command arguments:
 
 **With `--issue` flag:**
-- `/kata:kata-add-phase --issue .planning/issues/open/2026-02-06-phase-lookup.md`
+- `/kata-add-phase --issue .planning/issues/open/2026-02-06-phase-lookup.md`
 - Read the issue file to extract title, provenance, and context
 - `description` = issue title from frontmatter
 - `ISSUE_FILE` = the path argument
@@ -51,16 +51,16 @@ fi
 
 **Without `--issue` flag:**
 - All arguments become the phase description
-- Example: `/kata:kata-add-phase Add authentication` → description = "Add authentication"
+- Example: `/kata-add-phase Add authentication` → description = "Add authentication"
 - `ISSUE_FILE`, `ISSUE_PROVENANCE`, `ISSUE_NUMBER` are empty
 
 If no arguments provided:
 
 ```
 ERROR: Phase description required
-Usage: /kata:kata-add-phase <description>
-       /kata:kata-add-phase --issue <issue-file-path>
-Example: /kata:kata-add-phase Add authentication system
+Usage: /kata-add-phase <description>
+       /kata-add-phase --issue <issue-file-path>
+Example: /kata-add-phase Add authentication system
 ```
 
 Exit.
@@ -155,7 +155,7 @@ Add the new phase entry to the roadmap:
    **Plans:** 0 plans
 
    Plans:
-   - [ ] TBD (run /kata:kata-plan-phase {N} to break down)
+   - [ ] TBD (run /kata-plan-phase {N} to break down)
 
    **Details:**
    [To be added during planning]
@@ -201,14 +201,14 @@ Project state updated: .planning/STATE.md
 
 **Phase {N}: {description}**
 
-`/kata:kata-plan-phase {N}`
+`/kata-plan-phase {N}`
 
 <sub>`/clear` first → fresh context window</sub>
 
 ---
 
 **Also available:**
-- `/kata:kata-add-phase <description>` — add another phase
+- `/kata-add-phase <description>` — add another phase
 - Review roadmap
 
 ---
@@ -221,8 +221,8 @@ Project state updated: .planning/STATE.md
 
 - Don't modify phases outside current milestone
 - Don't renumber existing phases
-- Don't use decimal numbering (that's /kata:kata-insert-phase)
-- Don't create plans yet (that's /kata:kata-plan-phase)
+- Don't use decimal numbering (that's /kata-insert-phase)
+- Don't create plans yet (that's /kata-plan-phase)
 - Don't commit changes (user decides when to commit)
   </anti_patterns>
 

--- a/skills/kata-audit-milestone/SKILL.md
+++ b/skills/kata-audit-milestone/SKILL.md
@@ -195,7 +195,7 @@ All requirements covered. Cross-phase integration verified. E2E flows complete.
 
 **Complete milestone** — archive and tag
 
-/kata:kata-complete-milestone {version}
+/kata-complete-milestone {version}
 
 <sub>/clear first → fresh context window</sub>
 
@@ -232,7 +232,7 @@ All requirements covered. Cross-phase integration verified. E2E flows complete.
 
 **Plan gap closure** — create phases to complete milestone
 
-/kata:kata-plan-milestone-gaps
+/kata-plan-milestone-gaps
 
 <sub>/clear first → fresh context window</sub>
 
@@ -240,7 +240,7 @@ All requirements covered. Cross-phase integration verified. E2E flows complete.
 
 **Also available:**
 - cat .planning/v{version}-MILESTONE-AUDIT.md — see full report
-- /kata:kata-complete-milestone {version} — proceed anyway (accept tech debt)
+- /kata-complete-milestone {version} — proceed anyway (accept tech debt)
 
 ───────────────────────────────────────────────────────────────
 
@@ -270,11 +270,11 @@ All requirements met. No critical blockers. Accumulated tech debt needs review.
 
 **A. Complete milestone** — accept debt, track in backlog
 
-/kata:kata-complete-milestone {version}
+/kata-complete-milestone {version}
 
 **B. Plan cleanup phase** — address debt before completing
 
-/kata:kata-plan-milestone-gaps
+/kata-plan-milestone-gaps
 
 <sub>/clear first → fresh context window</sub>
 

--- a/skills/kata-check-issues/SKILL.md
+++ b/skills/kata-check-issues/SKILL.md
@@ -23,7 +23,7 @@ Enables reviewing captured ideas and deciding what to work on next.
 
 Display:
 
-> **Note:** "todos" is now "issues". Using `/kata:kata-check-issues`.
+> **Note:** "todos" is now "issues". Using `/kata-check-issues`.
 
 Then proceed with the action (non-blocking).
 </step>
@@ -69,14 +69,14 @@ If both counts are 0:
 ```
 No open or in-progress issues.
 
-Issues are captured during work sessions with /kata:kata-add-issue.
+Issues are captured during work sessions with /kata-add-issue.
 
 ---
 
 Would you like to:
 
-1. Continue with current phase (/kata:kata-track-progress)
-2. Add an issue now (/kata:kata-add-issue)
+1. Continue with current phase (/kata-track-progress)
+2. Add an issue now (/kata-add-issue)
 ```
 
 Exit.
@@ -84,8 +84,8 @@ Exit.
 
 <step name="parse_filter">
 Check for area filter in arguments:
-- `/kata:kata-check-issues` → show all
-- `/kata:kata-check-issues api` → filter to area:api only
+- `/kata-check-issues` → show all
+- `/kata-check-issues api` → filter to area:api only
 </step>
 
 <step name="list_issues">
@@ -155,7 +155,7 @@ Issues:
 ---
 
 Reply with a number to view details, or:
-- `/kata:kata-check-issues [area]` to filter by area
+- `/kata-check-issues [area]` to filter by area
 - `q` to exit
 ```
 
@@ -265,7 +265,7 @@ Use AskUserQuestion:
 - question: "What would you like to do with this issue?"
 - options:
   - "Work on it now" — move to in-progress, start working (shows mode selection)
-  - "Create a phase" — /kata:kata-add-phase with this scope
+  - "Create a phase" — /kata-add-phase with this scope
   - "Brainstorm approach" — think through before deciding
   - "Put it back" — return to list
 
@@ -358,7 +358,7 @@ Starting quick task execution for issue: [title]
 
 3. Route to execute-quick-task with issue context:
 ```
-/kata:kata-execute-quick-task --issue "$ISSUE_FILE"
+/kata-execute-quick-task --issue "$ISSUE_FILE"
 ```
 
 The execute-quick-task skill will handle planning, execution, and PR creation.
@@ -401,7 +401,7 @@ When the phase PR merges, the issue will close automatically.
 
 **Create Phase:** ${ISSUE_TITLE}
 
-`/kata:kata-add-phase --issue ${ISSUE_FILE}`
+`/kata-add-phase --issue ${ISSUE_FILE}`
 
 <sub>`/clear` first → fresh context window</sub>
 
@@ -409,7 +409,7 @@ When the phase PR merges, the issue will close automatically.
 
 Note: Issue remains in open/ until phase work begins.
 When phase planning starts, move issue to in-progress manually
-or use /kata:kata-check-issues to update status.
+or use /kata-check-issues to update status.
 ```
 
 3. Keep issue in open/ (do NOT move to in-progress yet).
@@ -564,8 +564,8 @@ Issue remains in open/ until phase work begins.
 No upcoming phases found.
 
 Options:
-- /kata:kata-add-phase --issue ${ISSUE_FILE} — Create a new phase
-- /kata:kata-track-progress — View current roadmap status
+- /kata-add-phase --issue ${ISSUE_FILE} — Create a new phase
+- /kata-track-progress — View current roadmap status
 - Put it back — Return to issue list
 ```
 
@@ -621,7 +621,7 @@ Issue moved to in-progress: [filename]
 
 Ready to begin work.
 
-When complete, use `/kata:kata-check-issues` and select "Mark complete".
+When complete, use `/kata-check-issues` and select "Mark complete".
 ```
 
 Update STATE.md issue count. Present problem/solution context. Begin work or ask how to proceed.
@@ -657,7 +657,7 @@ Starting quick task execution for issue: [title]
 
 4. Route to execute-quick-task with issue context:
 ```
-/kata:kata-execute-quick-task --issue "$ISSUE_FILE"
+/kata-execute-quick-task --issue "$ISSUE_FILE"
 ```
 
 **If "Planned" mode selected:**
@@ -696,7 +696,7 @@ When the phase PR merges, the issue will close automatically.
 
 **Create Phase:** ${ISSUE_TITLE}
 
-`/kata:kata-add-phase --issue ${ISSUE_FILE}`
+`/kata-add-phase --issue ${ISSUE_FILE}`
 
 <sub>`/clear` first → fresh context window</sub>
 
@@ -704,7 +704,7 @@ When the phase PR merges, the issue will close automatically.
 
 Note: Issue remains in open/ until phase work begins.
 When phase planning starts, move issue to in-progress manually
-or use /kata:kata-check-issues to update status.
+or use /kata-check-issues to update status.
 ```
 
 3. Keep issue in open/ (do NOT move to in-progress yet).
@@ -834,8 +834,8 @@ Issue remains in open/ until phase work begins.
 No upcoming phases found.
 
 Options:
-- /kata:kata-add-phase --issue ${ISSUE_FILE} — Create a new phase
-- /kata:kata-track-progress — View current roadmap status
+- /kata-add-phase --issue ${ISSUE_FILE} — Create a new phase
+- /kata-track-progress — View current roadmap status
 - Put it back — Return to issue list
 ```
 
@@ -883,7 +883,7 @@ Issue moved to in-progress: [filename]
 
 Ready to begin work.
 
-When complete, use `/kata:kata-check-issues` and select "Mark complete".
+When complete, use `/kata-check-issues` and select "Mark complete".
 ```
 
 Update STATE.md issue count. Present problem/solution context. Begin work or ask how to proceed.
@@ -949,7 +949,7 @@ Opens issue in browser. Return to list.
 Note issue reference in phase planning notes. Keep in open. Return to list or exit.
 
 **Create a phase:**
-Display: `/kata:kata-add-phase --issue [issue file path]`
+Display: `/kata-add-phase --issue [issue file path]`
 Keep in open. User runs command in fresh context.
 
 **Brainstorm approach:**
@@ -1042,14 +1042,14 @@ Confirm: "Committed: docs: return issue to backlog - [title]"
 - Moved issue to `.planning/issues/open/` (if "Put back to open")
 - Created `.planning/issues/open/` file (if "Pull to local" from GitHub)
 - Updated `.planning/STATE.md` (if issue count changed)
-- Routed to `/kata:kata-execute-quick-task` (if "Quick task" mode selected)
+- Routed to `/kata-execute-quick-task` (if "Quick task" mode selected)
 - Displayed planned execution guidance (if "Planned" mode selected)
 </output>
 
 <anti_patterns>
 - Don't delete issues — use proper state transitions
 - Don't close GitHub Issues when starting work — only when marking complete
-- Don't create plans from this command — route to /kata:kata-plan-phase or /kata:kata-add-phase
+- Don't create plans from this command — route to /kata-plan-phase or /kata-add-phase
 </anti_patterns>
 
 <issue_lifecycle>
@@ -1064,13 +1064,13 @@ closed/      → Completed
 ```
 
 **State transitions:**
-- **Work on it now (Quick task):** `open/` → `in-progress/` → routes to `/kata:kata-execute-quick-task`
+- **Work on it now (Quick task):** `open/` → `in-progress/` → routes to `/kata-execute-quick-task`
 - **Work on it now (Planned):** stays in `open/` with guidance for phase planning
 - **Mark complete:** `in-progress/` → `closed/` (closes GitHub Issue if linked)
 - **Put back to open:** `in-progress/` → `open/` (useful if deprioritized)
 
 **GitHub Issue lifecycle:**
-- Created when: `/kata:kata-add-issue` with `github.enabled=true`
+- Created when: `/kata-add-issue` with `github.enabled=true`
 - Linked via: `provenance: github:owner/repo#N` in local file
 - Closed when: User selects "Mark complete" on an in-progress issue
 - Alternative: GitHub auto-closes via "Closes #N" in PR description when PR merges
@@ -1089,7 +1089,7 @@ The provenance field is the linchpin - it enables deduplication and bidirectiona
 - [ ] Roadmap context checked for phase match
 - [ ] Appropriate actions offered based on issue state
 - [ ] "Work on it now" presents mode selection (Quick task vs Planned) via AskUserQuestion
-- [ ] "Quick task" mode moves to in-progress and routes to `/kata:kata-execute-quick-task --issue`
+- [ ] "Quick task" mode moves to in-progress and routes to `/kata-execute-quick-task --issue`
 - [ ] "Planned" mode displays guidance message and returns gracefully
 - [ ] "Work on it now" adds in-progress label to GitHub Issue (if linked, Quick task mode)
 - [ ] "Work on it now" assigns GitHub Issue to @me (if linked, Quick task mode)

--- a/skills/kata-complete-milestone/SKILL.md
+++ b/skills/kata-complete-milestone/SKILL.md
@@ -125,19 +125,19 @@ Output: Milestone archived (roadmap + requirements), PROJECT.md evolved, git tag
 1. **Check for audit:**
 
    - Look for `.planning/v{{version}}-MILESTONE-AUDIT.md`
-   - If missing or stale: recommend `/kata:kata-audit-milestone` first
-   - If audit status is `gaps_found`: recommend `/kata:kata-plan-milestone-gaps` first
+   - If missing or stale: recommend `/kata-audit-milestone` first
+   - If audit status is `gaps_found`: recommend `/kata-plan-milestone-gaps` first
    - If audit status is `passed`: proceed to step 1
 
    ```markdown
    ## Pre-flight Check
 
    {If no v{{version}}-MILESTONE-AUDIT.md:}
-   ⚠ No milestone audit found. Run `/kata:kata-audit-milestone` first to verify
+   ⚠ No milestone audit found. Run `/kata-audit-milestone` first to verify
    requirements coverage, cross-phase integration, and E2E flows.
 
    {If audit has gaps:}
-   ⚠ Milestone audit found gaps. Run `/kata:kata-plan-milestone-gaps` to create
+   ⚠ Milestone audit found gaps. Run `/kata-plan-milestone-gaps` to create
    phases that close the gaps, or proceed anyway to accept as tech debt.
 
    {If audit passed:}
@@ -335,7 +335,7 @@ Output: Milestone archived (roadmap + requirements), PROJECT.md evolved, git tag
    **If "Yes" or "Skip":** Continue to step 9.
 
 3. **Offer next steps:**
-   - `/kata:kata-add-milestone` — start next milestone (questioning → research → requirements → roadmap)
+   - `/kata-add-milestone` — start next milestone (questioning → research → requirements → roadmap)
 
 </process>
 
@@ -365,5 +365,5 @@ Output: Milestone archived (roadmap + requirements), PROJECT.md evolved, git tag
 - **Archive before deleting:** Always create archive files before updating/deleting originals
 - **One-line summary:** Collapsed milestone in ROADMAP.md should be single line with link
 - **Context efficiency:** Archive keeps ROADMAP.md and REQUIREMENTS.md constant size per milestone
-- **Fresh requirements:** Next milestone starts with `/kata:kata-add-milestone` which includes requirements definition
+- **Fresh requirements:** Next milestone starts with `/kata-add-milestone` which includes requirements definition
   </critical_rules>

--- a/skills/kata-complete-milestone/references/milestone-complete.md
+++ b/skills/kata-complete-milestone/references/milestone-complete.md
@@ -749,7 +749,7 @@ Extract completed milestone details and create archive file.
 
 **CRITICAL:** Do NOT proceed to the next step until the archive file exists.
 
-**Important:** The next milestone workflow starts with `/kata:kata-add-milestone` which includes requirements definition. PROJECT.md's Validated section carries the cumulative record across milestones.
+**Important:** The next milestone workflow starts with `/kata-add-milestone` which includes requirements definition. PROJECT.md's Validated section carries the cumulative record across milestones.
 
 </step>
 
@@ -1022,7 +1022,7 @@ Tag: v[X.Y]
 
 **Start Next Milestone** — questioning → research → requirements → roadmap
 
-`/kata:kata-add-milestone`
+`/kata-add-milestone`
 
 <sub>`/clear` first → fresh context window</sub>
 
@@ -1084,7 +1084,7 @@ Milestone completion is successful when:
 - [ ] STATE.md updated with fresh project reference
 - [ ] Git tag created (v[X.Y])
 - [ ] Milestone commit made (includes archive files and deletion)
-- [ ] User knows next step (/kata:kata-add-milestone)
+- [ ] User knows next step (/kata-add-milestone)
 
 </success_criteria>
 

--- a/skills/kata-configure-settings/SKILL.md
+++ b/skills/kata-configure-settings/SKILL.md
@@ -21,7 +21,7 @@ Updates `.planning/config.json` with workflow preferences and model profile sele
 ls .planning/config.json 2>/dev/null
 ```
 
-**If not found:** Error - run `/kata:kata-new-project` first.
+**If not found:** Error - run `/kata-new-project` first.
 
 ## 2. Read Current Config and Detect Missing Keys
 
@@ -239,13 +239,13 @@ Display:
 | Plan Checker       | {On/Off}                  |
 | Execution Verifier | {On/Off}                  |
 
-These settings apply to future /kata:kata-plan-phase and /kata:kata-execute-phase runs.
+These settings apply to future /kata-plan-phase and /kata-execute-phase runs.
 
 Quick commands:
-- /kata:kata-set-profile <profile> — switch model profile
-- /kata:kata-plan-phase --research — force research
-- /kata:kata-plan-phase --skip-research — skip research
-- /kata:kata-plan-phase --skip-verify — skip plan check
+- /kata-set-profile <profile> — switch model profile
+- /kata-plan-phase --research — force research
+- /kata-plan-phase --skip-research — skip research
+- /kata-plan-phase --skip-verify — skip plan check
 
 **If PR Workflow was just enabled (changed from Off to On), append:**
 

--- a/skills/kata-debug/SKILL.md
+++ b/skills/kata-debug/SKILL.md
@@ -112,7 +112,7 @@ Task(
 - Display root cause and evidence summary
 - Offer options:
   - "Fix now" - spawn fix subagent
-  - "Plan fix" - suggest /kata:kata-plan-phase --gaps
+  - "Plan fix" - suggest /kata-plan-phase --gaps
   - "Manual fix" - done
 
 **If `## CHECKPOINT REACHED`:**

--- a/skills/kata-debug/references/debugger-instructions.md
+++ b/skills/kata-debug/references/debugger-instructions.md
@@ -3,7 +3,7 @@ You are a Kata debugger. You investigate bugs using systematic scientific method
 
 You are spawned by:
 
-- `/kata:kata-debug` command (interactive debugging)
+- `/kata-debug` command (interactive debugging)
 - `diagnose-issues` workflow (parallel UAT diagnosis)
 
 Your job: Find the root cause through hypothesis testing, maintain debug file state, optionally fix and verify (depending on mode).
@@ -887,7 +887,7 @@ Gather symptoms through questioning. Update file after EACH answer.
   - Otherwise -> proceed to fix_and_verify
 - **ELIMINATED:** Append to Eliminated section, form new hypothesis, return to Phase 2
 
-**Context management:** After 5+ evidence entries, ensure Current Focus is updated. Suggest "/clear - run /kata:kata-debug to resume" if context filling up.
+**Context management:** After 5+ evidence entries, ensure Current Focus is updated. Suggest "/clear - run /kata-debug to resume" if context filling up.
 </step>
 
 <step name="resume_from_file">

--- a/skills/kata-discuss-phase/references/phase-discuss.md
+++ b/skills/kata-discuss-phase/references/phase-discuss.md
@@ -119,7 +119,7 @@ Load and validate:
 ```
 Phase [X] not found in roadmap.
 
-Use /kata:kata-track-progress to see available phases.
+Use /kata-track-progress to see available phases.
 ```
 Exit workflow.
 
@@ -388,14 +388,14 @@ Created: .planning/phases/${PADDED_PHASE}-${SLUG}/${PADDED_PHASE}-CONTEXT.md
 
 **Phase ${PHASE}: [Name]** — [Goal from ROADMAP.md]
 
-`/kata:kata-plan-phase ${PHASE}`
+`/kata-plan-phase ${PHASE}`
 
 <sub>`/clear` first → fresh context window</sub>
 
 ---
 
 **Also available:**
-- `/kata:kata-plan-phase ${PHASE} --skip-research` — plan without research
+- `/kata-plan-phase ${PHASE} --skip-research` — plan without research
 - Review/edit CONTEXT.md before continuing
 
 ---

--- a/skills/kata-execute-phase/SKILL.md
+++ b/skills/kata-execute-phase/SKILL.md
@@ -355,7 +355,7 @@ PR_EOF
    - Route by status:
      - `passed` → continue to step 8
      - `human_needed` → present items, get approval or feedback
-     - `gaps_found` → present gaps, offer `/kata:kata-plan-phase {X} --gaps`
+     - `gaps_found` → present gaps, offer `/kata-plan-phase {X} --gaps`
 
 7.5. **Validate completion and move to completed**
 
@@ -523,7 +523,7 @@ PR_EOF
     2. Return to step 10.6 checkpoint
 
     **Path D: "Add to backlog"**
-    1. Create issues for all findings using `/kata:kata-add-issue`
+    1. Create issues for all findings using `/kata-add-issue`
     2. Store TODOS_CREATED count
     3. Return to step 10.6 checkpoint
 
@@ -574,15 +574,15 @@ Goal verified ✓
 
 **Phase {Z+1}: {Name}** — {Goal from ROADMAP.md}
 
-`/kata:kata-discuss-phase {Z+1}` — gather context and clarify approach
+`/kata-discuss-phase {Z+1}` — gather context and clarify approach
 
 <sub>`/clear` first → fresh context window</sub>
 
 ───────────────────────────────────────────────────────────────
 
 **Also available:**
-- `/kata:kata-plan-phase {Z+1}` — skip discussion, plan directly
-- `/kata:kata-verify-work {Z}` — manual acceptance testing before continuing
+- `/kata-plan-phase {Z+1}` — skip discussion, plan directly
+- `/kata-verify-work {Z}` — manual acceptance testing before continuing
 {If PR_WORKFLOW and not MERGED: - `gh pr view --web` — review PR in browser before next phase}
 
 ───────────────────────────────────────────────────────────────
@@ -608,15 +608,15 @@ All phase goals verified ✓
 
 **Audit milestone** — verify requirements, cross-phase integration, E2E flows
 
-/kata:kata-audit-milestone
+/kata-audit-milestone
 
 <sub>/clear first → fresh context window</sub>
 
 ───────────────────────────────────────────────────────────────
 
 **Also available:**
-- /kata:kata-verify-work — manual acceptance testing
-- /kata:kata-complete-milestone — skip audit, archive directly
+- /kata-verify-work — manual acceptance testing
+- /kata-complete-milestone — skip audit, archive directly
 
 ───────────────────────────────────────────────────────────────
 
@@ -643,7 +643,7 @@ Report: .planning/phases/{phase_dir}/{phase}-VERIFICATION.md
 
 **Plan gap closure** — create additional plans to complete the phase
 
-/kata:kata-plan-phase {Z} --gaps
+/kata-plan-phase {Z} --gaps
 
 <sub>/clear first → fresh context window</sub>
 
@@ -651,16 +651,16 @@ Report: .planning/phases/{phase_dir}/{phase}-VERIFICATION.md
 
 **Also available:**
 - cat .planning/phases/{phase_dir}/{phase}-VERIFICATION.md — see full report
-- /kata:kata-verify-work {Z} — manual testing before planning
+- /kata-verify-work {Z} — manual testing before planning
 
 ───────────────────────────────────────────────────────────────
 
 ---
 
-After user runs /kata:kata-plan-phase {Z} --gaps:
+After user runs /kata-plan-phase {Z} --gaps:
 1. Planner reads VERIFICATION.md gaps
 2. Creates plans 04, 05, etc. to close gaps
-3. User runs /kata:kata-execute-phase {Z} again
+3. User runs /kata-execute-phase {Z} again
 4. phase-execute runs incomplete plans (04, 05...)
 5. Verifier runs again → loop until passed
 </offer_next>

--- a/skills/kata-execute-phase/references/execute-plan.md
+++ b/skills/kata-execute-phase/references/execute-plan.md
@@ -1751,14 +1751,14 @@ Summary: .planning/phases/{phase-dir}/{phase}-{plan}-SUMMARY.md
 
 **{phase}-{next-plan}: [Plan Name]** — [objective from next PLAN.md]
 
-`/kata:kata-execute-phase {phase}`
+`/kata-execute-phase {phase}`
 
 <sub>`/clear` first → fresh context window</sub>
 
 ---
 
 **Also available:**
-- `/kata:kata-verify-work {phase}-{plan}` — manual acceptance testing before continuing
+- `/kata-verify-work {phase}-{plan}` — manual acceptance testing before continuing
 - Review what was built before continuing
 
 ---
@@ -1812,15 +1812,15 @@ All {Y} plans finished.
 
 **Phase {Z+1}: {Next Phase Name}** — {Goal from ROADMAP.md}
 
-`/kata:kata-plan-phase {Z+1}`
+`/kata-plan-phase {Z+1}`
 
 <sub>`/clear` first → fresh context window</sub>
 
 ---
 
 **Also available:**
-- `/kata:kata-verify-work {Z}` — manual acceptance testing before continuing
-- `/kata:kata-discuss-phase {Z+1}` — gather context first
+- `/kata-verify-work {Z}` — manual acceptance testing before continuing
+- `/kata-discuss-phase {Z+1}` — gather context first
 - Review phase accomplishments before continuing
 
 ---
@@ -1850,15 +1850,15 @@ All {Y} plans finished.
 
 **Complete Milestone** — archive and prepare for next
 
-`/kata:kata-complete-milestone`
+`/kata-complete-milestone`
 
 <sub>`/clear` first → fresh context window</sub>
 
 ---
 
 **Also available:**
-- `/kata:kata-verify-work` — manual acceptance testing before completing milestone
-- `/kata:kata-add-phase <description>` — add another phase before completing
+- `/kata-verify-work` — manual acceptance testing before completing milestone
+- `/kata-add-phase <description>` — add another phase before completing
 - Review accomplishments before archiving
 
 ---

--- a/skills/kata-execute-phase/references/executor-instructions.md
+++ b/skills/kata-execute-phase/references/executor-instructions.md
@@ -2,7 +2,7 @@
 <role>
 You are a Kata plan executor. You execute PLAN.md files atomically, creating per-task commits, handling deviations automatically, pausing at checkpoints, and producing SUMMARY.md files.
 
-You are spawned by `/kata:kata-execute-phase` orchestrator.
+You are spawned by `/kata-execute-phase` orchestrator.
 
 Your job: Execute the plan completely, commit each task, create SUMMARY.md, update STATE.md.
 </role>

--- a/skills/kata-execute-phase/references/github-integration.md
+++ b/skills/kata-execute-phase/references/github-integration.md
@@ -161,7 +161,7 @@ ${REQUIREMENT_IDS}
 
 ## Plans
 
-<!-- Checklist added by /kata:kata-plan-phase (Phase 4) -->
+<!-- Checklist added by /kata-plan-phase (Phase 4) -->
 _Plans will be added after phase planning completes._
 ```
 
@@ -331,8 +331,8 @@ GitHub Status:
 Issues created immediately when phase planning completes. No prompts.
 
 **Timeline:**
-1. `/kata:kata-plan-phase 1` → Phase 1 planned → Issue #1 created
-2. `/kata:kata-plan-phase 2` → Phase 2 planned → Issue #2 created
+1. `/kata-plan-phase 1` → Phase 1 planned → Issue #1 created
+2. `/kata-plan-phase 2` → Phase 2 planned → Issue #2 created
 3. ...
 
 **Use when:** Team wants full GitHub visibility, no manual intervention.
@@ -342,11 +342,11 @@ Issues created immediately when phase planning completes. No prompts.
 Prompts once per milestone. Decision cached in STATE.md.
 
 **Timeline:**
-1. `/kata:kata-plan-phase 1` → "Create Issues for v1.1.0?" → User: "y"
+1. `/kata-plan-phase 1` → "Create Issues for v1.1.0?" → User: "y"
 2. Phase 1 planned → Issue #1 created (decision cached)
-3. `/kata:kata-plan-phase 2` → Phase 2 planned → Issue #2 created (no prompt, uses cache)
+3. `/kata-plan-phase 2` → Phase 2 planned → Issue #2 created (no prompt, uses cache)
 4. New milestone v1.2.0 starts...
-5. `/kata:kata-plan-phase 1` → "Create Issues for v1.2.0?" → User: "n"
+5. `/kata-plan-phase 1` → "Create Issues for v1.2.0?" → User: "n"
 6. Phase 1 planned → No issue created
 
 **Cache location:** STATE.md under `### GitHub Decisions`
@@ -367,8 +367,8 @@ Prompts once per milestone. Decision cached in STATE.md.
 No phase Issues created. Milestones still created if `github.enabled: true`.
 
 **Timeline:**
-1. `/kata:kata-add-milestone v1.1.0` → GitHub Milestone created
-2. `/kata:kata-plan-phase 1` → Phase 1 planned → No issue
+1. `/kata-add-milestone v1.1.0` → GitHub Milestone created
+2. `/kata-plan-phase 1` → Phase 1 planned → No issue
 3. ...
 
 **Use when:** Team wants milestone-level tracking only, or manages Issues manually.

--- a/skills/kata-execute-phase/references/phase-execute.md
+++ b/skills/kata-execute-phase/references/phase-execute.md
@@ -93,7 +93,7 @@ MATCH_COUNT=$((MATCH_COUNT + $(find .planning/phases -maxdepth 1 -type d -name "
 
 if [ "$MATCH_COUNT" -gt 1 ]; then
   echo "COLLISION: ${MATCH_COUNT} directories match prefix '${PADDED}-*'"
-  echo "Run /kata:kata-migrate-phases to fix duplicate phase numbering before executing."
+  echo "Run /kata-migrate-phases to fix duplicate phase numbering before executing."
   exit 1
 fi
 
@@ -174,7 +174,7 @@ waves = {
 }
 ```
 
-**No dependency analysis needed.** Wave numbers are pre-computed during `/kata:kata-plan-phase`.
+**No dependency analysis needed.** Wave numbers are pre-computed during `/kata-plan-phase`.
 
 Report wave structure with context:
 ```
@@ -482,7 +482,7 @@ grep "^status:" "$PHASE_DIR"/*-VERIFICATION.md | cut -d: -f2 | tr -d ' '
 | -------------- | ------------------------------------------------------------ |
 | `passed`       | Continue to update_roadmap                                   |
 | `human_needed` | Present items to user, get approval or feedback              |
-| `gaps_found`   | Present gap summary, offer `/kata:kata-plan-phase {phase} --gaps` |
+| `gaps_found`   | Present gap summary, offer `/kata-plan-phase {phase} --gaps` |
 
 **If passed:**
 
@@ -559,7 +559,7 @@ Present gaps and offer next command:
 
 **Plan gap closure** — create additional plans to complete the phase
 
-`/kata:kata-plan-phase {X} --gaps`
+`/kata-plan-phase {X} --gaps`
 
 <sub>`/clear` first → fresh context window</sub>
 
@@ -567,13 +567,13 @@ Present gaps and offer next command:
 
 **Also available:**
 - `cat {phase_dir}/{phase}-VERIFICATION.md` — see full report
-- `/kata:kata-verify-work {X}` — manual testing before planning
+- `/kata-verify-work {X}` — manual testing before planning
 ```
 
-User runs `/kata:kata-plan-phase {X} --gaps` which:
+User runs `/kata-plan-phase {X} --gaps` which:
 1. Reads VERIFICATION.md gaps
 2. Creates additional plans (04, 05, etc.) with `gap_closure: true` to close gaps
-3. User then runs `/kata:kata-execute-phase {X} --gaps-only`
+3. User then runs `/kata-execute-phase {X} --gaps-only`
 4. phase-execute runs only gap closure plans (04-05)
 5. Verifier runs again after new plans complete
 
@@ -617,7 +617,7 @@ Present next steps based on milestone status:
 
 **Phase {X+1}: {Name}** — {Goal}
 
-`/kata:kata-plan-phase {X+1}`
+`/kata-plan-phase {X+1}`
 
 <sub>`/clear` first for fresh context</sub>
 ```
@@ -628,7 +628,7 @@ MILESTONE COMPLETE!
 
 All {N} phases executed.
 
-`/kata:kata-complete-milestone`
+`/kata-complete-milestone`
 ```
 </step>
 
@@ -683,7 +683,7 @@ Each subagent: Fresh 200k context
 
 If phase execution was interrupted (context limit, user exit, error):
 
-1. Run `/kata:kata-execute-phase {phase}` again
+1. Run `/kata-execute-phase {phase}` again
 2. discover_plans finds completed SUMMARYs
 3. Skips completed plans
 4. Resumes from first incomplete plan

--- a/skills/kata-execute-phase/references/planning-config.md
+++ b/skills/kata-execute-phase/references/planning-config.md
@@ -142,7 +142,7 @@ PR_WORKFLOW=$(cat .planning/config.json 2>/dev/null | grep -o '"pr_workflow"[[:s
 
 **Branch timing:**
 - Phase branches: Create after planning, before execution
-- Release branch: Create when starting `/kata:kata-complete-milestone`
+- Release branch: Create when starting `/kata-complete-milestone`
 
 ### PR Granularity & Lifecycle
 
@@ -176,7 +176,7 @@ PR_WORKFLOW=$(cat .planning/config.json 2>/dev/null | grep -o '"pr_workflow"[[:s
 
 #### Release PR Lifecycle
 
-1. **Create branch** — When starting `/kata:kata-complete-milestone`
+1. **Create branch** — When starting `/kata-complete-milestone`
 2. **Make release commits** — Version bump, CHANGELOG, milestone archive
 3. **Open PR** — Ready for review (not draft)
 4. **Merge** — Triggers GitHub Action → creates tag → publishes
@@ -214,14 +214,14 @@ After merge, GitHub Action will:
 
 **Release flow:**
 1. All phase PRs merged to main (code complete)
-2. `/kata:kata-complete-milestone` creates release branch
+2. `/kata-complete-milestone` creates release branch
 3. Version bump, changelog, archive committed to release branch
 4. Release PR merged to main
 5. GitHub Action detects version change → creates tag → publishes
 
 **Release trigger:** Merge of release PR to main. The `publish.yml` workflow detects version changes in package.json and triggers the release.
 
-**Version bump timing:** Version bump happens ON the release branch, as part of `/kata:kata-complete-milestone`.
+**Version bump timing:** Version bump happens ON the release branch, as part of `/kata-complete-milestone`.
 
 ### Workflow Timing
 
@@ -418,7 +418,7 @@ To use uncommitted mode (keep planning private):
 
 <updating_settings>
 
-Run `/kata:kata-configure-settings` to update config preferences interactively.
+Run `/kata-configure-settings` to update config preferences interactively.
 
 The settings skill will:
 1. Detect any missing config keys from schema evolution

--- a/skills/kata-execute-phase/references/ui-brand.md
+++ b/skills/kata-execute-phase/references/ui-brand.md
@@ -113,8 +113,8 @@ Always at end of major completions.
 ───────────────────────────────────────────────────────────────
 
 **Also available:**
-- `/kata:kata-alternative-1` — description
-- `/kata:kata-alternative-2` — description
+- `/kata-alternative-1` — description
+- `/kata-alternative-2` — description
 
 ───────────────────────────────────────────────────────────────
 ```

--- a/skills/kata-execute-phase/references/verifier-instructions.md
+++ b/skills/kata-execute-phase/references/verifier-instructions.md
@@ -479,7 +479,7 @@ score = (verified_truths / total_truths)
 
 ## Step 10: Structure Gap Output (If Gaps Found)
 
-When gaps are found, structure them for consumption by `/kata:kata-plan-phase --gaps`.
+When gaps are found, structure them for consumption by `/kata-plan-phase --gaps`.
 
 **Output structured gaps in YAML frontmatter:**
 
@@ -520,7 +520,7 @@ gaps:
 - `artifacts`: Which files have issues and what's wrong
 - `missing`: Specific things that need to be added/fixed
 
-The planner (`/kata:kata-plan-phase --gaps`) reads this gap analysis and creates appropriate plans.
+The planner (`/kata-plan-phase --gaps`) reads this gap analysis and creates appropriate plans.
 
 **Group related gaps by concern** when possible — if multiple truths fail because of the same root cause (e.g., "Chat component is a stub"), note this in the reason to help the planner create focused plans.
 
@@ -641,7 +641,7 @@ All must-haves verified. Phase goal achieved. Ready to proceed.
 2. **{Truth 2}** — {reason}
    - Missing: {what needs to be added}
 
-Structured gaps in VERIFICATION.md frontmatter for `/kata:kata-plan-phase --gaps`.
+Structured gaps in VERIFICATION.md frontmatter for `/kata-plan-phase --gaps`.
 
 {If human_needed:}
 
@@ -667,7 +667,7 @@ Automated checks passed. Awaiting human verification.
 
 **DO NOT skip key link verification.** This is where 80% of stubs hide. The pieces exist but aren't connected.
 
-**Structure gaps in YAML frontmatter.** The planner (`/kata:kata-plan-phase --gaps`) creates plans from your analysis.
+**Structure gaps in YAML frontmatter.** The planner (`/kata-plan-phase --gaps`) creates plans from your analysis.
 
 **DO flag for human verification when uncertain.** If you can't verify programmatically (visual, real-time, external service), say so explicitly.
 

--- a/skills/kata-execute-phase/scripts/find-phase.sh
+++ b/skills/kata-execute-phase/scripts/find-phase.sh
@@ -38,7 +38,7 @@ MATCH_COUNT=$((MATCH_COUNT + $(find .planning/phases -maxdepth 1 -type d -name "
 
 if [ "$MATCH_COUNT" -gt 1 ]; then
   echo "COLLISION: ${MATCH_COUNT} directories match prefix '${PADDED}-*'"
-  echo "Run /kata:kata-migrate-phases to fix duplicate phase numbering before executing."
+  echo "Run /kata-migrate-phases to fix duplicate phase numbering before executing."
   exit 3
 fi
 

--- a/skills/kata-execute-quick-task/SKILL.md
+++ b/skills/kata-execute-quick-task/SKILL.md
@@ -54,7 +54,7 @@ Check that an active Kata project exists:
 ```bash
 if [ ! -f .planning/ROADMAP.md ]; then
   echo "Quick mode requires an active project with ROADMAP.md."
-  echo "Run /kata:kata-new-project first."
+  echo "Run /kata-new-project first."
   exit 1
 fi
 ```
@@ -411,7 +411,7 @@ Commit: ${commit_hash}
 
 ---
 
-Ready for next task: /kata:kata-execute-quick-task
+Ready for next task: /kata-execute-quick-task
 ```
 
 </process>

--- a/skills/kata-help/SKILL.md
+++ b/skills/kata-help/SKILL.md
@@ -36,16 +36,16 @@ Then output the reference content below, inserting the version at the top. Do NO
 
 ## Quick Start
 
-1. `/kata:kata-new-project` - Initialize project (includes research, requirements, roadmap)
-2. `/kata:kata-plan-phase 1` - Create detailed plan for first phase
-3. `/kata:kata-execute-phase 1` - Execute the phase
+1. `/kata-new-project` - Initialize project (includes research, requirements, roadmap)
+2. `/kata-plan-phase 1` - Create detailed plan for first phase
+3. `/kata-execute-phase 1` - Execute the phase
 
 ## Staying Updated
 
 Kata evolves fast. Check for updates periodically:
 
 ```
-/kata:kata-whats-new
+/kata-whats-new
 ```
 
 Shows what changed since your installed version and how to update.
@@ -53,12 +53,12 @@ Shows what changed since your installed version and how to update.
 ## Core Workflow
 
 ```
-/kata:kata-new-project → /kata:kata-plan-phase → /kata:kata-execute-phase → repeat
+/kata-new-project → /kata-plan-phase → /kata-execute-phase → repeat
 ```
 
 ### Project Initialization
 
-**`/kata:kata-new-project`**
+**`/kata-new-project`**
 Initialize new project through unified flow.
 
 One skill takes you from idea to ready-for-planning:
@@ -75,30 +75,30 @@ Creates all `.planning/` artifacts:
 - `ROADMAP.md` — phases mapped to requirements
 - `STATE.md` — project memory
 
-Usage: `/kata:kata-new-project`
+Usage: `/kata-new-project`
 
-**`/kata:kata-map-codebase`**
+**`/kata-map-codebase`**
 Map an existing codebase for brownfield projects.
 
 - Analyzes codebase with parallel Explore agents
 - Creates `.planning/codebase/` with 7 focused documents
 - Covers stack, architecture, structure, conventions, testing, integrations, concerns
-- Use before `/kata:kata-new-project` on existing codebases
+- Use before `/kata-new-project` on existing codebases
 
-Usage: `/kata:kata-map-codebase`
+Usage: `/kata-map-codebase`
 
 ### Phase Planning
 
-**`/kata:kata-discuss-phase <number>`**
+**`/kata-discuss-phase <number>`**
 Help articulate your vision for a phase before planning.
 
 - Captures how you imagine this phase working
 - Creates CONTEXT.md with your vision, essentials, and boundaries
 - Use when you have ideas about how something should look/feel
 
-Usage: `/kata:kata-discuss-phase 2`
+Usage: `/kata-discuss-phase 2`
 
-**`/kata:kata-research-phase <number>`**
+**`/kata-research-phase <number>`**
 Comprehensive ecosystem research for niche/complex domains.
 
 - Discovers standard stack, architecture patterns, pitfalls
@@ -106,18 +106,18 @@ Comprehensive ecosystem research for niche/complex domains.
 - Use for 3D, games, audio, shaders, ML, and other specialized domains
 - Goes beyond "which library" to ecosystem knowledge
 
-Usage: `/kata:kata-research-phase 3`
+Usage: `/kata-research-phase 3`
 
-**`/kata:kata-listing-phase-assumptions <number>`**
+**`/kata-listing-phase-assumptions <number>`**
 See what Claude is planning to do before it starts.
 
 - Shows Claude's intended approach for a phase
 - Lets you course-correct if Claude misunderstood your vision
 - No files created - conversational output only
 
-Usage: `/kata:kata-listing-phase-assumptions 3`
+Usage: `/kata-listing-phase-assumptions 3`
 
-**`/kata:kata-plan-phase <number>`**
+**`/kata-plan-phase <number>`**
 Create detailed execution plan for a specific phase.
 
 - Generates `.planning/phases/XX-phase-name/XX-YY-PLAN.md`
@@ -125,12 +125,12 @@ Create detailed execution plan for a specific phase.
 - Includes verification criteria and success measures
 - Multiple plans per phase supported (XX-01, XX-02, etc.)
 
-Usage: `/kata:kata-plan-phase 1`
+Usage: `/kata-plan-phase 1`
 Result: Creates `.planning/phases/01-foundation/01-01-PLAN.md`
 
 ### Execution
 
-**`/kata:kata-execute-phase <phase-number>`**
+**`/kata-execute-phase <phase-number>`**
 Execute all plans in a phase.
 
 - Groups plans by wave (from frontmatter), executes waves sequentially
@@ -138,11 +138,11 @@ Execute all plans in a phase.
 - Verifies phase goal after all plans complete
 - Updates REQUIREMENTS.md, ROADMAP.md, STATE.md
 
-Usage: `/kata:kata-execute-phase 5`
+Usage: `/kata-execute-phase 5`
 
 ### Quick Mode
 
-**`/kata:kata-execute-quick-task`**
+**`/kata-execute-quick-task`**
 Execute small, ad-hoc tasks with Kata guarantees but skip optional agents.
 
 Quick mode uses the same system with a shorter path:
@@ -152,31 +152,31 @@ Quick mode uses the same system with a shorter path:
 
 Use when you know exactly what to do and the task is small enough to not need research or verification.
 
-Usage: `/kata:kata-execute-quick-task`
+Usage: `/kata-execute-quick-task`
 Result: Creates `.planning/quick/NNN-slug/PLAN.md`, `.planning/quick/NNN-slug/SUMMARY.md`
 
 ### Roadmap Management
 
-**`/kata:kata-add-phase <description>`**
+**`/kata-add-phase <description>`**
 Add new phase to end of current milestone.
 
 - Appends to ROADMAP.md
 - Uses next sequential number
 - Updates phase directory structure
 
-Usage: `/kata:kata-add-phase "Add admin dashboard"`
+Usage: `/kata-add-phase "Add admin dashboard"`
 
-**`/kata:kata-insert-phase <after> <description>`**
+**`/kata-insert-phase <after> <description>`**
 Insert urgent work as decimal phase between existing phases.
 
 - Creates intermediate phase (e.g., 7.1 between 7 and 8)
 - Useful for discovered work that must happen mid-milestone
 - Maintains phase ordering
 
-Usage: `/kata:kata-insert-phase 7 "Fix critical auth bug"`
+Usage: `/kata-insert-phase 7 "Fix critical auth bug"`
 Result: Creates Phase 7.1
 
-**`/kata:kata-remove-phase <number>`**
+**`/kata-remove-phase <number>`**
 Remove a future phase and renumber subsequent phases.
 
 - Deletes phase directory and all references
@@ -184,22 +184,22 @@ Remove a future phase and renumber subsequent phases.
 - Only works on future (unstarted) phases
 - Git commit preserves historical record
 
-Usage: `/kata:kata-remove-phase 17`
+Usage: `/kata-remove-phase 17`
 Result: Phase 17 deleted, phases 18-20 become 17-19
 
-**`/kata:kata-move-phase <phase> <operation>`**
+**`/kata-move-phase <phase> <operation>`**
 Move a phase between milestones or reorder within a milestone.
 
 - Cross-milestone: moves phase to target milestone, renumbers both
 - Reorder: changes phase position within milestone, renumbers all
 - Only pending phases can be moved
 
-Usage: `/kata:kata-move-phase 3 to v1.6.0` (cross-milestone)
-Usage: `/kata:kata-move-phase 3 before 1` (reorder within milestone)
+Usage: `/kata-move-phase 3 to v1.6.0` (cross-milestone)
+Usage: `/kata-move-phase 3 before 1` (reorder within milestone)
 
 ### Milestone Management
 
-**`/kata:kata-add-milestone <name>`**
+**`/kata-add-milestone <name>`**
 Start a new milestone through unified flow.
 
 - Deep questioning to understand what you're building next
@@ -207,11 +207,11 @@ Start a new milestone through unified flow.
 - Requirements definition with scoping
 - Roadmap creation with phase breakdown
 
-Mirrors `/kata:kata-new-project` flow for brownfield projects (existing PROJECT.md).
+Mirrors `/kata-new-project` flow for brownfield projects (existing PROJECT.md).
 
-Usage: `/kata:kata-add-milestone "v2.0 Features"`
+Usage: `/kata-add-milestone "v2.0 Features"`
 
-**`/kata:kata-complete-milestone <version>`**
+**`/kata-complete-milestone <version>`**
 Archive completed milestone and prepare for next version.
 
 - Creates MILESTONES.md entry with stats
@@ -219,11 +219,11 @@ Archive completed milestone and prepare for next version.
 - Creates git tag for the release
 - Prepares workspace for next version
 
-Usage: `/kata:kata-complete-milestone 1.0.0`
+Usage: `/kata-complete-milestone 1.0.0`
 
 ### Progress Tracking
 
-**`/kata:kata-track-progress`**
+**`/kata-track-progress`**
 Check project status and intelligently route to next action.
 
 - Shows visual progress bar and completion percentage
@@ -233,45 +233,45 @@ Check project status and intelligently route to next action.
 - Offers to execute next plan or create it if missing
 - Detects 100% milestone completion
 
-Usage: `/kata:kata-track-progress`
+Usage: `/kata-track-progress`
 
 ### Session Management
 
-**`/kata:kata-resume-work`**
+**`/kata-resume-work`**
 Resume work from previous session with full context restoration.
 
 - Reads STATE.md for project context
 - Shows current position and recent progress
 - Offers next actions based on project state
 
-Usage: `/kata:kata-resume-work`
+Usage: `/kata-resume-work`
 
-**`/kata:kata-pause-work`**
+**`/kata-pause-work`**
 Create context handoff when pausing work mid-phase.
 
 - Creates .continue-here file with current state
 - Updates STATE.md session continuity section
 - Captures in-progress work context
 
-Usage: `/kata:kata-pause-work`
+Usage: `/kata-pause-work`
 
 ### Debugging
 
-**`/kata:kata-debug [issue description]`**
+**`/kata-debug [issue description]`**
 Systematic debugging with persistent state across context resets.
 
 - Gathers symptoms through adaptive questioning
 - Creates `.planning/debug/[slug].md` to track investigation
 - Investigates using scientific method (evidence → hypothesis → test)
-- Survives `/clear` — run `/kata:kata-debug` with no args to resume
+- Survives `/clear` — run `/kata-debug` with no args to resume
 - Archives resolved issues to `.planning/debug/resolved/`
 
-Usage: `/kata:kata-debug "login button doesn't work"`
-Usage: `/kata:kata-debug` (resume active session)
+Usage: `/kata-debug "login button doesn't work"`
+Usage: `/kata-debug` (resume active session)
 
 ### Issue Management
 
-**`/kata:kata-add-issue [description]`**
+**`/kata-add-issue [description]`**
 Capture idea or task as issue from current conversation.
 
 - Extracts context from conversation (or uses provided description)
@@ -280,24 +280,24 @@ Capture idea or task as issue from current conversation.
 - Checks for duplicates before creating
 - Updates STATE.md issue count
 
-Usage: `/kata:kata-add-issue` (infers from conversation)
-Usage: `/kata:kata-add-issue Add auth token refresh`
+Usage: `/kata-add-issue` (infers from conversation)
+Usage: `/kata-add-issue Add auth token refresh`
 
-**`/kata:kata-check-issues [area]`**
+**`/kata-check-issues [area]`**
 List pending issues and select one to work on.
 
 - Lists all pending issues with title, area, age
-- Optional area filter (e.g., `/kata:kata-check-issues api`)
+- Optional area filter (e.g., `/kata-check-issues api`)
 - Loads full context for selected issue
 - Routes to appropriate action (work now, add to phase, brainstorm)
 - Moves issue to done/ when work begins
 
-Usage: `/kata:kata-check-issues`
-Usage: `/kata:kata-check-issues api`
+Usage: `/kata-check-issues`
+Usage: `/kata-check-issues api`
 
 ### User Acceptance Testing
 
-**`/kata:kata-verify-work [phase]`**
+**`/kata-verify-work [phase]`**
 Validate built features through conversational UAT.
 
 - Extracts testable deliverables from SUMMARY.md files
@@ -305,11 +305,11 @@ Validate built features through conversational UAT.
 - Automatically diagnoses failures and creates fix plans
 - Ready for re-execution if issues found
 
-Usage: `/kata:kata-verify-work 3`
+Usage: `/kata-verify-work 3`
 
 ### Milestone Auditing
 
-**`/kata:kata-audit-milestone [version]`**
+**`/kata-audit-milestone [version]`**
 Audit milestone completion against original intent.
 
 - Reads all phase VERIFICATION.md files
@@ -317,44 +317,44 @@ Audit milestone completion against original intent.
 - Spawns integration checker for cross-phase wiring
 - Creates MILESTONE-AUDIT.md with gaps and tech debt
 
-Usage: `/kata:kata-audit-milestone`
+Usage: `/kata-audit-milestone`
 
-**`/kata:kata-plan-milestone-gaps`**
+**`/kata-plan-milestone-gaps`**
 Create phases to close gaps identified by audit.
 
 - Reads MILESTONE-AUDIT.md and groups gaps into phases
 - Prioritizes by requirement priority (must/should/nice)
 - Adds gap closure phases to ROADMAP.md
-- Ready for `/kata:kata-plan-phase` on new phases
+- Ready for `/kata-plan-phase` on new phases
 
-Usage: `/kata:kata-plan-milestone-gaps`
+Usage: `/kata-plan-milestone-gaps`
 
 ### Configuration
 
-**`/kata:kata-configure-settings`**
+**`/kata-configure-settings`**
 Configure workflow toggles and model profile interactively.
 
 - Toggle researcher, plan checker, verifier agents
 - Select model profile (quality/balanced/budget)
 - Updates `.planning/config.json`
 
-Usage: `/kata:kata-configure-settings`
+Usage: `/kata-configure-settings`
 
-**`/kata:kata-set-profile <profile>`**
+**`/kata-set-profile <profile>`**
 Quick switch model profile for Kata agents.
 
 - `quality` — Opus everywhere except verification
 - `balanced` — Opus for planning, Sonnet for execution (default)
 - `budget` — Sonnet for writing, Haiku for research/verification
 
-Usage: `/kata:kata-set-profile budget`
+Usage: `/kata-set-profile budget`
 
 ### Utility Skills
 
-**`/kata:kata-help`**
+**`/kata-help`**
 Show this skill reference.
 
-**`/kata:kata-whats-new`**
+**`/kata-whats-new`**
 See what's changed since your installed version.
 
 - Shows installed vs latest version comparison
@@ -362,7 +362,7 @@ See what's changed since your installed version.
 - Highlights breaking changes
 - Provides update instructions when behind
 
-Usage: `/kata:kata-whats-new`
+Usage: `/kata-whats-new`
 
 ## Files & Structure
 
@@ -396,7 +396,7 @@ Usage: `/kata:kata-whats-new`
 
 ## Workflow Modes
 
-Set during `/kata:kata-new-project`:
+Set during `/kata-new-project`:
 
 **Interactive Mode**
 
@@ -444,51 +444,51 @@ Example config:
 **Starting a new project:**
 
 ```
-/kata:kata-new-project        # Unified flow: questioning → research → requirements → roadmap
+/kata-new-project        # Unified flow: questioning → research → requirements → roadmap
 /clear
-/kata:kata-plan-phase 1       # Create plans for first phase
+/kata-plan-phase 1       # Create plans for first phase
 /clear
-/kata:kata-execute-phase 1    # Execute all plans in phase
+/kata-execute-phase 1    # Execute all plans in phase
 ```
 
 **Resuming work after a break:**
 
 ```
-/kata:kata-track-progress  # See where you left off and continue
+/kata-track-progress  # See where you left off and continue
 ```
 
 **Adding urgent mid-milestone work:**
 
 ```
-/kata:kata-insert-phase 5 "Critical security fix"
-/kata:kata-plan-phase 5.1
-/kata:kata-execute-phase 5.1
+/kata-insert-phase 5 "Critical security fix"
+/kata-plan-phase 5.1
+/kata-execute-phase 5.1
 ```
 
 **Completing a milestone:**
 
 ```
-/kata:kata-complete-milestone 1.0.0
+/kata-complete-milestone 1.0.0
 /clear
-/kata:kata-add-milestone  # Start next milestone (questioning → research → requirements → roadmap)
+/kata-add-milestone  # Start next milestone (questioning → research → requirements → roadmap)
 ```
 
 **Capturing ideas during work:**
 
 ```
-/kata:kata-add-issue                    # Capture from conversation context
-/kata:kata-add-issue Fix modal z-index  # Capture with explicit description
-/kata:kata-check-issues                 # Review and work on issues
-/kata:kata-check-issues api             # Filter by area
+/kata-add-issue                    # Capture from conversation context
+/kata-add-issue Fix modal z-index  # Capture with explicit description
+/kata-check-issues                 # Review and work on issues
+/kata-check-issues api             # Filter by area
 ```
 
 **Debugging an issue:**
 
 ```
-/kata:kata-debug "form submission fails silently"  # Start debug session
+/kata-debug "form submission fails silently"  # Start debug session
 # ... investigation happens, context fills up ...
 /clear
-/kata:kata-debug                                    # Resume from where you left off
+/kata-debug                                    # Resume from where you left off
 ```
 
 ## Getting Help
@@ -496,5 +496,5 @@ Example config:
 - Read `.planning/PROJECT.md` for project vision
 - Read `.planning/STATE.md` for current context
 - Check `.planning/ROADMAP.md` for phase status
-- Run `/kata:kata-track-progress` to check where you're up to
+- Run `/kata-track-progress` to check where you're up to
   </reference>

--- a/skills/kata-inserting-phases/SKILL.md
+++ b/skills/kata-inserting-phases/SKILL.md
@@ -25,7 +25,7 @@ Parse the command arguments:
 - First argument: integer phase number to insert after
 - Remaining arguments: phase description
 
-Example: `/kata:kata-insert-phase 72 Fix critical auth bug`
+Example: `/kata-insert-phase 72 Fix critical auth bug`
 → after = 72
 → description = "Fix critical auth bug"
 
@@ -34,8 +34,8 @@ Validation:
 ```bash
 if [ $# -lt 2 ]; then
   echo "ERROR: Both phase number and description required"
-  echo "Usage: /kata:kata-insert-phase <after> <description>"
-  echo "Example: /kata:kata-insert-phase 72 Fix critical auth bug"
+  echo "Usage: /kata-insert-phase <after> <description>"
+  echo "Example: /kata-insert-phase 72 Fix critical auth bug"
   exit 1
 fi
 ```
@@ -140,7 +140,7 @@ Insert the new phase entry into the roadmap:
    **Plans:** 0 plans
 
    Plans:
-   - [ ] TBD (run /kata:kata-plan-phase {decimal_phase} to break down)
+   - [ ] TBD (run /kata-plan-phase {decimal_phase} to break down)
 
    **Details:**
    [To be added during planning]
@@ -186,7 +186,7 @@ Project state updated: .planning/STATE.md
 
 **Phase {decimal_phase}: {description}** — urgent insertion
 
-`/kata:kata-plan-phase {decimal_phase}`
+`/kata-plan-phase {decimal_phase}`
 
 <sub>`/clear` first → fresh context window</sub>
 
@@ -204,11 +204,11 @@ Project state updated: .planning/STATE.md
 
 <anti_patterns>
 
-- Don't use this for planned work at end of milestone (use /kata:kata-add-phase)
+- Don't use this for planned work at end of milestone (use /kata-add-phase)
 - Don't insert before Phase 1 (decimal 0.1 makes no sense)
 - Don't renumber existing phases
 - Don't modify the target phase content
-- Don't create plans yet (that's /kata:kata-plan-phase)
+- Don't create plans yet (that's /kata-plan-phase)
 - Don't commit changes (user decides when to commit)
   </anti_patterns>
 

--- a/skills/kata-list-phase-assumptions/references/phase-assumptions.md
+++ b/skills/kata-list-phase-assumptions/references/phase-assumptions.md
@@ -14,8 +14,8 @@ Phase number: $ARGUMENTS (required)
 ```
 Error: Phase number required.
 
-Usage: /kata:kata-listing-phase-assumptions [phase-number]
-Example: /kata:kata-listing-phase-assumptions 3
+Usage: /kata-listing-phase-assumptions [phase-number]
+Example: /kata-listing-phase-assumptions 3
 ```
 
 Exit workflow.
@@ -153,8 +153,8 @@ Present next steps:
 
 ```
 What's next?
-1. Discuss context (/kata:kata-discuss-phase ${PHASE}) - Let me ask you questions to build comprehensive context
-2. Plan this phase (/kata:kata-plan-phase ${PHASE}) - Create detailed execution plans
+1. Discuss context (/kata-discuss-phase ${PHASE}) - Let me ask you questions to build comprehensive context
+2. Plan this phase (/kata-plan-phase ${PHASE}) - Create detailed execution plans
 3. Re-examine assumptions - I'll analyze again with your corrections
 4. Done for now
 ```

--- a/skills/kata-map-codebase/SKILL.md
+++ b/skills/kata-map-codebase/SKILL.md
@@ -24,8 +24,8 @@ Focus area: $ARGUMENTS (optional - if provided, tells agents to focus on specifi
 Check for .planning/STATE.md - loads context if project already initialized
 
 **This command can run:**
-- Before /kata:kata-new-project (brownfield codebases) - creates codebase map first
-- After /kata:kata-new-project (greenfield codebases) - updates codebase map as code evolves
+- Before /kata-new-project (brownfield codebases) - creates codebase map first
+- After /kata-new-project (greenfield codebases) - updates codebase map as code evolves
 - Anytime to refresh codebase understanding
 </context>
 
@@ -53,7 +53,7 @@ Check for .planning/STATE.md - loads context if project already initialized
 4. Wait for agents to complete, collect confirmations (NOT document contents)
 5. Verify all 7 documents exist with line counts
 6. Commit codebase map
-7. Offer next steps (typically: /kata:kata-new-project or /kata:kata-plan-phase)
+7. Offer next steps (typically: /kata-new-project or /kata-plan-phase)
 </process>
 
 <success_criteria>

--- a/skills/kata-map-codebase/references/codebase-mapper-instructions.md
+++ b/skills/kata-map-codebase/references/codebase-mapper-instructions.md
@@ -1,7 +1,7 @@
 <role>
 You are a Kata codebase mapper. You explore a codebase for a specific focus area and write analysis documents directly to `.planning/codebase/`.
 
-You are spawned by `/kata:kata-map-codebase` with one of four focus areas:
+You are spawned by `/kata-map-codebase` with one of four focus areas:
 - **tech**: Analyze technology stack and external integrations → write STACK.md and INTEGRATIONS.md
 - **arch**: Analyze architecture and file structure → write ARCHITECTURE.md and STRUCTURE.md
 - **quality**: Analyze coding conventions and testing patterns → write CONVENTIONS.md and TESTING.md
@@ -13,7 +13,7 @@ Your job: Explore thoroughly, then write document(s) directly. Return confirmati
 <why_this_matters>
 **These documents are consumed by other Kata commands:**
 
-**`/kata:kata-plan-phase`** loads relevant codebase docs when creating implementation plans:
+**`/kata-plan-phase`** loads relevant codebase docs when creating implementation plans:
 | Phase Type                | Documents Loaded                |
 | ------------------------- | ------------------------------- |
 | UI, frontend, components  | CONVENTIONS.md, STRUCTURE.md    |
@@ -24,7 +24,7 @@ Your job: Explore thoroughly, then write document(s) directly. Return confirmati
 | refactor, cleanup         | CONCERNS.md, ARCHITECTURE.md    |
 | setup, config             | STACK.md, STRUCTURE.md          |
 
-**`/kata:kata-execute-phase`** references codebase docs to:
+**`/kata-execute-phase`** references codebase docs to:
 - Follow existing conventions when writing code
 - Know where to place new files (STRUCTURE.md)
 - Match testing patterns (TESTING.md)

--- a/skills/kata-map-codebase/references/project-analyze.md
+++ b/skills/kata-map-codebase/references/project-analyze.md
@@ -313,14 +313,14 @@ Created .planning/codebase/:
 
 **Initialize project** — use codebase context for planning
 
-`/kata:kata-new-project`
+`/kata-new-project`
 
 <sub>`/clear` first → fresh context window</sub>
 
 ---
 
 **Also available:**
-- Re-run mapping: `/kata:kata-map-codebase`
+- Re-run mapping: `/kata-map-codebase`
 - Review specific file: `cat .planning/codebase/STACK.md`
 - Edit any document before proceeding
 

--- a/skills/kata-move-phase/SKILL.md
+++ b/skills/kata-move-phase/SKILL.md
@@ -12,8 +12,8 @@ Purpose: Enable flexible phase reorganization (cross-milestone moves and within-
 Output: Phase moved/reordered, directories renamed, ROADMAP.md updated, STATE.md updated, git commit as historical record.
 
 **Supported operations:**
-- Cross-milestone move: `/kata:kata-move-phase 3 to v1.6.0`
-- Reorder within milestone: `/kata:kata-move-phase 3 before 1` or `/kata:kata-move-phase 3 after 1`
+- Cross-milestone move: `/kata-move-phase 3 to v1.6.0`
+- Reorder within milestone: `/kata-move-phase 3 before 1` or `/kata-move-phase 3 after 1`
 </objective>
 
 <execution_context>
@@ -31,19 +31,19 @@ Parse the command arguments. First arg is always the phase number (integer).
 - `"before"` or `"after"` + target phase number → reorder within milestone
 
 **Cross-milestone move:**
-- `/kata:kata-move-phase 3 to v1.6.0`
+- `/kata-move-phase 3 to v1.6.0`
 
 **Reorder within milestone:**
-- `/kata:kata-move-phase 3 before 1` → Phase 3 takes position 1, everything shifts up
-- `/kata:kata-move-phase 3 after 1` → Phase 3 takes position 2, phases 2+ shift up
+- `/kata-move-phase 3 before 1` → Phase 3 takes position 1, everything shifts up
+- `/kata-move-phase 3 after 1` → Phase 3 takes position 2, phases 2+ shift up
 
 **Validation:**
 - If no arguments or missing second arg:
 
 ```
 ERROR: Phase number and operation required
-Usage: /kata:kata-move-phase <phase> to <milestone>
-       /kata:kata-move-phase <phase> before|after <position>
+Usage: /kata-move-phase <phase> to <milestone>
+       /kata-move-phase <phase> before|after <position>
 ```
 
 Exit.
@@ -266,7 +266,7 @@ git commit -m "chore: reorder phase {N} {before|after} {M}"
 </step>
 
 <step name="completion">
-Present completion summary showing: operation performed, directories renamed, phases renumbered, files updated, commit message. Then offer next actions: `/kata:kata-track-progress`, continue current phase, review roadmap.
+Present completion summary showing: operation performed, directories renamed, phases renumbered, files updated, commit message. Then offer next actions: `/kata-track-progress`, continue current phase, review roadmap.
 </step>
 
 </process>

--- a/skills/kata-new-project/SKILL.md
+++ b/skills/kata-new-project/SKILL.md
@@ -15,7 +15,7 @@ This is the most leveraged moment in any project. Deep questioning here means be
 - `.planning/PROJECT.md` — project context
 - `.planning/config.json` — workflow preferences
 
-**After this command:** Run `/kata:kata-add-milestone` to define your first milestone.
+**After this command:** Run `/kata-add-milestone` to define your first milestone.
 
 </objective>
 
@@ -35,7 +35,7 @@ This is the most leveraged moment in any project. Deep questioning here means be
 
 1. **Abort if project exists:**
    ```bash
-   [ -f .planning/PROJECT.md ] && echo "ERROR: Project already initialized. Use /kata:kata-track-progress" && exit 1
+   [ -f .planning/PROJECT.md ] && echo "ERROR: Project already initialized. Use /kata-track-progress" && exit 1
    ```
 
 2. **Initialize git repo in THIS directory** (required even if inside a parent repo):
@@ -69,12 +69,12 @@ Use AskUserQuestion:
 - header: "Existing Code"
 - question: "I detected existing code in this directory. Would you like to map the codebase first?"
 - options:
-  - "Map codebase first" — Run /kata:kata-map-codebase to understand existing architecture (Recommended)
+  - "Map codebase first" — Run /kata-map-codebase to understand existing architecture (Recommended)
   - "Skip mapping" — Proceed with project initialization
 
 **If "Map codebase first":**
 ```
-Run `/kata:kata-map-codebase` first, then return to `/kata:kata-new-project`
+Run `/kata-map-codebase` first, then return to `/kata-new-project`
 ```
 Exit command.
 
@@ -492,7 +492,7 @@ EOF
 )"
 ```
 
-**Note:** Run `/kata:kata-configure-settings` anytime to update these preferences.
+**Note:** Run `/kata-configure-settings` anytime to update these preferences.
 
 **If pr_workflow = Yes:**
 
@@ -791,7 +791,7 @@ Settings for `main`:
 
 **Define your first milestone**
 
-`/kata:kata-add-milestone` — research, requirements, and roadmap
+`/kata-add-milestone` — research, requirements, and roadmap
 
 <sub>`/clear` first → fresh context window</sub>
 
@@ -817,7 +817,7 @@ Settings for `main`:
 - [ ] PROJECT.md captures full context → **committed**
 - [ ] config.json has workflow mode, depth, parallelization → **committed**
 - [ ] Self-validation passed (all artifacts exist)
-- [ ] User knows next step is `/kata:kata-add-milestone`
+- [ ] User knows next step is `/kata-add-milestone`
 
 **Atomic commits:** PROJECT.md and config.json are committed. If context is lost, artifacts persist.
 

--- a/skills/kata-new-project/references/project-template.md
+++ b/skills/kata-new-project/references/project-template.md
@@ -147,7 +147,7 @@ PROJECT.md evolves throughout the project lifecycle.
 
 For existing codebases:
 
-1. **Map codebase first** via `/kata:kata-map-codebase`
+1. **Map codebase first** via `/kata-map-codebase`
 
 2. **Infer Validated requirements** from existing code:
    - What does the codebase actually do?

--- a/skills/kata-new-project/references/ui-brand.md
+++ b/skills/kata-new-project/references/ui-brand.md
@@ -113,8 +113,8 @@ Always at end of major completions.
 ───────────────────────────────────────────────────────────────
 
 **Also available:**
-- `/kata:kata-alternative-1` — description
-- `/kata:kata-alternative-2` — description
+- `/kata-alternative-1` — description
+- `/kata-alternative-2` — description
 
 ───────────────────────────────────────────────────────────────
 ```

--- a/skills/kata-pause-work/SKILL.md
+++ b/skills/kata-pause-work/SKILL.md
@@ -135,7 +135,7 @@ Current state:
 - Status: [in_progress/blocked]
 - Committed as WIP
 
-To resume: /kata:kata-resume-work
+To resume: /kata-resume-work
 
 ```
 </step>

--- a/skills/kata-plan-milestone-gaps/SKILL.md
+++ b/skills/kata-plan-milestone-gaps/SKILL.md
@@ -6,11 +6,11 @@ metadata:
 allowed-tools: Read Write Bash
 ---
 <objective>
-Create all phases necessary to close gaps identified by `/kata:kata-audit-milestone`.
+Create all phases necessary to close gaps identified by `/kata-audit-milestone`.
 
 Reads MILESTONE-AUDIT.md, groups gaps into logical phases, creates phase entries in ROADMAP.md, and offers to plan each phase.
 
-One command creates all fix phases — no manual `/kata:kata-add-phase` per gap.
+One command creates all fix phases — no manual `/kata-add-phase` per gap.
 </objective>
 
 <execution_context>
@@ -46,7 +46,7 @@ Parse YAML frontmatter to extract structured gaps:
 
 If no audit file exists or has no gaps, error:
 ```
-No audit gaps found. Run `/kata:kata-audit-milestone` first.
+No audit gaps found. Run `/kata-audit-milestone` first.
 ```
 
 ## 2. Prioritize Gaps
@@ -192,22 +192,22 @@ git commit -m "docs(roadmap): add gap closure phases {N}-{M}"
 
 **Plan first gap closure phase**
 
-`/kata:kata-plan-phase {N}`
+`/kata-plan-phase {N}`
 
 <sub>`/clear` first → fresh context window</sub>
 
 ---
 
 **Also available:**
-- `/kata:kata-execute-phase {N}` — if plans already exist
+- `/kata-execute-phase {N}` — if plans already exist
 - `cat .planning/ROADMAP.md` — see updated roadmap
 
 ---
 
 **After all gap phases complete:**
 
-`/kata:kata-audit-milestone` — re-audit to verify gaps closed
-`/kata:kata-complete-milestone {version}` — archive when audit passes
+`/kata-audit-milestone` — re-audit to verify gaps closed
+`/kata-complete-milestone {version}` — archive when audit passes
 ```
 
 </process>
@@ -295,5 +295,5 @@ becomes:
 - [ ] ROADMAP.md updated with new phases
 - [ ] Phase directories created
 - [ ] Changes committed
-- [ ] User knows to run `/kata:kata-plan-phase` next
+- [ ] User knows to run `/kata-plan-phase` next
 </success_criteria>

--- a/skills/kata-plan-phase/SKILL.md
+++ b/skills/kata-plan-phase/SKILL.md
@@ -39,7 +39,7 @@ Normalize phase input in step 2 before any directory lookups.
 ls .planning/ 2>/dev/null
 ```
 
-**If not found:** Error - user should run `/kata:kata-new-project` first.
+**If not found:** Error - user should run `/kata-new-project` first.
 
 **Resolve model profile for agent spawning:**
 
@@ -113,7 +113,7 @@ if [ "$MATCH_COUNT" -gt 1 ]; then
 fi
 ```
 
-**If COLLISION detected (MATCH_COUNT > 1):** STOP planning. Invoke `/kata:kata-migrate-phases` to renumber phases to globally sequential numbering. After migration completes, re-invoke `/kata:kata-plan-phase` with the migrated phase number. Do NOT continue with ambiguous phase directories.
+**If COLLISION detected (MATCH_COUNT > 1):** STOP planning. Invoke `/kata-migrate-phases` to renumber phases to globally sequential numbering. After migration completes, re-invoke `/kata-plan-phase` with the migrated phase number. Do NOT continue with ambiguous phase directories.
 
 ```bash
 find "${PHASE_DIR}" -maxdepth 1 -name "*-RESEARCH.md" 2>/dev/null
@@ -389,7 +389,7 @@ Fill prompt with inlined content and spawn:
 </planning_context>
 
 <downstream_consumer>
-Output consumed by /kata:kata-execute-phase
+Output consumed by /kata-execute-phase
 Plans must be executable prompts with:
 
 - Frontmatter (wave, depends_on, files_modified, autonomous)
@@ -683,7 +683,7 @@ GitHub Issue: #{ISSUE_NUMBER} updated with {PLAN_COUNT} plan checklist items
 
 **Execute Phase {X}** — run all {N} plans
 
-/kata:kata-execute-phase {X}
+/kata-execute-phase {X}
 
 <sub>/clear first → fresh context window</sub>
 
@@ -691,7 +691,7 @@ GitHub Issue: #{ISSUE_NUMBER} updated with {PLAN_COUNT} plan checklist items
 
 **Also available:**
 - cat .planning/phases/{phase-dir}/*-PLAN.md — review plans
-- /kata:kata-plan-phase {X} --research — re-research first
+- /kata-plan-phase {X} --research — re-research first
 
 ───────────────────────────────────────────────────────────────
 </offer_next>

--- a/skills/kata-plan-phase/references/phase-researcher-instructions.md
+++ b/skills/kata-plan-phase/references/phase-researcher-instructions.md
@@ -4,8 +4,8 @@ You are a Kata phase researcher. You research how to implement a specific phase 
 
 You are spawned by:
 
-- `/kata:kata-plan-phase` orchestrator (integrated research before planning)
-- `/kata:kata-research-phase` orchestrator (standalone research)
+- `/kata-plan-phase` orchestrator (integrated research before planning)
+- `/kata-research-phase` orchestrator (standalone research)
 
 Your job: Answer "What do I need to know to PLAN this phase well?" Produce a single RESEARCH.md file that the planner consumes immediately.
 
@@ -18,7 +18,7 @@ Your job: Answer "What do I need to know to PLAN this phase well?" Produce a sin
 </role>
 
 <upstream_input>
-**CONTEXT.md** (if exists) — User decisions from `/kata:kata-discuss-phase`
+**CONTEXT.md** (if exists) — User decisions from `/kata-discuss-phase`
 
 | Section                  | How You Use It                                    |
 | ------------------------ | ------------------------------------------------- |
@@ -452,7 +452,7 @@ if [ -z "$PHASE_DIR" ]; then
   [ -z "$PHASE_DIR" ] && PHASE_DIR=$(find .planning/phases -maxdepth 1 -type d -name "${PHASE}-*" 2>/dev/null | head -1)
 fi
 
-# Read CONTEXT.md if exists (from /kata:kata-discuss-phase)
+# Read CONTEXT.md if exists (from /kata-discuss-phase)
 cat "${PHASE_DIR}"/*-CONTEXT.md 2>/dev/null
 
 # Check if planning docs should be committed (default: true)

--- a/skills/kata-plan-phase/references/plan-checker-instructions.md
+++ b/skills/kata-plan-phase/references/plan-checker-instructions.md
@@ -4,7 +4,7 @@ You are a Kata plan checker. You verify that plans WILL achieve the phase goal, 
 
 You are spawned by:
 
-- `/kata:kata-plan-phase` orchestrator (after planner creates PLAN.md files)
+- `/kata-plan-phase` orchestrator (after planner creates PLAN.md files)
 - Re-verification (after planner revises based on your feedback)
 
 Your job: Goal-backward verification of PLANS before execution. Start from what the phase SHOULD deliver, verify the plans address it.
@@ -662,7 +662,7 @@ When all checks pass:
 
 ### Ready for Execution
 
-Plans verified. Run `/kata:kata-execute-phase {phase}` to proceed.
+Plans verified. Run `/kata-execute-phase {phase}` to proceed.
 ```
 
 ## ISSUES FOUND

--- a/skills/kata-plan-phase/references/planner-instructions.md
+++ b/skills/kata-plan-phase/references/planner-instructions.md
@@ -4,9 +4,9 @@ You are a Kata planner. You create executable phase plans with task breakdown, d
 
 You are spawned by:
 
-- `/kata:kata-plan-phase` orchestrator (standard phase planning)
-- `/kata:kata-plan-phase --gaps` orchestrator (gap closure planning from verification failures)
-- `/kata:kata-plan-phase` orchestrator in revision mode (updating plans based on checker feedback)
+- `/kata-plan-phase` orchestrator (standard phase planning)
+- `/kata-plan-phase --gaps` orchestrator (gap closure planning from verification failures)
+- `/kata-plan-phase` orchestrator in revision mode (updating plans based on checker feedback)
 
 Your job: Produce PLAN.md files that Claude executors can implement without interpretation. Plans are prompts, not documents that become prompts.
 
@@ -106,7 +106,7 @@ Discovery is MANDATORY unless you can prove current context exists.
 - Level 2+: New library not in package.json, external API, "choose/select/evaluate" in description
 - Level 3: "architecture/design/system", multiple external services, data modeling, auth design
 
-For niche domains (3D, games, audio, shaders, ML), suggest `/kata:kata-research-phase` before phase-plan.
+For niche domains (3D, games, audio, shaders, ML), suggest `/kata-research-phase` before phase-plan.
 
 </discovery_levels>
 
@@ -1142,10 +1142,10 @@ if [ -z "$PHASE_DIR" ]; then
   [ -z "$PHASE_DIR" ] && PHASE_DIR=$(find .planning/phases -maxdepth 1 -type d -name "${PHASE}-*" 2>/dev/null | head -1)
 fi
 
-# Read CONTEXT.md if exists (from /kata:kata-discuss-phase)
+# Read CONTEXT.md if exists (from /kata-discuss-phase)
 cat "${PHASE_DIR}"/*-CONTEXT.md 2>/dev/null
 
-# Read RESEARCH.md if exists (from /kata:kata-research-phase)
+# Read RESEARCH.md if exists (from /kata-research-phase)
 cat "${PHASE_DIR}"/*-RESEARCH.md 2>/dev/null
 
 # Read DISCOVERY.md if exists (from mandatory discovery)
@@ -1253,7 +1253,7 @@ Update ROADMAP.md to finalize phase placeholders created by phase-add or phase-i
 
 **Plans** (always update):
 - `**Plans:** 0 plans` → `**Plans:** {N} plans`
-- `**Plans:** (created by /kata:kata-plan-phase)` → `**Plans:** {N} plans`
+- `**Plans:** (created by /kata-plan-phase)` → `**Plans:** {N} plans`
 
 **Plan list** (always update):
 - Replace `Plans:\n- [ ] TBD ...` with actual plan checkboxes:
@@ -1316,7 +1316,7 @@ Return structured planning outcome to orchestrator.
 
 ### Next Steps
 
-Execute: `/kata:kata-execute-phase {phase}`
+Execute: `/kata-execute-phase {phase}`
 
 <sub>`/clear` first - fresh context window</sub>
 ```
@@ -1360,7 +1360,7 @@ Execute: `/kata:kata-execute-phase {phase}`
 
 ### Next Steps
 
-Execute: `/kata:kata-execute-phase {phase} --gaps-only`
+Execute: `/kata-execute-phase {phase} --gaps-only`
 ```
 
 ## Revision Complete
@@ -1426,6 +1426,6 @@ Planning complete when:
 - [ ] PLAN file(s) exist with gap_closure: true
 - [ ] Each plan: tasks derived from gap.missing items
 - [ ] PLAN file(s) committed to git
-- [ ] User knows to run `/kata:kata-execute-phase {X}` next
+- [ ] User knows to run `/kata-execute-phase {X}` next
 
 </success_criteria>

--- a/skills/kata-plan-phase/references/ui-brand.md
+++ b/skills/kata-plan-phase/references/ui-brand.md
@@ -113,8 +113,8 @@ Always at end of major completions.
 ───────────────────────────────────────────────────────────────
 
 **Also available:**
-- `/kata:kata-alternative-1` — description
-- `/kata:kata-alternative-2` — description
+- `/kata-alternative-1` — description
+- `/kata-alternative-2` — description
 
 ───────────────────────────────────────────────────────────────
 ```

--- a/skills/kata-remove-phase/SKILL.md
+++ b/skills/kata-remove-phase/SKILL.md
@@ -22,15 +22,15 @@ Output: Phase deleted, all subsequent phases renumbered, git commit as historica
 <step name="parse_arguments">
 Parse the command arguments:
 - Argument is the phase number to remove (integer or decimal)
-- Example: `/kata:kata-remove-phase 17` → phase = 17
-- Example: `/kata:kata-remove-phase 16.1` → phase = 16.1
+- Example: `/kata-remove-phase 17` → phase = 17
+- Example: `/kata-remove-phase 16.1` → phase = 16.1
 
 If no argument provided:
 
 ```
 ERROR: Phase number required
-Usage: /kata:kata-remove-phase <phase-number>
-Example: /kata:kata-remove-phase 17
+Usage: /kata-remove-phase <phase-number>
+Example: /kata-remove-phase 17
 ```
 
 Exit.
@@ -76,7 +76,7 @@ Only future phases can be removed:
 - Current phase: {current}
 - Phase {target} is current or completed
 
-To abandon current work, use /kata:kata-pause-work instead.
+To abandon current work, use /kata-pause-work instead.
 ```
 
 Exit.
@@ -315,7 +315,7 @@ Current position: Phase {current} of {new-total}
 ## What's Next
 
 Would you like to:
-- `/kata:kata-track-progress` — see updated roadmap status
+- `/kata-track-progress` — see updated roadmap status
 - Continue with current phase
 - Review roadmap
 

--- a/skills/kata-research-phase/SKILL.md
+++ b/skills/kata-research-phase/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: Read Write Bash
 <objective>
 Research how to implement a phase. Spawns kata-phase-researcher agent with phase context.
 
-**Note:** This is a standalone research command. For most workflows, use `/kata:kata-plan-phase` which integrates research automatically.
+**Note:** This is a standalone research command. For most workflows, use `/kata-plan-phase` which integrates research automatically.
 
 **Use this command when:**
 - You want to research without planning yet
@@ -141,7 +141,7 @@ Mode: ecosystem
 </context>
 
 <downstream_consumer>
-Your RESEARCH.md will be loaded by `/kata:kata-plan-phase` which uses specific sections:
+Your RESEARCH.md will be loaded by `/kata-plan-phase` which uses specific sections:
 - `## Standard Stack` → Plans use these libraries
 - `## Architecture Patterns` → Task structure follows these
 - `## Don't Hand-Roll` → Tasks NEVER build custom solutions for listed problems

--- a/skills/kata-research-phase/references/phase-researcher-instructions.md
+++ b/skills/kata-research-phase/references/phase-researcher-instructions.md
@@ -4,8 +4,8 @@ You are a Kata phase researcher. You research how to implement a specific phase 
 
 You are spawned by:
 
-- `/kata:kata-plan-phase` orchestrator (integrated research before planning)
-- `/kata:kata-research-phase` orchestrator (standalone research)
+- `/kata-plan-phase` orchestrator (integrated research before planning)
+- `/kata-research-phase` orchestrator (standalone research)
 
 Your job: Answer "What do I need to know to PLAN this phase well?" Produce a single RESEARCH.md file that the planner consumes immediately.
 
@@ -18,7 +18,7 @@ Your job: Answer "What do I need to know to PLAN this phase well?" Produce a sin
 </role>
 
 <upstream_input>
-**CONTEXT.md** (if exists) — User decisions from `/kata:kata-discuss-phase`
+**CONTEXT.md** (if exists) — User decisions from `/kata-discuss-phase`
 
 | Section                  | How You Use It                                    |
 | ------------------------ | ------------------------------------------------- |
@@ -452,7 +452,7 @@ if [ -z "$PHASE_DIR" ]; then
   [ -z "$PHASE_DIR" ] && PHASE_DIR=$(find .planning/phases -maxdepth 1 -type d -name "${PHASE}-*" 2>/dev/null | head -1)
 fi
 
-# Read CONTEXT.md if exists (from /kata:kata-discuss-phase)
+# Read CONTEXT.md if exists (from /kata-discuss-phase)
 cat "${PHASE_DIR}"/*-CONTEXT.md 2>/dev/null
 
 # Check if planning docs should be committed (default: true)

--- a/skills/kata-resume-work/references/continuation-format.md
+++ b/skills/kata-resume-work/references/continuation-format.md
@@ -44,7 +44,7 @@ Standard format for presenting next steps after completing a command or workflow
 
 **02-03: Refresh Token Rotation** — Add /api/auth/refresh with sliding expiry
 
-`/kata:kata-execute-phase 2`
+`/kata-execute-phase 2`
 
 <sub>`/clear` first → fresh context window</sub>
 
@@ -52,7 +52,7 @@ Standard format for presenting next steps after completing a command or workflow
 
 **Also available:**
 - Review plan before executing
-- `/kata:kata-listing-phase-assumptions 2` — check assumptions
+- `/kata-listing-phase-assumptions 2` — check assumptions
 
 ---
 ```
@@ -69,7 +69,7 @@ Add note that this is the last plan and what comes after:
 **02-03: Refresh Token Rotation** — Add /api/auth/refresh with sliding expiry
 <sub>Final plan in Phase 2</sub>
 
-`/kata:kata-execute-phase 2`
+`/kata-execute-phase 2`
 
 <sub>`/clear` first → fresh context window</sub>
 
@@ -91,15 +91,15 @@ Add note that this is the last plan and what comes after:
 
 **Phase 2: Authentication** — JWT login flow with refresh tokens
 
-`/kata:kata-plan-phase 2`
+`/kata-plan-phase 2`
 
 <sub>`/clear` first → fresh context window</sub>
 
 ---
 
 **Also available:**
-- `/kata:kata-discuss-phase 2` — gather context first
-- `/kata:kata-research-phase 2` — investigate unknowns
+- `/kata-discuss-phase 2` — gather context first
+- `/kata-research-phase 2` — investigate unknowns
 - Review roadmap
 
 ---
@@ -120,15 +120,15 @@ Show completion status before next action:
 
 **Phase 3: Core Features** — User dashboard, settings, and data export
 
-`/kata:kata-plan-phase 3`
+`/kata-plan-phase 3`
 
 <sub>`/clear` first → fresh context window</sub>
 
 ---
 
 **Also available:**
-- `/kata:kata-discuss-phase 3` — gather context first
-- `/kata:kata-research-phase 3` — investigate unknowns
+- `/kata-discuss-phase 3` — gather context first
+- `/kata-research-phase 3` — investigate unknowns
 - Review what Phase 2 built
 
 ---
@@ -145,11 +145,11 @@ When there's no clear primary action:
 
 **Phase 3: Core Features** — User dashboard, settings, and data export
 
-**To plan directly:** `/kata:kata-plan-phase 3`
+**To plan directly:** `/kata-plan-phase 3`
 
-**To discuss context first:** `/kata:kata-discuss-phase 3`
+**To discuss context first:** `/kata-discuss-phase 3`
 
-**To research unknowns:** `/kata:kata-research-phase 3`
+**To research unknowns:** `/kata-research-phase 3`
 
 <sub>`/clear` first → fresh context window</sub>
 
@@ -169,7 +169,7 @@ All 4 phases shipped
 
 **Start v1.1** — questioning → research → requirements → roadmap
 
-`/kata:kata-add-milestone`
+`/kata-add-milestone`
 
 <sub>`/clear` first → fresh context window</sub>
 
@@ -214,7 +214,7 @@ Extract: `**02-03: Refresh Token Rotation** — Add /api/auth/refresh with slidi
 ## To Continue
 
 Run `/clear`, then paste:
-/kata:kata-execute-phase 2
+/kata-execute-phase 2
 ```
 
 User has no idea what 02-03 is about.
@@ -222,7 +222,7 @@ User has no idea what 02-03 is about.
 ### Don't: Missing /clear explanation
 
 ```
-`/kata:kata-plan-phase 3`
+`/kata-plan-phase 3`
 
 Run /clear first.
 ```
@@ -242,7 +242,7 @@ Sounds like an afterthought. Use "Also available:" instead.
 
 ```
 ```
-/kata:kata-plan-phase 3
+/kata-plan-phase 3
 ```
 ```
 

--- a/skills/kata-resume-work/references/resume-project.md
+++ b/skills/kata-resume-work/references/resume-project.md
@@ -30,7 +30,7 @@ ls .planning/PROJECT.md 2>/dev/null && echo "Project file exists"
 
 **If STATE.md exists:** Proceed to load_state
 **If only ROADMAP.md/PROJECT.md exist:** Offer to reconstruct STATE.md
-**If .planning/ doesn't exist:** This is a new project - route to /kata:kata-new-project
+**If .planning/ doesn't exist:** This is a new project - route to /kata-new-project
 </step>
 
 <step name="load_state">
@@ -141,7 +141,7 @@ Present complete project status to user:
     Resume with: Task tool (resume parameter with agent ID)
 
 [If pending issues exist:]
-📋 [N] pending issues — /kata:kata-check-issues to review
+📋 [N] pending issues — /kata-check-issues to review
 
 [If blockers exist:]
 ⚠️  Carried concerns:
@@ -197,11 +197,11 @@ What would you like to do?
 [Primary action based on state - e.g.:]
 1. Resume interrupted agent [if interrupted agent found]
    OR
-1. Execute phase (/kata:kata-execute-phase {phase})
+1. Execute phase (/kata-execute-phase {phase})
    OR
-1. Discuss Phase 3 context (/kata:kata-discuss-phase 3) [if CONTEXT.md missing]
+1. Discuss Phase 3 context (/kata-discuss-phase 3) [if CONTEXT.md missing]
    OR
-1. Plan Phase 3 (/kata:kata-plan-phase 3) [if CONTEXT.md exists or discuss option declined]
+1. Plan Phase 3 (/kata-plan-phase 3) [if CONTEXT.md exists or discuss option declined]
 
 [Secondary options:]
 2. Review current phase status
@@ -233,7 +233,7 @@ Based on user selection, route to appropriate workflow:
 
   **{phase}-{plan}: [Plan Name]** — [objective from PLAN.md]
 
-  `/kata:kata-execute-phase {phase}`
+  `/kata-execute-phase {phase}`
 
   <sub>`/clear` first → fresh context window</sub>
 
@@ -247,15 +247,15 @@ Based on user selection, route to appropriate workflow:
 
   **Phase [N]: [Name]** — [Goal from ROADMAP.md]
 
-  `/kata:kata-plan-phase [phase-number]`
+  `/kata-plan-phase [phase-number]`
 
   <sub>`/clear` first → fresh context window</sub>
 
   ---
 
   **Also available:**
-  - `/kata:kata-discuss-phase [N]` — gather context first
-  - `/kata:kata-research-phase [N]` — investigate unknowns
+  - `/kata-discuss-phase [N]` — gather context first
+  - `/kata-research-phase [N]` — investigate unknowns
 
   ---
   ```

--- a/skills/kata-review-pull-requests/SKILL.md
+++ b/skills/kata-review-pull-requests/SKILL.md
@@ -111,24 +111,24 @@ Run a comprehensive pull request review using multiple specialized agents, each 
 
 **Full review (default):**
 ```
-/kata:kata-review-pull-requests
+/kata-review-pull-requests
 ```
 
 **Specific aspects:**
 ```
-/kata:kata-review-pull-requests tests errors
+/kata-review-pull-requests tests errors
 # Reviews only test coverage and error handling
 
-/kata:kata-review-pull-requests comments
+/kata-review-pull-requests comments
 # Reviews only code comments
 
-/kata:kata-review-pull-requests simplify
+/kata-review-pull-requests simplify
 # Simplifies code after passing review
 ```
 
 **Parallel review:**
 ```
-/kata:kata-review-pull-requests all parallel
+/kata-review-pull-requests all parallel
 # Launches all agents in parallel
 ```
 
@@ -178,7 +178,7 @@ Run a comprehensive pull request review using multiple specialized agents, each 
 **Before committing:**
 ```
 1. Write code
-2. Run: /kata:kata-review-pull-requests code errors
+2. Run: /kata-review-pull-requests code errors
 3. Fix any critical issues
 4. Commit
 ```
@@ -186,7 +186,7 @@ Run a comprehensive pull request review using multiple specialized agents, each 
 **Before creating PR:**
 ```
 1. Stage all changes
-2. Run: /kata:kata-review-pull-requests all
+2. Run: /kata-review-pull-requests all
 3. Address all critical and important issues
 4. Run specific reviews again to verify
 5. Create PR

--- a/skills/kata-review-pull-requests/references/entity-generator-instructions.md
+++ b/skills/kata-review-pull-requests/references/entity-generator-instructions.md
@@ -1,7 +1,7 @@
 <role>
 You are a Kata entity generator. You create semantic documentation for source files that captures PURPOSE (what the code does and why it exists), not just syntax.
 
-You are spawned by `/kata:kata-map-codebase` with a list of file paths.
+You are spawned by `/kata-map-codebase` with a list of file paths.
 
 Your job: Read each file, analyze its purpose, write entity markdown to `.planning/intel/entities/`, return statistics only.
 </role>

--- a/skills/kata-set-profile/SKILL.md
+++ b/skills/kata-set-profile/SKILL.md
@@ -37,7 +37,7 @@ ls .planning/config.json 2>/dev/null
 If no `.planning/` directory:
 ```
 Error: No Kata project found.
-Run /kata:kata-new-project first to initialize a project.
+Run /kata-new-project first to initialize a project.
 ```
 
 ## 3. Update config.json
@@ -73,7 +73,7 @@ Next spawned agents will use the new profile.
 
 **Switch to budget mode:**
 ```
-/kata:kata-set-profile budget
+/kata-set-profile budget
 
 ✓ Model profile set to: budget
 
@@ -88,7 +88,7 @@ Agents will now use:
 
 **Switch to quality mode:**
 ```
-/kata:kata-set-profile quality
+/kata-set-profile quality
 
 ✓ Model profile set to: quality
 

--- a/skills/kata-track-progress/SKILL.md
+++ b/skills/kata-track-progress/SKILL.md
@@ -28,18 +28,18 @@ If no `.planning/` directory:
 ```
 No planning structure found.
 
-Run /kata:kata-new-project to start a new project.
+Run /kata-new-project to start a new project.
 ```
 
 Exit.
 
-If missing STATE.md: suggest `/kata:kata-new-project`.
+If missing STATE.md: suggest `/kata-new-project`.
 
 **If ROADMAP.md missing but PROJECT.md exists:**
 
 This means a milestone was completed and archived. Go to **Route F** (between milestones).
 
-If missing both ROADMAP.md and PROJECT.md: suggest `/kata:kata-new-project`.
+If missing both ROADMAP.md and PROJECT.md: suggest `/kata-new-project`.
 </step>
 
 <step name="load">
@@ -102,10 +102,10 @@ CONTEXT: [✓ if CONTEXT.md exists | - if not]
 - [any blockers or concerns from STATE.md]
 
 ## Pending Issues
-- [count] pending — /kata:kata-check-issues to review
+- [count] pending — /kata-check-issues to review
 
 ## Active Debug Sessions
-- [count] active — /kata:kata-debug to continue
+- [count] active — /kata-debug to continue
 (Only show this section if count > 0)
 
 ## PR Status
@@ -234,7 +234,7 @@ Read its `<objective>` section.
 **{phase}-{plan}: [Plan Name]** — [objective summary from PLAN.md]
 {If PR_WORKFLOW is true AND PR exists: PR #[number] ([state]) — [url]}
 
-`/kata:kata-execute-phase {phase}`
+`/kata-execute-phase {phase}`
 
 <sub>`/clear` first → fresh context window</sub>
 
@@ -257,7 +257,7 @@ Check if `{phase}-CONTEXT.md` exists in phase directory.
 **Phase {N}: {Name}** — {Goal from ROADMAP.md}
 <sub>✓ Context gathered, ready to plan</sub>
 
-`/kata:kata-plan-phase {phase-number}`
+`/kata-plan-phase {phase-number}`
 
 <sub>`/clear` first → fresh context window</sub>
 
@@ -273,15 +273,15 @@ Check if `{phase}-CONTEXT.md` exists in phase directory.
 
 **Phase {N}: {Name}** — {Goal from ROADMAP.md}
 
-`/kata:kata-discuss-phase {phase}` — gather context and clarify approach
+`/kata-discuss-phase {phase}` — gather context and clarify approach
 
 <sub>`/clear` first → fresh context window</sub>
 
 ---
 
 **Also available:**
-- `/kata:kata-plan-phase {phase}` — skip discussion, plan directly
-- `/kata:kata-listing-phase-assumptions {phase}` — see Claude's assumptions
+- `/kata-plan-phase {phase}` — skip discussion, plan directly
+- `/kata-listing-phase-assumptions {phase}` — see Claude's assumptions
 
 ---
 ```
@@ -299,15 +299,15 @@ UAT.md exists with gaps (diagnosed issues). User needs to plan fixes.
 
 **{phase}-UAT.md** has {N} gaps requiring fixes.
 
-`/kata:kata-plan-phase {phase} --gaps`
+`/kata-plan-phase {phase} --gaps`
 
 <sub>`/clear` first → fresh context window</sub>
 
 ---
 
 **Also available:**
-- `/kata:kata-execute-phase {phase}` — execute phase plans
-- `/kata:kata-verify-work {phase}` — run more UAT testing
+- `/kata-execute-phase {phase}` — execute phase plans
+- `/kata-verify-work {phase}` — run more UAT testing
 
 ---
 ```
@@ -350,15 +350,15 @@ Then continue with:
 }
 **Phase {Z+1}: {Name}** — {Goal from ROADMAP.md}
 
-`/kata:kata-discuss-phase {Z+1}` — gather context and clarify approach
+`/kata-discuss-phase {Z+1}` — gather context and clarify approach
 
 <sub>`/clear` first → fresh context window</sub>
 
 ---
 
 **Also available:**
-- `/kata:kata-plan-phase {Z+1}` — skip discussion, plan directly
-- `/kata:kata-verify-work {Z}` — user acceptance test before continuing
+- `/kata-plan-phase {Z+1}` — skip discussion, plan directly
+- `/kata-verify-work {Z}` — user acceptance test before continuing
 
 ---
 ```
@@ -381,14 +381,14 @@ Then continue with:
 }
 **Complete Milestone** — archive and prepare for next
 
-`/kata:kata-complete-milestone`
+`/kata-complete-milestone`
 
 <sub>`/clear` first → fresh context window</sub>
 
 ---
 
 **Also available:**
-- `/kata:kata-verify-work` — user acceptance test before completing milestone
+- `/kata-verify-work` — user acceptance test before completing milestone
 
 ---
 ```
@@ -411,7 +411,7 @@ Ready to plan the next milestone.
 
 **Start Next Milestone** — questioning → research → requirements → roadmap
 
-`/kata:kata-add-milestone`
+`/kata-add-milestone`
 
 <sub>`/clear` first → fresh context window</sub>
 
@@ -422,10 +422,10 @@ Ready to plan the next milestone.
 <step name="edge_cases">
 **Handle edge cases:**
 
-- Phase complete but next phase not planned → offer `/kata:kata-plan-phase [next]`
+- Phase complete but next phase not planned → offer `/kata-plan-phase [next]`
 - All work complete → offer milestone completion
 - Blockers present → highlight before offering to continue
-- Handoff file exists → mention it, offer `/kata:kata-resume-work`
+- Handoff file exists → mention it, offer `/kata-resume-work`
   </step>
 
 </process>
@@ -435,7 +435,7 @@ Ready to plan the next milestone.
 - [ ] Rich context provided (recent work, decisions, issues)
 - [ ] Current position clear with visual progress
 - [ ] What's next clearly explained
-- [ ] Smart routing: /kata:kata-execute-phase if plans exist, /kata:kata-plan-phase if not
+- [ ] Smart routing: /kata-execute-phase if plans exist, /kata-plan-phase if not
 - [ ] User confirms before any action
 - [ ] Seamless handoff to appropriate kata command
       </success_criteria>

--- a/skills/kata-track-progress/references/codebase-mapper-instructions.md
+++ b/skills/kata-track-progress/references/codebase-mapper-instructions.md
@@ -1,7 +1,7 @@
 <role>
 You are a Kata codebase mapper. You explore a codebase for a specific focus area and write analysis documents directly to `.planning/codebase/`.
 
-You are spawned by `/kata:kata-map-codebase` with one of four focus areas:
+You are spawned by `/kata-map-codebase` with one of four focus areas:
 - **tech**: Analyze technology stack and external integrations → write STACK.md and INTEGRATIONS.md
 - **arch**: Analyze architecture and file structure → write ARCHITECTURE.md and STRUCTURE.md
 - **quality**: Analyze coding conventions and testing patterns → write CONVENTIONS.md and TESTING.md
@@ -13,7 +13,7 @@ Your job: Explore thoroughly, then write document(s) directly. Return confirmati
 <why_this_matters>
 **These documents are consumed by other Kata commands:**
 
-**`/kata:kata-plan-phase`** loads relevant codebase docs when creating implementation plans:
+**`/kata-plan-phase`** loads relevant codebase docs when creating implementation plans:
 | Phase Type                | Documents Loaded                |
 | ------------------------- | ------------------------------- |
 | UI, frontend, components  | CONVENTIONS.md, STRUCTURE.md    |
@@ -24,7 +24,7 @@ Your job: Explore thoroughly, then write document(s) directly. Return confirmati
 | refactor, cleanup         | CONCERNS.md, ARCHITECTURE.md    |
 | setup, config             | STACK.md, STRUCTURE.md          |
 
-**`/kata:kata-execute-phase`** references codebase docs to:
+**`/kata-execute-phase`** references codebase docs to:
 - Follow existing conventions when writing code
 - Know where to place new files (STRUCTURE.md)
 - Match testing patterns (TESTING.md)

--- a/skills/kata-verify-work/SKILL.md
+++ b/skills/kata-verify-work/SKILL.md
@@ -10,7 +10,7 @@ Validate built features through conversational testing with persistent state.
 
 Purpose: Confirm what Claude built actually works from user's perspective. One test at a time, plain text responses, no interrogation. When issues are found, automatically diagnose, plan fixes, and prepare for execution.
 
-Output: {phase}-UAT.md tracking all test results. If issues found: diagnosed gaps, verified fix plans ready for /kata:kata-execute-phase
+Output: {phase}-UAT.md tracking all test results. If issues found: diagnosed gaps, verified fix plans ready for /kata-execute-phase
 </objective>
 
 <execution_context>
@@ -46,7 +46,7 @@ Phase: $ARGUMENTS (optional)
    - Spawn kata-planner in --gaps mode to create fix plans
    - Spawn kata-plan-checker to verify fix plans
    - Iterate planner ↔ checker until plans pass (max 3)
-   - Present ready status with `/clear` then `/kata:kata-execute-phase`
+   - Present ready status with `/clear` then `/kata-execute-phase`
 </process>
 
 <step_7_5_pr_workflow>
@@ -153,7 +153,7 @@ Use AskUserQuestion with options based on what was found:
 3. Continue to offer_next
 
 **Path D: "Add to backlog"**
-1. Create issues for all findings using `/kata:kata-add-issue`
+1. Create issues for all findings using `/kata-add-issue`
 2. Store TODOS_CREATED count
 3. Continue to offer_next
 
@@ -224,15 +224,15 @@ UAT complete ✓
 
 **Phase {Z+1}: {Name}** — {Goal from ROADMAP.md}
 
-/kata:kata-discuss-phase {Z+1} — gather context and clarify approach
+/kata-discuss-phase {Z+1} — gather context and clarify approach
 
 <sub>/clear first → fresh context window</sub>
 
 ───────────────────────────────────────────────────────────────
 
 **Also available:**
-- /kata:kata-plan-phase {Z+1} — skip discussion, plan directly
-- /kata:kata-execute-phase {Z+1} — skip to execution (if already planned)
+- /kata-plan-phase {Z+1} — skip discussion, plan directly
+- /kata-execute-phase {Z+1} — skip to execution (if already planned)
 {If PR_WORKFLOW and not MERGED: - `gh pr view --web` — review PR in browser before next phase}
 
 ───────────────────────────────────────────────────────────────
@@ -280,14 +280,14 @@ Final phase verified ✓
 
 **Audit milestone** — verify requirements, cross-phase integration, E2E flows
 
-/kata:kata-audit-milestone
+/kata-audit-milestone
 
 <sub>/clear first → fresh context window</sub>
 
 ───────────────────────────────────────────────────────────────
 
 **Also available:**
-- /kata:kata-complete-milestone — skip audit, archive directly
+- /kata-complete-milestone — skip audit, archive directly
 {If PR_WORKFLOW and not MERGED: - `gh pr view --web` — review PR in browser before audit}
 
 ───────────────────────────────────────────────────────────────
@@ -316,7 +316,7 @@ Fix plans verified ✓
 
 **Execute fix plans** — run diagnosed fixes
 
-/kata:kata-execute-phase {Z} --gaps-only
+/kata-execute-phase {Z} --gaps-only
 
 <sub>/clear first → fresh context window</sub>
 
@@ -324,7 +324,7 @@ Fix plans verified ✓
 
 **Also available:**
 - cat ${PHASE_DIR}/*-PLAN.md — review fix plans
-- /kata:kata-plan-phase {Z} --gaps — regenerate fix plans
+- /kata-plan-phase {Z} --gaps — regenerate fix plans
 
 ───────────────────────────────────────────────────────────────
 
@@ -359,8 +359,8 @@ Review the issues above and either:
 ───────────────────────────────────────────────────────────────
 
 **Options:**
-- /kata:kata-plan-phase {Z} --gaps — retry fix planning with guidance
-- /kata:kata-discuss-phase {Z} — gather more context before replanning
+- /kata-plan-phase {Z} --gaps — retry fix planning with guidance
+- /kata-discuss-phase {Z} — gather more context before replanning
 
 ───────────────────────────────────────────────────────────────
 </offer_next>
@@ -375,5 +375,5 @@ Review the issues above and either:
 - [ ] If issues: parallel debug agents diagnose root causes
 - [ ] If issues: kata-planner creates fix plans from diagnosed gaps
 - [ ] If issues: kata-plan-checker verifies fix plans (max 3 iterations)
-- [ ] Ready for `/kata:kata-execute-phase` when complete
+- [ ] Ready for `/kata-execute-phase` when complete
 </success_criteria>

--- a/skills/kata-verify-work/references/UAT-template.md
+++ b/skills/kata-verify-work/references/UAT-template.md
@@ -98,7 +98,7 @@ skipped: [N]
 **Gaps:**
 - APPEND only when issue found (YAML format)
 - After diagnosis: fill `root_cause`, `artifacts`, `missing`, `debug_session`
-- This section feeds directly into /kata:kata-plan-phase --gaps
+- This section feeds directly into /kata-plan-phase --gaps
 
 </section_rules>
 
@@ -112,7 +112,7 @@ skipped: [N]
 4. UAT.md Gaps section updated with diagnosis:
    - Each gap gets `root_cause`, `artifacts`, `missing`, `debug_session` filled
 5. status → "diagnosed"
-6. Ready for /kata:kata-plan-phase --gaps with root causes
+6. Ready for /kata-plan-phase --gaps with root causes
 
 **After diagnosis:**
 ```yaml
@@ -136,7 +136,7 @@ skipped: [N]
 
 <lifecycle>
 
-**Creation:** When /kata:kata-verify-work starts new session
+**Creation:** When /kata-verify-work starts new session
 - Extract tests from SUMMARY.md files
 - Set status to "testing"
 - Current Test points to test 1

--- a/skills/kata-verify-work/references/diagnose-issues.md
+++ b/skills/kata-verify-work/references/diagnose-issues.md
@@ -226,7 +226,7 @@ Do NOT offer manual next steps - phase-verify handles the rest.
 
 **Agent times out:**
 - Check DEBUG-{slug}.md for partial progress
-- Can resume with /kata:kata-debug
+- Can resume with /kata-debug
 
 **All agents fail:**
 - Something systemic (permissions, git, etc.)

--- a/skills/kata-verify-work/references/plan-checker-instructions.md
+++ b/skills/kata-verify-work/references/plan-checker-instructions.md
@@ -4,7 +4,7 @@ You are a Kata plan checker. You verify that plans WILL achieve the phase goal, 
 
 You are spawned by:
 
-- `/kata:kata-plan-phase` orchestrator (after planner creates PLAN.md files)
+- `/kata-plan-phase` orchestrator (after planner creates PLAN.md files)
 - Re-verification (after planner revises based on your feedback)
 
 Your job: Goal-backward verification of PLANS before execution. Start from what the phase SHOULD deliver, verify the plans address it.
@@ -662,7 +662,7 @@ When all checks pass:
 
 ### Ready for Execution
 
-Plans verified. Run `/kata:kata-execute-phase {phase}` to proceed.
+Plans verified. Run `/kata-execute-phase {phase}` to proceed.
 ```
 
 ## ISSUES FOUND

--- a/skills/kata-verify-work/references/planner-instructions.md
+++ b/skills/kata-verify-work/references/planner-instructions.md
@@ -4,9 +4,9 @@ You are a Kata planner. You create executable phase plans with task breakdown, d
 
 You are spawned by:
 
-- `/kata:kata-plan-phase` orchestrator (standard phase planning)
-- `/kata:kata-plan-phase --gaps` orchestrator (gap closure planning from verification failures)
-- `/kata:kata-plan-phase` orchestrator in revision mode (updating plans based on checker feedback)
+- `/kata-plan-phase` orchestrator (standard phase planning)
+- `/kata-plan-phase --gaps` orchestrator (gap closure planning from verification failures)
+- `/kata-plan-phase` orchestrator in revision mode (updating plans based on checker feedback)
 
 Your job: Produce PLAN.md files that Claude executors can implement without interpretation. Plans are prompts, not documents that become prompts.
 
@@ -106,7 +106,7 @@ Discovery is MANDATORY unless you can prove current context exists.
 - Level 2+: New library not in package.json, external API, "choose/select/evaluate" in description
 - Level 3: "architecture/design/system", multiple external services, data modeling, auth design
 
-For niche domains (3D, games, audio, shaders, ML), suggest `/kata:kata-research-phase` before phase-plan.
+For niche domains (3D, games, audio, shaders, ML), suggest `/kata-research-phase` before phase-plan.
 
 </discovery_levels>
 
@@ -1142,10 +1142,10 @@ if [ -z "$PHASE_DIR" ]; then
   [ -z "$PHASE_DIR" ] && PHASE_DIR=$(find .planning/phases -maxdepth 1 -type d -name "${PHASE}-*" 2>/dev/null | head -1)
 fi
 
-# Read CONTEXT.md if exists (from /kata:kata-discuss-phase)
+# Read CONTEXT.md if exists (from /kata-discuss-phase)
 cat "${PHASE_DIR}"/*-CONTEXT.md 2>/dev/null
 
-# Read RESEARCH.md if exists (from /kata:kata-research-phase)
+# Read RESEARCH.md if exists (from /kata-research-phase)
 cat "${PHASE_DIR}"/*-RESEARCH.md 2>/dev/null
 
 # Read DISCOVERY.md if exists (from mandatory discovery)
@@ -1253,7 +1253,7 @@ Update ROADMAP.md to finalize phase placeholders created by phase-add or phase-i
 
 **Plans** (always update):
 - `**Plans:** 0 plans` → `**Plans:** {N} plans`
-- `**Plans:** (created by /kata:kata-plan-phase)` → `**Plans:** {N} plans`
+- `**Plans:** (created by /kata-plan-phase)` → `**Plans:** {N} plans`
 
 **Plan list** (always update):
 - Replace `Plans:\n- [ ] TBD ...` with actual plan checkboxes:
@@ -1316,7 +1316,7 @@ Return structured planning outcome to orchestrator.
 
 ### Next Steps
 
-Execute: `/kata:kata-execute-phase {phase}`
+Execute: `/kata-execute-phase {phase}`
 
 <sub>`/clear` first - fresh context window</sub>
 ```
@@ -1360,7 +1360,7 @@ Execute: `/kata:kata-execute-phase {phase}`
 
 ### Next Steps
 
-Execute: `/kata:kata-execute-phase {phase} --gaps-only`
+Execute: `/kata-execute-phase {phase} --gaps-only`
 ```
 
 ## Revision Complete
@@ -1426,6 +1426,6 @@ Planning complete when:
 - [ ] PLAN file(s) exist with gap_closure: true
 - [ ] Each plan: tasks derived from gap.missing items
 - [ ] PLAN file(s) committed to git
-- [ ] User knows to run `/kata:kata-execute-phase {X}` next
+- [ ] User knows to run `/kata-execute-phase {X}` next
 
 </success_criteria>

--- a/skills/kata-verify-work/references/verifier-instructions.md
+++ b/skills/kata-verify-work/references/verifier-instructions.md
@@ -479,7 +479,7 @@ score = (verified_truths / total_truths)
 
 ## Step 10: Structure Gap Output (If Gaps Found)
 
-When gaps are found, structure them for consumption by `/kata:kata-plan-phase --gaps`.
+When gaps are found, structure them for consumption by `/kata-plan-phase --gaps`.
 
 **Output structured gaps in YAML frontmatter:**
 
@@ -520,7 +520,7 @@ gaps:
 - `artifacts`: Which files have issues and what's wrong
 - `missing`: Specific things that need to be added/fixed
 
-The planner (`/kata:kata-plan-phase --gaps`) reads this gap analysis and creates appropriate plans.
+The planner (`/kata-plan-phase --gaps`) reads this gap analysis and creates appropriate plans.
 
 **Group related gaps by concern** when possible — if multiple truths fail because of the same root cause (e.g., "Chat component is a stub"), note this in the reason to help the planner create focused plans.
 
@@ -641,7 +641,7 @@ All must-haves verified. Phase goal achieved. Ready to proceed.
 2. **{Truth 2}** — {reason}
    - Missing: {what needs to be added}
 
-Structured gaps in VERIFICATION.md frontmatter for `/kata:kata-plan-phase --gaps`.
+Structured gaps in VERIFICATION.md frontmatter for `/kata-plan-phase --gaps`.
 
 {If human_needed:}
 
@@ -667,7 +667,7 @@ Automated checks passed. Awaiting human verification.
 
 **DO NOT skip key link verification.** This is where 80% of stubs hide. The pieces exist but aren't connected.
 
-**Structure gaps in YAML frontmatter.** The planner (`/kata:kata-plan-phase --gaps`) creates plans from your analysis.
+**Structure gaps in YAML frontmatter.** The planner (`/kata-plan-phase --gaps`) creates plans from your analysis.
 
 **DO flag for human verification when uncertain.** If you can't verify programmatically (visual, real-time, external service), say so explicitly.
 

--- a/skills/kata-verify-work/references/verify-work.md
+++ b/skills/kata-verify-work/references/verify-work.md
@@ -1,5 +1,5 @@
 <purpose>
-Validate built features through conversational testing with persistent state. Creates UAT.md that tracks test progress, survives /clear, and feeds gaps into /kata:kata-plan-phase --gaps.
+Validate built features through conversational testing with persistent state. Creates UAT.md that tracks test progress, survives /clear, and feeds gaps into /kata-plan-phase --gaps.
 
 User tests, Claude records. One test at a time. Plain text responses.
 </purpose>
@@ -78,7 +78,7 @@ If no, continue to `create_uat_file`.
 ```
 No active UAT sessions.
 
-Provide a phase number to start testing (e.g., /kata:kata-verify-work 4)
+Provide a phase number to start testing (e.g., /kata-verify-work 4)
 ```
 
 **If no active sessions AND $ARGUMENTS provided:**
@@ -353,8 +353,8 @@ Present summary:
 ```
 All tests passed. Ready to continue.
 
-- `/kata:kata-plan-phase {next}` — Plan next phase
-- `/kata:kata-execute-phase {next}` — Execute next phase
+- `/kata-plan-phase {next}` — Plan next phase
+- `/kata-execute-phase {next}` — Execute next phase
 ```
 </step>
 
@@ -420,7 +420,7 @@ Task(
 </planning_context>
 
 <downstream_consumer>
-Output consumed by /kata:kata-execute-phase
+Output consumed by /kata-execute-phase
 Plans must be executable prompts.
 </downstream_consumer>
 """,
@@ -527,7 +527,7 @@ Display: `Max iterations reached. {N} issues remain.`
 Offer options:
 1. Force proceed (execute despite issues)
 2. Provide guidance (user gives direction, retry)
-3. Abandon (exit, user runs /kata:kata-plan-phase manually)
+3. Abandon (exit, user runs /kata-plan-phase manually)
 
 Wait for user response.
 </step>
@@ -555,7 +555,7 @@ Plans verified and ready for execution.
 
 **Execute fixes** — run fix plans
 
-`/clear` then `/kata:kata-execute-phase {phase} --gaps-only`
+`/clear` then `/kata-execute-phase {phase} --gaps-only`
 
 ───────────────────────────────────────────────────────────────
 
@@ -609,5 +609,5 @@ Default to **major** if unclear. User can correct if needed.
 - [ ] If issues: kata-planner creates fix plans (gap_closure mode)
 - [ ] If issues: kata-plan-checker verifies fix plans
 - [ ] If issues: revision loop until plans pass (max 3 iterations)
-- [ ] Ready for `/kata:kata-execute-phase --gaps-only` when complete
+- [ ] Ready for `/kata-execute-phase --gaps-only` when complete
 </success_criteria>

--- a/tasks/prd-skills-only-architecture.md
+++ b/tasks/prd-skills-only-architecture.md
@@ -323,11 +323,11 @@ Migrate Kata from a hybrid skills + agents architecture to a 100% skills-based m
 **Description:** As a developer, I want to validate that the entire Kata workflow works with skills-only.
 
 **Acceptance Criteria:**
-- [ ] Run `/kata:kata-new-project` end-to-end - all skills spawn correctly
-- [ ] Run `/kata:kata-plan-phase` end-to-end - research/plan/check skills work
-- [ ] Run `/kata:kata-execute-phase` end-to-end - executor skills work in parallel
-- [ ] Run `/kata:kata-verify-work` end-to-end - verifier/debugger skills work
-- [ ] Run `/kata:kata-review-pull-requests` end-to-end - review skills work in parallel
+- [ ] Run `/kata-new-project` end-to-end - all skills spawn correctly
+- [ ] Run `/kata-plan-phase` end-to-end - research/plan/check skills work
+- [ ] Run `/kata-execute-phase` end-to-end - executor skills work in parallel
+- [ ] Run `/kata-verify-work` end-to-end - verifier/debugger skills work
+- [ ] Run `/kata-review-pull-requests` end-to-end - review skills work in parallel
 - [ ] All existing skill tests pass
 - [ ] No regressions in user-facing behavior
 
@@ -346,7 +346,7 @@ Migrate Kata from a hybrid skills + agents architecture to a 100% skills-based m
 
 ## Non-Goals
 
-- No changes to user-facing skill invocation (`/kata:kata-plan-phase`, etc.)
+- No changes to user-facing skill invocation (`/kata-plan-phase`, etc.)
 - No changes to planning file formats (PLAN.md, SUMMARY.md, etc.)
 - No changes to checkpoint or verification workflows
 - No new features - this is a refactoring migration

--- a/tests/README.md
+++ b/tests/README.md
@@ -317,7 +317,7 @@ assertFileStructure(testDir, [
 ]);
 
 // Good: Test "Next Up" proposal
-assertNextStepProposed(result, '/kata:kata-execute-phase');
+assertNextStepProposed(result, '/kata-execute-phase');
 
 // Avoid: Testing exact prose (brittle)
 assert(result.result.includes('I have created the plan'));
@@ -333,7 +333,7 @@ import { assertNextStepProposed } from '../harness/assertions.js';
 const result = invokeClaude('plan phase 1', { cwd: testDir });
 
 // Verify skill proposed execute-phase as next step
-assertNextStepProposed(result, '/kata:kata-execute-phase');
+assertNextStepProposed(result, '/kata-execute-phase');
 ```
 
 ### Test Isolation Best Practices
@@ -390,7 +390,7 @@ describe('kata-plan-phase (orchestrator)', () => {
     );
 
     // Verify orchestrator proposed next step
-    assertNextStepProposed(result, '/kata:kata-execute-phase');
+    assertNextStepProposed(result, '/kata-execute-phase');
   });
 });
 ```
@@ -476,7 +476,7 @@ it('spawns planner agent (verified by output)', () => {
 
 ```javascript
 it('provides help text', () => {
-  const result = invokeClaude('/kata:kata-providing-help', { cwd: testDir });
+  const result = invokeClaude('/kata-providing-help', { cwd: testDir });
   assertNoError(result);
   assertResultContains(result, '/kata:');  // Lists available commands
 });

--- a/tests/harness/assertions.js
+++ b/tests/harness/assertions.js
@@ -94,7 +94,7 @@ export function assertResultContains(result, expected, message) {
  * Kata skills output a standardized "Next Up" section with a suggested command.
  *
  * @param {Object} result - Claude JSON response
- * @param {string} expectedCommand - Command substring to match (e.g., '/kata:kata-execute-phase')
+ * @param {string} expectedCommand - Command substring to match (e.g., '/kata-execute-phase')
  * @param {string} [message] - Custom failure message
  */
 export function assertNextStepProposed(result, expectedCommand, message) {

--- a/tests/skills/discussing-phases.test.js
+++ b/tests/skills/discussing-phases.test.js
@@ -45,7 +45,7 @@ describe('kata-discuss-phase', () => {
 **Plans:** 0 plans
 
 Plans:
-- [ ] TBD (run /kata:kata-plan-phase 1 to break down)
+- [ ] TBD (run /kata-plan-phase 1 to break down)
 
 **Details:**
 Users should be able to register, login, logout, and manage their sessions.


### PR DESCRIPTION
## Summary

Removes the `kata:` plugin namespace prefix from all skill invocations. The prefix was required for plugin distribution (`/kata:kata-plan-phase`) but breaks skills-based installation (`npx skills add`). With dual distribution, invocations should work without the namespace.

- `/kata:kata-plan-phase` → `/kata-plan-phase`
- 90 files changed, 570 replacements
- All 44 tests passing