### PR TITLE
v1.6.1: namespace fix

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kata",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Spec-driven development framework for Claude Code. Provides structured workflows for requirements gathering, research, planning, execution, and verification.",
   "author": {
     "name": "gannonh",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [1.6.1] - 2026-02-06
+
+### Fixed
+- Remove `kata:` plugin namespace prefix from all skill invocations (breaks skills-based install)
+- Remove `agents/` directory checks from CI pipeline and artifact validation tests
+
 ## [1.6.0] - 2026-02-06 — Skills-Native Subagents
 
 Kata v1.6.0 ships **Skills-Native Subagents**: all 19 custom agent types migrated to skill resources with general-purpose subagent spawning, making Kata portable across Agent Skills-compatible platforms.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gannonh/kata",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "type": "module",
   "description": "Spec-driven development framework for Claude Code.",
   "scripts": {


### PR DESCRIPTION
## Summary

Patch release with namespace prefix removal and CI fix.

### Fixed
- Remove `kata:` plugin namespace prefix from all skill invocations (breaks skills-based install)
- Remove `agents/` directory checks from CI pipeline and artifact validation tests

### Release Files
- `package.json` — 1.6.0 → 1.6.1
- `.claude-plugin/plugin.json` — 1.6.0 → 1.6.1
- `CHANGELOG.md` — v1.6.1 entry added