### PR TITLE
fix: bump package.json to 1.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gannonh/kata",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "type": "module",
   "description": "Spec-driven development framework for Claude Code.",
   "scripts": {


### PR DESCRIPTION
## Summary

Fixes CI failure from v1.7.0 release — `package.json` version was not bumped alongside `plugin.json`.

- `package.json` 1.6.1 → 1.7.0
- Test: `package.json and plugin.json have same version` now passes