### PR TITLE
chore: accumulated fixes, config updates, and planning artifacts

### DIFF
--- a/.planning/config.json
+++ b/.planning/config.json
@@ -6,7 +6,7 @@
   "pr_workflow": true,
   "model_profile": "quality",
   "display": {
-    "statusline": true
+    "statusline": false
   },
   "workflow": {
     "research": true,
@@ -16,5 +16,16 @@
   "github": {
     "enabled": true,
     "issueMode": "auto"
+  },
+  "workflows": {
+    "execute-phase": {
+      "post_task_command": "npm run build:plugin && npm test"
+    },
+    "verify-work": {
+      "extra_verification_commands": "[\"npm run build:plugin\", \"npm test\", \"npm run test:smoke\"]"
+    },
+    "complete-milestone": {
+      "version_files": "[\"package.json\", \".claude-plugin/plugin.json\"]"
+    }
   }
 }

--- a/.planning/phases/completed/38-template-overrides/38-UAT.md
+++ b/.planning/phases/completed/38-template-overrides/38-UAT.md
@@ -1,0 +1,59 @@
+---
+status: testing
+phase: 38-template-overrides
+source: [38-01-SUMMARY.md, 38-02-SUMMARY.md]
+started: 2026-02-08T15:00:00Z
+updated: 2026-02-08T15:00:00Z
+---
+
+## Current Test
+<!-- OVERWRITE each test - shows where we are -->
+
+number: 1
+name: Five standalone template files exist with schema comments
+expected: |
+  Running: `for f in skills/kata-complete-milestone/references/changelog-entry.md skills/kata-plan-phase/references/plan-template.md skills/kata-verify-work/references/verification-report.md skills/kata-execute-phase/references/summary-template.md skills/kata-verify-work/references/UAT-template.md; do head -3 "$f"; echo "---"; done`
+  Each file exists and starts with `<!-- kata-template-schema`
+awaiting: user response
+
+## Tests
+
+### 1. Five standalone template files exist with schema comments
+expected: All 5 template files exist in their skill's references/ directory, each starting with a kata-template-schema HTML comment
+result: [pending]
+
+### 2. resolve-template.sh returns plugin default when no override
+expected: Running `CLAUDE_PLUGIN_ROOT="$(pwd)" bash skills/kata-execute-phase/scripts/resolve-template.sh summary-template.md` returns a path to skills/kata-execute-phase/references/summary-template.md
+result: [pending]
+
+### 3. resolve-template.sh returns project override when present
+expected: Creating .planning/templates/summary-template.md and running resolve-template.sh returns the project override path instead of the plugin default
+result: [pending]
+
+### 4. Four orchestrator skills reference resolve-template.sh
+expected: Running `grep -l "resolve-template.sh" skills/kata-execute-phase/references/phase-execute.md skills/kata-complete-milestone/references/milestone-complete.md skills/kata-verify-work/references/verify-work.md skills/kata-plan-phase/SKILL.md` returns all 4 files
+result: [pending]
+
+### 5. Drift hook emits nothing when no .planning/templates/ exists
+expected: Running `echo '{"cwd":"'"$(pwd)"'"}' | CLAUDE_PLUGIN_ROOT="$(pwd)" node hooks/kata-template-drift.js` produces no output
+result: [pending]
+
+### 6. Drift hook warns when project override is missing required fields
+expected: Creating a minimal .planning/templates/summary-template.md and running the drift hook emits a warning about missing required fields
+result: [pending]
+
+### 7. hooks.json registers both session-start hooks
+expected: hooks/hooks.json contains both kata-setup-statusline.js and kata-template-drift.js entries
+result: [pending]
+
+## Summary
+
+total: 7
+passed: 0
+issues: 0
+pending: 7
+skipped: 0
+
+## Gaps
+
+[none yet]

--- a/.planning/proposals/testing-hardening.md
+++ b/.planning/proposals/testing-hardening.md
@@ -1,0 +1,144 @@
+# Proposal: Testing Hardening & Regression Prevention
+
+## Problem
+
+Regressions in bash scripts and hooks. All three bugs documented in MEMORY.md originated in untested bash scripts. Zero unit tests exist for 5 bash scripts and 4 hooks. Skill integration tests (28 files) test through Claude CLI invocation but can't isolate script-level failures.
+
+## Current Coverage
+
+| Layer | Files | Tests | Gap |
+|-------|-------|-------|-----|
+| Build system | build.js | build.test.js, smoke.test.js, artifact-validation.test.js | Covered |
+| Architecture | migration rules | migration-validation.test.js | Covered |
+| Skill workflows | 30 SKILL.md files | 28 skill integration tests (Claude CLI) | Mostly covered |
+| Bash scripts | 5 scripts | 0 tests | **Zero coverage** |
+| Hooks | 4 hooks | 0 tests | **Zero coverage** |
+| Multi-skill chains | plan→execute→verify | 0 tests | **Zero coverage** |
+| Error/edge cases | various | 0 tests | **Zero coverage** |
+
+## Documented Regressions (from MEMORY.md)
+
+1. **find-phase.sh: missing state directories** — `find` exits non-zero when directory missing, `pipefail` kills script silently
+2. **find-phase.sh: bash vs zsh** — tests passed in zsh but failed in bash due to different `pipefail` handling
+3. **Phase directory move not staged in git** — `mv` moves directory on filesystem but git staging only catches specific files, not the directory move
+4. **gh issue list --milestone with closed milestones** — returns empty silently, causing missing `Closes #N` lines in PR bodies
+
+## Proposed Work
+
+### Phase A: Extract Inline Bash into Testable Scripts
+
+Extract duplicated and regression-prone inline bash from SKILL.md files into standalone scripts in each skill's `scripts/` directory.
+
+**High-value extractions:**
+
+1. **discover-phases.sh** — The `for state in active pending completed; do find...` pattern is copy-pasted across ~6 skills. Already caused 2 bugs. Single script replaces all instances.
+
+2. **resolve-milestone-issues.sh** — The `gh api` two-step lookup (resolve milestone title to number via `milestones?state=all`, then query issues by number) is duplicated in 4 skills after the closed-milestone fix. One script eliminates that duplication.
+
+3. **stage-phase-move.sh** — The `git add`/`git rm` sequence for moving phase directories between `pending/active/completed`. Caused the "phase directory move not staged" bug.
+
+**Extraction criteria (what to extract vs leave inline):**
+- Extract: complex logic with loops/conditionals, code duplicated across skills, code that has caused bugs
+- Leave inline: single `cat`/`grep` lines, output formatting, one-liner file checks
+
+**Existing examples of this pattern:** `find-phase.sh`, `resolve-template.sh`, `read-pref.sh`, `has-pref.sh`, `set-config.sh` — all previously extracted from inline bash.
+
+### Phase B: Bash Script Unit Tests
+
+Add bats-core (Bash Automated Testing System) for script-level unit testing.
+
+**Infrastructure:**
+- Install bats-core as dev dependency
+- Create `tests/scripts/` directory
+- Add `npm run test:scripts` command
+- Wire into CI (`npm test` should include script tests)
+
+**Test files to create:**
+
+| Script | Test Cases |
+|--------|------------|
+| find-phase.sh | missing state dirs, empty results, pipefail in bash, multiple matches, flat dir fallback |
+| read-pref.sh | missing files, invalid JSON, nested keys, fallback chain, type resolution |
+| has-pref.sh | key in prefs only, key in config only, nested keys, absent key, defaults ignored |
+| set-config.sh | flat keys, nested keys, type coercion (bool/number/string), atomic write, concurrent writes |
+| resolve-template.sh | override present, override absent, missing template, glob expansion |
+| discover-phases.sh | (from Phase A) all state combos, empty dirs, backward compat |
+| resolve-milestone-issues.sh | (from Phase A) open milestone, closed milestone, no issues, multiple issues |
+| stage-phase-move.sh | (from Phase A) pending→active, active→completed, git status verification |
+
+**Regression tests from MEMORY.md (named, permanent):**
+- `find-phase-missing-directory.bats` — state directory doesn't exist
+- `find-phase-pipefail-bash.bats` — explicit `/bin/bash` execution, not zsh
+- `gh-milestone-closed.bats` — milestone in closed state returns issues
+
+### Phase C: Hook Unit Tests
+
+Test hooks using Node.js built-in test runner (already in use).
+
+**Infrastructure:**
+- Create `tests/hooks/` directory
+- Mock stdin input (`{"cwd":"/path/to/project"}`)
+- Capture stdout/stderr for assertion
+- Add `npm run test:hooks` command
+
+**Test files to create:**
+
+| Hook | Test Cases |
+|------|------------|
+| kata-config-validator.js | valid config silent, unknown key warns, invalid enum errors, invalid boolean errors, invalid array errors, broken JSON silent, always exits 0 |
+| kata-template-drift.js | no overrides silent, complete override silent, missing fields warns, multiple templates, no .planning/templates/ dir silent |
+| kata-setup-statusline.js | settings.json created/updated, existing settings preserved |
+| kata-plugin-statusline.js | status line output format |
+
+### Phase D: Affected Test Detection + CI Hardening
+
+**Extend affected.js dependency graph:**
+- If `read-pref.sh` changes → re-test all skills that use it (execute-phase, verify-work, complete-milestone, configure-settings, plan-phase)
+- If a hook changes → re-test the hook
+- If `find-phase.sh` changes → re-test execute-phase, audit-milestone, track-progress
+- Map: `scripts/*.sh` → skills that reference them → skill tests
+
+**CI additions:**
+- `npm run test:scripts` in release pipeline (before artifact validation)
+- `npm run test:hooks` in release pipeline
+- shellcheck lint pass on all `.sh` files
+
+## Requirements Sketch
+
+### Script Extraction
+- [ ] Phase discovery pattern extracted into standalone script, called from all skills that use it
+- [ ] GitHub milestone-to-issue lookup extracted, called from all skills that use it
+- [ ] Phase move git staging extracted, called from kata-execute-phase
+- [ ] All SKILL.md files updated to call scripts instead of inline bash
+- [ ] No behavioral changes (pure refactor)
+
+### Bash Testing
+- [ ] bats-core installed and wired into `npm run test:scripts`
+- [ ] Every bash script in `scripts/` has a corresponding `.bats` test file
+- [ ] Every MEMORY.md bug has a named regression test
+- [ ] Tests run in `/bin/bash` explicitly (not default shell)
+- [ ] CI runs script tests before artifact validation
+
+### Hook Testing
+- [ ] Hook tests use Node.js test runner with mocked stdin
+- [ ] Every hook has tests for valid input, invalid input, and edge cases
+- [ ] All hooks verified to exit 0 regardless of input
+- [ ] CI runs hook tests
+
+### Affected Detection
+- [ ] Script changes trigger downstream skill tests
+- [ ] Hook changes trigger hook tests
+- [ ] shellcheck runs on all `.sh` files in CI
+
+## Out of Scope
+
+- Multi-skill workflow integration tests (plan→execute→verify chain) — high value but expensive (Claude invocation), defer to separate milestone
+- Skill integration test expansion — existing 28 tests provide adequate workflow coverage
+- Performance testing — not a current concern
+- Security testing — bash scripts don't handle user input from external sources
+
+## Source
+
+- Milestone audit conversation (2026-02-08)
+- MEMORY.md bug documentation
+- Test infrastructure exploration of tests/ directory

--- a/.planning/v1.8.0-MANUAL-TEST.md
+++ b/.planning/v1.8.0-MANUAL-TEST.md
@@ -1,0 +1,680 @@
+# v1.8.0 Adaptive Workflows - Manual Testing Script
+
+**Milestone:** v1.8.0 Adaptive Workflows  
+**Tested:** _______  
+**Tester:** _______
+
+---
+
+## Project Setup
+
+### 1. Create Fresh Test Project
+
+```bash
+# Navigate to a temp directory
+cd /tmp
+mkdir kata-v180-test && cd kata-v180-test
+git init
+
+# Create minimal project structure
+mkdir -p .planning/templates
+echo '{}' > .planning/preferences.json
+echo '{}' > .planning/config.json
+```
+
+### 2. Install Kata Plugin
+
+Ensure kata-orchestrator is installed as a Claude Code plugin in the test project.
+
+```bash
+# If not already configured, link the development plugin:
+cp -r /Users/gannonhall/dev/kata/kata-orchestrator/dist/plugin ~/.claude/extensions/kata-orchestrator
+```
+
+---
+
+## Phase 37: Preferences Infrastructure & Progressive Capture
+
+### PREF-01: Preferences Storage ✅/❌
+
+**Test:** Verify preferences are stored in `.planning/preferences.json` with flat dot-notation keys.
+
+```bash
+# Set a preference in preferences.json
+cat > .planning/preferences.json << 'EOF'
+{
+  "release.changelog_format": "keep-a-changelog",
+  "docs.readme_on_milestone": "prompt"
+}
+EOF
+
+# Verify structure
+cat .planning/preferences.json | jq .
+```
+
+**Expected:** JSON file with flat dot-notation keys as shown above.
+
+**Result:** [ PASS / FAIL ] _______
+
+---
+
+### PREF-02: read-pref.sh Resolution Chain ✅/❌
+
+**Test:** Verify `read-pref.sh` resolves in order: preferences.json → config.json → defaults → fallback.
+
+```bash
+SCRIPT_DIR="/Users/gannonhall/dev/kata/kata-orchestrator/skills/kata-configure-settings/scripts"
+
+# Test 1: Read from preferences.json (highest priority)
+echo '{"release.changelog_format": "npm"}' > .planning/preferences.json
+echo '{}' > .planning/config.json
+RESULT=$(bash "$SCRIPT_DIR/read-pref.sh" "release.changelog_format")
+echo "From prefs: $RESULT" # Should be: npm
+[ "$RESULT" = "npm" ] && echo "✅ Prefs priority" || echo "❌ Prefs priority failed"
+
+# Test 2: Fallback to config.json
+echo '{}' > .planning/preferences.json
+echo '{"release": {"changelog_format": "semantic"}}' > .planning/config.json
+RESULT=$(bash "$SCRIPT_DIR/read-pref.sh" "release.changelog_format")
+echo "From config: $RESULT" # Should be: semantic
+[ "$RESULT" = "semantic" ] && echo "✅ Config fallback" || echo "❌ Config fallback failed"
+
+# Test 3: Fallback to built-in default
+echo '{}' > .planning/preferences.json
+echo '{}' > .planning/config.json
+RESULT=$(bash "$SCRIPT_DIR/read-pref.sh" "model_profile")
+echo "From default: $RESULT" # Should be: balanced
+[ "$RESULT" = "balanced" ] && echo "✅ Default fallback" || echo "❌ Default fallback failed"
+
+# Test 4: Fallback to explicit fallback arg
+RESULT=$(bash "$SCRIPT_DIR/read-pref.sh" "nonexistent.key" "my-fallback")
+echo "From fallback arg: $RESULT" # Should be: my-fallback
+[ "$RESULT" = "my-fallback" ] && echo "✅ Explicit fallback" || echo "❌ Explicit fallback failed"
+```
+
+**Result:** [ PASS / FAIL ] _______
+
+---
+
+### PREF-03: has-pref.sh Detection ✅/❌
+
+**Test:** Verify `has-pref.sh` returns exit 0 when user has expressed preference, exit 1 otherwise.
+
+```bash
+SCRIPT_DIR="/Users/gannonhall/dev/kata/kata-orchestrator/skills/kata-configure-settings/scripts"
+
+# Test 1: Key exists in preferences.json
+echo '{"mode": "yolo"}' > .planning/preferences.json
+echo '{}' > .planning/config.json
+bash "$SCRIPT_DIR/has-pref.sh" "mode" && echo "✅ Found in prefs" || echo "❌ Should find in prefs"
+
+# Test 2: Key exists in config.json (nested)
+echo '{}' > .planning/preferences.json
+echo '{"workflow": {"research": true}}' > .planning/config.json
+bash "$SCRIPT_DIR/has-pref.sh" "workflow.research" && echo "✅ Found in config" || echo "❌ Should find in config"
+
+# Test 3: Key does NOT exist anywhere
+echo '{}' > .planning/preferences.json
+echo '{}' > .planning/config.json
+bash "$SCRIPT_DIR/has-pref.sh" "nonexistent.key" && echo "❌ Should NOT find" || echo "✅ Correctly not found"
+```
+
+**Result:** [ PASS / FAIL ] _______
+
+---
+
+### PREF-04: New Project Scaffolds preferences.json ✅/❌
+
+**Test:** Verify `kata-new-project` skill scaffolds empty `preferences.json`.
+
+**Steps:**
+1. Start a new Claude Code chat in an empty directory
+2. Invoke: "new project"
+3. Complete onboarding questions
+
+**Expected:** `.planning/preferences.json` created as empty object `{}`
+
+**Result:** [ PASS / FAIL ] _______
+
+---
+
+### PREF-05: Built-in Defaults Coverage ✅/❌
+
+**Test:** Verify all 23 known preference keys have defaults in `read-pref.sh`.
+
+```bash
+# List all default keys from read-pref.sh
+grep -oP "'\K[^']+(?=': )" /Users/gannonhall/dev/kata/kata-orchestrator/skills/kata-configure-settings/scripts/read-pref.sh | sort
+
+# Expected keys (23 total):
+# commit_docs
+# conventions.commit_format
+# depth
+# display.statusline
+# docs.auto_update_files
+# docs.readme_on_milestone
+# github.enabled
+# github.issueMode
+# mode
+# model_profile
+# pr_workflow
+# release.changelog
+# release.changelog_format
+# release.version_bump
+# workflow.plan_check
+# workflow.research
+# workflow.verifier
+# workflows.complete-milestone.pre_release_commands
+# workflows.complete-milestone.version_files
+# workflows.execute-phase.commit_scope_format
+# workflows.execute-phase.commit_style
+# workflows.execute-phase.post_task_command
+# workflows.verify-work.extra_verification_commands
+```
+
+**Result:** [ PASS / FAIL ] _______
+
+---
+
+### CAP-01: Onboarding Reduced to 5 Questions ✅/❌
+
+**Test:** Verify new project onboarding asks 5 base questions (+ conditional follow-ups).
+
+**Steps:**
+1. Start a new Claude Code chat
+2. Invoke: "new project"
+3. Count the questions asked
+
+**Expected Questions:**
+1. Project name
+2. Project overview/description
+3. Tech stack
+4. Primary directory structure
+5. GitHub integration (if applicable)
+
+**Conditional:** Follow-ups for GitHub issue mode, repo creation (based on answers)
+
+**Result:** [ PASS / FAIL ] _______
+
+---
+
+### CAP-02: model_profile Deferred via Check-or-Ask ✅/❌
+
+**Test:** Verify `model_profile` is NOT asked during onboarding, but prompts on first `plan-phase`.
+
+**Steps:**
+1. Complete new project setup
+2. Add a milestone
+3. Invoke: "plan phase 1"
+4. Observe check-or-ask prompt for model profile
+
+**Expected:** User sees model profile selection on first plan, not during onboarding.
+
+**Result:** [ PASS / FAIL ] _______
+
+---
+
+### CAP-03: Workflow Agent Toggles Default to True ✅/❌
+
+**Test:** Verify workflow toggles (research, plan_check, verifier) default to true with first-run notice.
+
+```bash
+SCRIPT_DIR="/Users/gannonhall/dev/kata/kata-orchestrator/skills/kata-configure-settings/scripts"
+
+# Clean slate
+echo '{}' > .planning/preferences.json
+echo '{}' > .planning/config.json
+
+RESEARCH=$(bash "$SCRIPT_DIR/read-pref.sh" "workflow.research")
+PLAN_CHECK=$(bash "$SCRIPT_DIR/read-pref.sh" "workflow.plan_check")
+VERIFIER=$(bash "$SCRIPT_DIR/read-pref.sh" "workflow.verifier")
+
+echo "workflow.research: $RESEARCH"     # Should be: true
+echo "workflow.plan_check: $PLAN_CHECK" # Should be: true
+echo "workflow.verifier: $VERIFIER"     # Should be: true
+```
+
+**Result:** [ PASS / FAIL ] _______
+
+---
+
+### CAP-04: set-config.sh Atomic Write ✅/❌
+
+**Test:** Verify `set-config.sh` handles JSON parse, nested key set, type coercion, atomic write.
+
+```bash
+SCRIPT_DIR="/Users/gannonhall/dev/kata/kata-orchestrator/skills/kata-configure-settings/scripts"
+
+# Start fresh
+echo '{}' > .planning/config.json
+
+# Test 1: Set nested key
+bash "$SCRIPT_DIR/set-config.sh" "workflows.execute-phase.commit_style" "semantic"
+cat .planning/config.json | jq '.workflows."execute-phase".commit_style'
+# Should output: "semantic"
+
+# Test 2: Boolean coercion
+bash "$SCRIPT_DIR/set-config.sh" "pr_workflow" "true"
+cat .planning/config.json | jq '.pr_workflow'
+# Should output: true (boolean, not string)
+
+# Test 3: Number coercion
+bash "$SCRIPT_DIR/set-config.sh" "some.number" "42"
+cat .planning/config.json | jq '.some.number'
+# Should output: 42 (number, not string)
+
+# Test 4: Atomic write (no partial writes on failure)
+ls .planning/config.json.tmp 2>/dev/null && echo "❌ Temp file left behind" || echo "✅ Clean atomic write"
+```
+
+**Result:** [ PASS / FAIL ] _______
+
+---
+
+### CAP-05: Dead parallelization Key Removed ✅/❌
+
+**Test:** Verify `parallelization` key removed from onboarding, config schema, and settings skill.
+
+```bash
+# Should NOT find parallelization in new-project skill
+grep -r "parallelization" /Users/gannonhall/dev/kata/kata-orchestrator/skills/kata-new-project/ && \
+  echo "❌ Found in new-project" || echo "✅ Removed from new-project"
+
+# Check if config-validator includes it (it may for deprecation warning)
+grep "parallelization" /Users/gannonhall/dev/kata/kata-orchestrator/hooks/kata-config-validator.js
+# Note: May still exist in KNOWN_KEYS for validation purposes
+```
+
+**Result:** [ PASS / FAIL ] _______
+
+---
+
+## Phase 38: Template Overrides
+
+### TMPL-01: Five Templates Extracted ✅/❌
+
+**Test:** Verify 5 standalone templates exist in skills with schema comments.
+
+```bash
+# Check for key templates with schema comments
+for skill in kata-plan-phase kata-execute-phase kata-complete-milestone; do
+  echo "=== $skill ==="
+  ls /Users/gannonhall/dev/kata/kata-orchestrator/skills/$skill/references/*.md 2>/dev/null | head -5
+done
+
+# Verify schema comment exists
+grep -l "kata-template-schema" /Users/gannonhall/dev/kata/kata-orchestrator/skills/*/references/*.md | wc -l
+# Should have multiple templates with schema comments
+```
+
+**Result:** [ PASS / FAIL ] _______
+
+---
+
+### TMPL-02: resolve-template.sh Resolution ✅/❌
+
+**Test:** Verify template resolution checks `.planning/templates/` first, then falls back to plugin.
+
+```bash
+SCRIPT_DIR="/Users/gannonhall/dev/kata/kata-orchestrator/skills/kata-execute-phase/scripts"
+
+# Test 1: Project override takes priority
+mkdir -p .planning/templates
+echo "# Custom Plan Template" > .planning/templates/plan-template.md
+RESULT=$(bash "$SCRIPT_DIR/resolve-template.sh" "plan-template.md")
+echo "Resolved: $RESULT"
+[[ "$RESULT" == *".planning/templates/plan-template.md" ]] && \
+  echo "✅ Override takes priority" || echo "❌ Override not prioritized"
+
+# Test 2: Fallback to plugin default
+rm -rf .planning/templates
+RESULT=$(bash "$SCRIPT_DIR/resolve-template.sh" "plan-template.md")
+echo "Fallback: $RESULT"
+[[ "$RESULT" == *"/skills/kata-"* ]] && \
+  echo "✅ Falls back to plugin" || echo "❌ Fallback failed"
+```
+
+**Result:** [ PASS / FAIL ] _______
+
+---
+
+### TMPL-03: Templates Include Schema Comments ✅/❌
+
+**Test:** Verify each template includes schema comment listing required fields.
+
+```bash
+# Check plan-template.md for schema
+head -20 /Users/gannonhall/dev/kata/kata-orchestrator/skills/kata-plan-phase/references/plan-template.md
+
+# Should show:
+# <!-- kata-template-schema
+# required-fields:
+#   frontmatter: [phase, plan, type, wave, depends_on, files_modified, autonomous, must_haves]
+#   body: [objective, execution_context, context, tasks, verification, success_criteria, output]
+```
+
+**Result:** [ PASS / FAIL ] _______
+
+---
+
+### TMPL-04: Session-Start Drift Detection ✅/❌
+
+**Test:** Verify `kata-template-drift.js` hook detects missing required fields in override templates.
+
+```bash
+# Create override with missing required field
+mkdir -p .planning/templates
+cat > .planning/templates/plan-template.md << 'EOF'
+---
+phase: test
+plan: 1
+---
+# Missing most required fields
+EOF
+
+# Run the drift detector manually
+CLAUDE_PLUGIN_ROOT="/Users/gannonhall/dev/kata/kata-orchestrator" \
+  echo '{"cwd": "'$(pwd)'"}' | node /Users/gannonhall/dev/kata/kata-orchestrator/hooks/kata-template-drift.js
+
+# Should output warning about missing fields
+```
+
+**Expected:** `[kata] Template drift: plan-template.md missing required field(s): type, wave, depends_on...`
+
+**Result:** [ PASS / FAIL ] _______
+
+---
+
+## Phase 39: Config Workflow Variants & Settings
+
+### WKFL-01: config.json Workflows Section ✅/❌
+
+**Test:** Verify `config.json` supports `workflows` section with per-skill keys.
+
+```bash
+cat > .planning/config.json << 'EOF'
+{
+  "mode": "yolo",
+  "workflows": {
+    "execute-phase": {
+      "post_task_command": "npm test",
+      "commit_style": "semantic",
+      "commit_scope_format": "{phase}"
+    },
+    "verify-work": {
+      "extra_verification_commands": ["npm run lint"]
+    },
+    "complete-milestone": {
+      "version_files": ["package.json"],
+      "pre_release_commands": ["npm run build"]
+    }
+  }
+}
+EOF
+
+# Validate structure
+cat .planning/config.json | jq '.workflows'
+```
+
+**Result:** [ PASS / FAIL ] _______
+
+---
+
+### WKFL-02: kata-execute-phase Reads Config ✅/❌
+
+**Test:** Verify `kata-execute-phase` reads `workflows.execute-phase` config.
+
+```bash
+SCRIPT_DIR="/Users/gannonhall/dev/kata/kata-orchestrator/skills/kata-configure-settings/scripts"
+
+echo '{"workflows": {"execute-phase": {"commit_style": "semantic"}}}' > .planning/config.json
+echo '{}' > .planning/preferences.json
+
+RESULT=$(bash "$SCRIPT_DIR/read-pref.sh" "workflows.execute-phase.commit_style")
+echo "commit_style: $RESULT"  # Should be: semantic
+```
+
+**Result:** [ PASS / FAIL ] _______
+
+---
+
+### WKFL-03: kata-verify-work Reads Config ✅/❌
+
+**Test:** Verify `kata-verify-work` reads `workflows.verify-work` config.
+
+```bash
+SCRIPT_DIR="/Users/gannonhall/dev/kata/kata-orchestrator/skills/kata-configure-settings/scripts"
+
+echo '{"workflows": {"verify-work": {"extra_verification_commands": ["npm test", "npm run lint"]}}}' > .planning/config.json
+echo '{}' > .planning/preferences.json
+
+RESULT=$(bash "$SCRIPT_DIR/read-pref.sh" "workflows.verify-work.extra_verification_commands")
+echo "extra_commands: $RESULT"  # Should be: ["npm test","npm run lint"]
+```
+
+**Result:** [ PASS / FAIL ] _______
+
+---
+
+### WKFL-04: kata-complete-milestone Reads Config ✅/❌
+
+**Test:** Verify `kata-complete-milestone` reads `workflows.complete-milestone` config.
+
+```bash
+SCRIPT_DIR="/Users/gannonhall/dev/kata/kata-orchestrator/skills/kata-configure-settings/scripts"
+
+echo '{"workflows": {"complete-milestone": {"version_files": ["package.json", "VERSION"]}}}' > .planning/config.json
+echo '{}' > .planning/preferences.json
+
+RESULT=$(bash "$SCRIPT_DIR/read-pref.sh" "workflows.complete-milestone.version_files")
+echo "version_files: $RESULT"  # Should be: ["package.json","VERSION"]
+```
+
+**Result:** [ PASS / FAIL ] _______
+
+---
+
+### WKFL-05: Schema Validation on Session Start ✅/❌
+
+**Test:** Verify `kata-config-validator.js` warns on unknown keys, errors on invalid types.
+
+```bash
+# Create config with unknown key and invalid type
+cat > .planning/config.json << 'EOF'
+{
+  "mode": "yolo",
+  "unknown_key": "test",
+  "pr_workflow": "yes"
+}
+EOF
+
+# Run validator
+echo '{"cwd": "'$(pwd)'"}' | node /Users/gannonhall/dev/kata/kata-orchestrator/hooks/kata-config-validator.js
+
+# Expected output:
+# [kata] Config warning: Unknown key 'unknown_key'
+# [kata] Config error: Invalid value for 'pr_workflow': expected boolean, got 'yes'
+```
+
+**Result:** [ PASS / FAIL ] _______
+
+---
+
+### WKFL-06: kata-configure-settings Manages All Sections ✅/❌
+
+**Test:** Verify `/kata:configure-settings` presents and updates all three sections.
+
+**Steps:**
+1. Open Claude Code chat in test project
+2. Invoke: "settings"
+3. Verify three sections presented:
+   - Section A: Project-Lifetime Preferences (preferences.json)
+   - Section B: Session Settings (config.json)
+   - Section C: Workflow Variants (config.json workflows section)
+4. Modify a setting in each section
+5. Verify files updated correctly
+
+**Expected:**
+- All sections displayed with current values
+- Changes saved to correct files
+- Summary shown after update
+
+**Result:** [ PASS / FAIL ] _______
+
+---
+
+## Cross-Phase Integration Tests
+
+### INT-01: Resolution Pattern Consistency ✅/❌
+
+**Test:** Both `read-pref.sh` and `resolve-template.sh` use project-override-first pattern.
+
+```bash
+# read-pref.sh: preferences.json → config.json → defaults
+# resolve-template.sh: .planning/templates/ → plugin default
+
+# Verify both honor project overrides first
+echo '{"mode": "interactive"}' > .planning/preferences.json
+RESULT=$(bash "$SCRIPT_DIR/read-pref.sh" "mode")
+[ "$RESULT" = "interactive" ] && echo "✅ read-pref honors override" || echo "❌ Failed"
+
+mkdir -p .planning/templates
+echo "# Override" > .planning/templates/plan-template.md
+RESULT=$(bash "/Users/gannonhall/dev/kata/kata-orchestrator/skills/kata-execute-phase/scripts/resolve-template.sh" "plan-template.md")
+[[ "$RESULT" == *".planning/templates"* ]] && echo "✅ resolve-template honors override" || echo "❌ Failed"
+```
+
+**Result:** [ PASS / FAIL ] _______
+
+---
+
+### INT-02: Three Hooks Fire on Session Start ✅/❌
+
+**Test:** Verify all 3 SessionStart hooks registered and fire.
+
+```bash
+# Check hooks.json registration
+cat /Users/gannonhall/dev/kata/kata-orchestrator/hooks/hooks.json | jq '.hooks.SessionStart'
+
+# Should show 3 hooks:
+# 1. kata-setup-statusline.js
+# 2. kata-template-drift.js
+# 3. kata-config-validator.js
+```
+
+**Result:** [ PASS / FAIL ] _______
+
+---
+
+### INT-03: DEFAULTS Table Coverage ✅/❌
+
+**Test:** All 23 preference keys covered in DEFAULTS table.
+
+```bash
+# Count default keys
+grep -c "'[^']*':" /Users/gannonhall/dev/kata/kata-orchestrator/skills/kata-configure-settings/scripts/read-pref.sh
+
+# Verify the 6 workflow keys specifically
+for key in \
+  "workflows.execute-phase.post_task_command" \
+  "workflows.execute-phase.commit_style" \
+  "workflows.execute-phase.commit_scope_format" \
+  "workflows.verify-work.extra_verification_commands" \
+  "workflows.complete-milestone.version_files" \
+  "workflows.complete-milestone.pre_release_commands"; do
+  grep -q "'$key'" /Users/gannonhall/dev/kata/kata-orchestrator/skills/kata-configure-settings/scripts/read-pref.sh && \
+    echo "✅ $key" || echo "❌ $key missing"
+done
+```
+
+**Result:** [ PASS / FAIL ] _______
+
+---
+
+## E2E Flow Tests
+
+### E2E-01: New Project → First Plan Flow ✅/❌
+
+**Test:** Complete flow from new project to first plan.
+
+**Steps:**
+1. Create empty directory
+2. Invoke "new project", complete onboarding
+3. Verify `preferences.json` scaffolded (empty)
+4. Verify `model_profile` NOT set in config
+5. Add milestone, then invoke "plan phase 1"
+6. Verify check-or-ask prompts for model_profile
+
+**Result:** [ PASS / FAIL ] _______
+
+---
+
+### E2E-02: Template Override Flow ✅/❌
+
+**Test:** Full template override lifecycle.
+
+**Steps:**
+1. Create `.planning/templates/plan-template.md` with custom content
+2. Start new session (trigger drift detection)
+3. Observe drift warning if fields missing
+4. Invoke "plan phase" and verify custom template used
+
+**Result:** [ PASS / FAIL ] _______
+
+---
+
+### E2E-03: Workflow Config Flow ✅/❌
+
+**Test:** Configure and apply workflow settings.
+
+**Steps:**
+1. Invoke "settings"
+2. Set `workflows.execute-phase.commit_style` to "semantic"
+3. Execute a phase
+4. Verify commits use semantic style
+
+**Result:** [ PASS / FAIL ] _______
+
+---
+
+### E2E-04: Session Startup Flow ✅/❌
+
+**Test:** All three hooks fire correctly on session start.
+
+**Steps:**
+1. Configure project with statusline, custom template, and workflow config
+2. Start new Claude Code session
+3. Verify statusline appears
+4. Verify drift detection runs (if override exists)
+5. Verify config validation runs
+
+**Result:** [ PASS / FAIL ] _______
+
+---
+
+## Cleanup
+
+```bash
+# Remove test project
+cd /tmp && rm -rf kata-v180-test
+```
+
+---
+
+## Summary
+
+| Category | Tests | Passed | Failed |
+|----------|-------|--------|--------|
+| Phase 37: Preferences Infrastructure | 10 | __ | __ |
+| Phase 38: Template Overrides | 4 | __ | __ |
+| Phase 39: Workflow Variants | 6 | __ | __ |
+| Cross-Phase Integration | 3 | __ | __ |
+| E2E Flows | 4 | __ | __ |
+| **TOTAL** | **27** | **__** | **__** |
+
+**Overall Result:** [ PASS / FAIL ]
+
+**Notes:**
+_________________________________________________________________________
+_________________________________________________________________________
+_________________________________________________________________________

--- a/.planning/v1.8.0-MILESTONE-AUDIT.md
+++ b/.planning/v1.8.0-MILESTONE-AUDIT.md
@@ -1,0 +1,150 @@
+---
+milestone: v1.8.0
+audited: 2026-02-08
+status: passed
+scores:
+  requirements: 20/20
+  phases: 3/3
+  integration: 6/6
+  flows: 4/4
+gaps:
+  requirements: []
+  integration: []
+  flows: []
+tech_debt:
+  - phase: 37-preferences-infrastructure--progressive-capture
+    items:
+      - "Ambiguous success criterion: '5 questions' vs 5 base + conditional follow-ups (non-blocking, interpretation matches intent)"
+---
+
+# Milestone Audit: v1.8.0 Adaptive Workflows
+
+## Overview
+
+**Goal:** Enable project-specific workflow customization through preferences storage, progressive capture, template overrides, and config-driven workflow variants.
+
+**Phases:** 37 (Preferences Infrastructure & Progressive Capture), 38 (Template Overrides), 39 (Config Workflow Variants & Settings)
+
+**Result:** All 20 requirements satisfied. All 3 phases verified and passed. Cross-phase integration verified with no gaps.
+
+---
+
+## Requirements Coverage
+
+### Preferences Infrastructure (5/5)
+
+| Req | Description | Phase | Status |
+|-----|-------------|-------|--------|
+| PREF-01 | Preferences stored in `.planning/preferences.json` with flat dot-notation keys | 37 | ✅ |
+| PREF-02 | `read-pref.sh` centralizes parsing with resolution chain | 37 | ✅ |
+| PREF-03 | `has-pref.sh` returns whether user has expressed a preference | 37 | ✅ |
+| PREF-04 | `kata-new-project` scaffolds empty `preferences.json` | 37 | ✅ |
+| PREF-05 | Built-in defaults table covers all known preference keys | 37 | ✅ |
+
+### Progressive Capture (5/5)
+
+| Req | Description | Phase | Status |
+|-----|-------------|-------|--------|
+| CAP-01 | Onboarding reduced to 5 essential questions | 37 | ✅ |
+| CAP-02 | `model_profile` deferred to first plan-phase via check-or-ask | 37 | ✅ |
+| CAP-03 | Workflow agent toggles silent-default to true with first-run notice | 37 | ✅ |
+| CAP-04 | `set-config.sh` handles JSON parse, nested key set, atomic write | 37 | ✅ |
+| CAP-05 | Dead `parallelization` key removed from onboarding, config schema, and settings skill | 37 | ✅ |
+
+### Template Overrides (4/4)
+
+| Req | Description | Phase | Status |
+|-----|-------------|-------|--------|
+| TMPL-01 | Five templates extracted into standalone files within skills | 38 | ✅ |
+| TMPL-02 | Template resolution checks `.planning/templates/` first, falls back to plugin default | 38 | ✅ |
+| TMPL-03 | Each template includes schema comment listing required fields | 38 | ✅ |
+| TMPL-04 | Session-start hook detects drift between project templates and plugin schema | 38 | ✅ |
+
+### Config Workflow Variants (6/6)
+
+| Req | Description | Phase | Status |
+|-----|-------------|-------|--------|
+| WKFL-01 | `config.json` gains `workflows` section with per-skill keys | 39 | ✅ |
+| WKFL-02 | `kata-execute-phase` reads `workflows.execute-phase` config | 39 | ✅ |
+| WKFL-03 | `kata-verify-work` reads `workflows.verify-work` config | 39 | ✅ |
+| WKFL-04 | `kata-complete-milestone` reads `workflows.complete-milestone` config | 39 | ✅ |
+| WKFL-05 | Schema validation on session start warns on unknown keys, errors on invalid types | 39 | ✅ |
+| WKFL-06 | `/kata-configure-settings` updated to manage preferences, workflow variants, uses accessor scripts | 39 | ✅ |
+
+---
+
+## Phase Verification Summary
+
+### Phase 37: Preferences Infrastructure & Progressive Capture ✅
+
+- **Plans:** 2/2 completed
+- **Commits:** 3 (f126a8e, e6b7eb0, 12cfe8a)
+- **Key deliverables:** read-pref.sh, has-pref.sh, set-config.sh, reduced onboarding, check-or-ask pattern
+- **Verification:** Passed with one non-blocking note (ambiguous "5 questions" criterion)
+
+### Phase 38: Template Overrides ✅
+
+- **Plans:** 2/2 completed
+- **Commits:** 4 (f1c5eb6, c22ce42, 099d59b, 3ad100f)
+- **Score:** 29/29
+- **Key deliverables:** 5 standalone templates with schema comments, resolve-template.sh, kata-template-drift.js hook, wiring in 4 orchestrator skills
+
+### Phase 39: Config Workflow Variants & Settings ✅
+
+- **Plans:** 3/3 completed
+- **Commits:** 6 (f8f0b7c, 81f5ba9, 77b31de, 632b5b4, e8eb5fe, 1eee765)
+- **Key deliverables:** 6 workflow config keys in DEFAULTS, kata-config-validator.js hook, workflow config wiring in 3 skills, settings skill rewrite (381 lines)
+
+---
+
+## Cross-Phase Integration
+
+### Connection Verification (6/6)
+
+| Connection | From | To | Status |
+|------------|------|----|--------|
+| Resolution pattern consistency | Phase 37 (read-pref.sh) | Phase 38 (resolve-template.sh) | ✅ Both use project-override-first |
+| Accessor script usage | Phase 37 (scripts) | Phase 39 (3 workflow skills) | ✅ All 3 skills use read-pref.sh |
+| Template + config co-location | Phase 38 (templates) | Phase 39 (workflow config) | ✅ Both wired in kata-execute-phase |
+| DEFAULTS table coverage | Phase 37 (DEFAULTS) | Phase 39 (6 workflow keys) | ✅ All 6 keys present (23 total) |
+| Hook registration | Phase 38 + 39 (hooks) | hooks.json | ✅ 3 SessionStart hooks registered |
+| Settings skill coverage | Phase 37 + 39 | kata-configure-settings | ✅ Three sections: preferences, session, workflow |
+
+### E2E Flow Verification (4/4)
+
+| Flow | Status | Description |
+|------|--------|-------------|
+| New Project → First Plan | ✅ | Scaffolds preferences.json, omits model_profile, triggers check-or-ask on first plan-phase |
+| Template Override | ✅ | User places override → drift detection on session start → resolve-template.sh returns override path → executor receives content |
+| Workflow Config | ✅ | User configures via settings → read-pref.sh resolves → orchestrator injects into subagent → executor applies |
+| Session Startup | ✅ | Three hooks fire: statusline, template drift, config validator |
+
+---
+
+## Tech Debt
+
+### Phase 37 (1 item)
+
+- **Ambiguous success criterion:** "Asks exactly 5 questions" implemented as 5 base + conditional follow-ups (GitHub issue creation, repo creation). Implementation matches plan intent. Recommend clarifying language in future phases.
+
+### Phase 38 (0 items)
+
+No tech debt.
+
+### Phase 39 (0 items)
+
+No tech debt.
+
+---
+
+## Deviations from Plan
+
+No substantive deviations across any of the 3 phases. All 7 plans executed as written.
+
+---
+
+## Conclusion
+
+Milestone v1.8.0 achieved its definition of done. All 20 requirements delivered across 4 categories. Cross-phase integration verified with no gaps. One minor tech debt item (ambiguous criterion wording) is non-blocking.
+
+**Recommendation:** Proceed with milestone completion.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,8 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this package.
+
+**Important:** Keep this file and the root `CLAUDE.md` up-to-date whenever functionality changes.
 
 ## Project Overview
 
@@ -83,8 +85,8 @@ Skills are the primary interface for all Kata workflows. They respond to both na
 
 ### Invocation Syntax
 
-| Syntax                  | Example                   |
-| ----------------------- | ------------------------- |
+| Syntax             | Example              |
+| ------------------ | -------------------- |
 | `/kata-skill-name` | `/kata-plan-phase 1` |
 
 **Key points:**
@@ -96,8 +98,8 @@ Skills are the primary interface for all Kata workflows. They respond to both na
 
 Skills are installed to `.claude/skills/` and invoked via `/kata-skill-name`.
 
-| Skill                 | Invocation                  | Purpose                                        |
-| --------------------- | --------------------------- | ---------------------------------------------- |
+| Skill                 | Invocation             | Purpose                                        |
+| --------------------- | ---------------------- | ---------------------------------------------- |
 | `kata-plan-phase`     | `/kata-plan-phase`     | Phase planning, task breakdown                 |
 | `kata-execute-phase`  | `/kata-execute-phase`  | Plan execution, checkpoints                    |
 | `kata-verify-work`    | `/kata-verify-work`    | Goal verification, UAT                         |

--- a/skills/kata-execute-phase/scripts/find-phase.sh
+++ b/skills/kata-execute-phase/scripts/find-phase.sh
@@ -13,8 +13,9 @@ PHASE_DIR=""
 PHASE_STATE=""
 
 for state in active pending completed; do
-  dir=$(find .planning/phases/${state} -maxdepth 1 -type d -name "${PADDED}-*" 2>/dev/null | head -1)
-  [ -z "$dir" ] && dir=$(find .planning/phases/${state} -maxdepth 1 -type d -name "${PHASE_ARG}-*" 2>/dev/null | head -1)
+  [ -d ".planning/phases/${state}" ] || continue
+  dir=$(find .planning/phases/${state} -maxdepth 1 -type d -name "${PADDED}-*" | head -1 || true)
+  [ -z "$dir" ] && dir=$(find .planning/phases/${state} -maxdepth 1 -type d -name "${PHASE_ARG}-*" | head -1 || true)
   if [ -n "$dir" ]; then
     PHASE_DIR="$dir"
     PHASE_STATE="$state"
@@ -24,17 +25,18 @@ done
 
 # Fallback: flat directory (backward compatibility for unmigrated projects)
 if [ -z "$PHASE_DIR" ]; then
-  PHASE_DIR=$(find .planning/phases -maxdepth 1 -type d -name "${PADDED}-*" 2>/dev/null | head -1)
-  [ -z "$PHASE_DIR" ] && PHASE_DIR=$(find .planning/phases -maxdepth 1 -type d -name "${PHASE_ARG}-*" 2>/dev/null | head -1)
+  PHASE_DIR=$(find .planning/phases -maxdepth 1 -type d -name "${PADDED}-*" | head -1 || true)
+  [ -z "$PHASE_DIR" ] && PHASE_DIR=$(find .planning/phases -maxdepth 1 -type d -name "${PHASE_ARG}-*" | head -1 || true)
   [ -n "$PHASE_DIR" ] && PHASE_STATE="flat"
 fi
 
 # Collision detection: check for duplicate phase numbering
 MATCH_COUNT=0
 for state in active pending completed; do
-  MATCH_COUNT=$((MATCH_COUNT + $(find .planning/phases/${state} -maxdepth 1 -type d -name "${PADDED}-*" 2>/dev/null | wc -l)))
+  [ -d ".planning/phases/${state}" ] || continue
+  MATCH_COUNT=$((MATCH_COUNT + $(find .planning/phases/${state} -maxdepth 1 -type d -name "${PADDED}-*" | wc -l)))
 done
-MATCH_COUNT=$((MATCH_COUNT + $(find .planning/phases -maxdepth 1 -type d -name "${PADDED}-*" 2>/dev/null | wc -l)))
+MATCH_COUNT=$((MATCH_COUNT + $(find .planning/phases -maxdepth 1 -type d -name "${PADDED}-*" | wc -l)))
 
 if [ "$MATCH_COUNT" -gt 1 ]; then
   echo "COLLISION: ${MATCH_COUNT} directories match prefix '${PADDED}-*'"

--- a/skills/kata-move-phase/SKILL.md
+++ b/skills/kata-move-phase/SKILL.md
@@ -67,7 +67,10 @@ cat .planning/STATE.md 2>/dev/null
 cat .planning/ROADMAP.md 2>/dev/null
 ```
 
-Parse current milestone version from ROADMAP.md (the milestone marked "In Progress").
+Parse current milestone version from ROADMAP.md. Use the "Current Milestone:" heading or `🔄` line marker:
+```bash
+VERSION=$(grep -E "Current Milestone:|🔄" .planning/ROADMAP.md | grep -oE 'v[0-9]+\.[0-9]+(\.[0-9]+)?' | head -1 | tr -d 'v')
+```
 </step>
 
 <step name="validate_phase_exists">

--- a/skills/kata-review-pull-requests/SKILL.md
+++ b/skills/kata-review-pull-requests/SKILL.md
@@ -2,107 +2,163 @@
 name: kata-review-pull-requests
 description: Run a comprehensive pull request review using multiple specialized agents. Each agent focuses on a different aspect of code quality, such as comments, tests, error handling, type design, and general code review. The skill aggregates results and provides a clear action plan for improvements. Triggers include "review PR", "analyze pull request", "code review", and "PR quality check".
 metadata:
-  version: "1.6.1"
+  version: "1.7.0"
 ---
+
 # Comprehensive PR Review
 
-Run a comprehensive pull request review using multiple specialized agents, each focusing on a different aspect of code quality.
+Run a comprehensive pull request review by spawning `general-purpose` subagents with inlined reference instructions. Each subagent gets a fresh context window with its specialized review instructions, the diff, and project context.
 
 **Review Aspects (optional):** "$ARGUMENTS"
 
-## Review Workflow:
+<process>
 
-1. **Determine Review Scope**
-   - Check git status to identify changed files
-   - Parse arguments to see if user requested specific review aspects
-   - Default: Run all applicable reviews
+## 1. Determine Review Scope
 
-2. **Available Review Aspects:**
+- Check git status to identify changed files
+- Parse arguments to see if user requested specific review aspects
+- Default: Run all applicable reviews
 
-   - **comments** - Analyze code comment accuracy and maintainability
-   - **tests** - Review test coverage quality and completeness
-   - **errors** - Check error handling for silent failures
-   - **types** - Analyze type design and invariants (if new types added)
-   - **code** - General code review for project guidelines
-   - **simplify** - Simplify code for clarity and maintainability
-   - **all** - Run all applicable reviews (default)
+## 2. Available Review Aspects
 
-3. **Identify Changed Files**
-   - Run `git diff --name-only` to see modified files
-   - Check if PR already exists: `gh pr view`
-   - Identify file types and what reviews apply
+| Aspect       | Reference File                        | Purpose                                    |
+| ------------ | ------------------------------------- | ------------------------------------------ |
+| **code**     | code-reviewer-instructions.md         | General code review for project guidelines |
+| **tests**    | pr-test-analyzer-instructions.md      | Test coverage quality and completeness     |
+| **comments** | comment-analyzer-instructions.md      | Code comment accuracy and maintainability  |
+| **errors**   | silent-failure-hunter-instructions.md | Silent failures and error handling         |
+| **types**    | type-design-analyzer-instructions.md  | Type design and invariants                 |
+| **simplify** | code-simplifier-instructions.md       | Code clarity and maintainability           |
+| **all**      | _(all applicable)_                    | Run all reviews (default)                  |
 
-   **Error handling:**
-   - If `git diff` fails (not a git repo): Report error clearly and stop
-   - If `gh pr view` fails with "no PR found": Expected for pre-PR reviews, continue with git diff
-   - If `gh pr view` fails with auth error: Note that GitHub CLI authentication is needed
-   - If no changed files found: Report "No changes detected" and stop
+## 3. Identify Changed Files
 
-4. **Determine Applicable Reviews**
+- Run `git diff --name-only` to see modified files
+- Check if PR already exists: `gh pr view`
+- Identify file types and what reviews apply
 
-   Based on changes:
-   - **Always applicable**: kata-code-reviewer (general quality)
-   - **If test files changed**: kata-pr-test-analyzer
-   - **If comments/docs added**: kata-comment-analyzer
-   - **If error handling changed**: kata-failure-finder
-   - **If types added/modified**: kata-type-design-analyzer
-   - **After passing review**: kata-code-simplifier (polish and refine)
+**Error handling:**
+- If `git diff` fails (not a git repo): Report error clearly and stop
+- If `gh pr view` fails with "no PR found": Expected for pre-PR reviews, continue with git diff
+- If `gh pr view` fails with auth error: Note that GitHub CLI authentication is needed
+- If no changed files found: Report "No changes detected" and stop
 
-5. **Launch Review Agents**
+## 4. Determine Applicable Reviews
 
-   **Sequential approach** (one at a time):
-   - Easier to understand and act on
-   - Each report is complete before next
-   - Good for interactive review
+Based on changes:
+- **Always applicable**: code (general quality)
+- **If test files changed**: tests
+- **If comments/docs added**: comments
+- **If error handling changed**: errors
+- **If types added/modified**: types
+- **After passing review**: simplify (polish and refine)
 
-   **Parallel approach** (user can request):
-   - Launch all agents simultaneously
-   - Faster for comprehensive review
-   - Results come back together
+## 5. Read Reference Instructions
 
-   **Agent failure handling:**
-   - If agent completes: Include results in aggregation
-   - If agent times out: Report "[agent-name] timed out - consider running independently"
-   - If agent fails: Report "[agent-name] failed: [error reason]"
-   - If one agent fails, STILL proceed with remaining agents
-   - **Never silently skip a failed agent** - always report its status
+Read each applicable reference file into a variable for inlining into subagent prompts:
 
-6. **Aggregate Results**
+```
+code_instructions      = Read("${SKILL_BASE_DIR}/references/code-reviewer-instructions.md")
+test_instructions      = Read("${SKILL_BASE_DIR}/references/pr-test-analyzer-instructions.md")
+comment_instructions   = Read("${SKILL_BASE_DIR}/references/comment-analyzer-instructions.md")
+errors_instructions    = Read("${SKILL_BASE_DIR}/references/silent-failure-hunter-instructions.md")
+types_instructions     = Read("${SKILL_BASE_DIR}/references/type-design-analyzer-instructions.md")
+simplify_instructions  = Read("${SKILL_BASE_DIR}/references/code-simplifier-instructions.md")
+```
 
-   After agents complete, summarize:
-   - **Critical Issues** (must fix before merge)
-   - **Important Issues** (should fix)
-   - **Suggestions** (nice to have)
-   - **Positive Observations** (what's good)
+Only read files for applicable review aspects. Also read:
+- `git diff` output into `diff_content`
+- `CLAUDE.md` (if exists) into `project_context`
 
-   **Edge cases:**
-   - If no issues found: Celebrate with "All Checks Passed" summary
-   - If agents conflict: Note the disagreement and let user decide
-   - If agent output malformed: Note "[agent] output could not be parsed"
-   - Always include count of agents completed vs failed
+## 6. Resolve Model Profile
 
-7. **Provide Action Plan**
+```bash
+MODEL_PROFILE=$(cat .planning/config.json 2>/dev/null | grep -o '"model_profile"[[:space:]]*:[[:space:]]*"[^"]*"' | grep -o '"[^"]*"$' | tr -d '"' || echo "balanced")
+```
 
-   Organize findings:
-   ```markdown
-   # PR Review Summary
+Default to "balanced" if not set.
 
-   ## Critical Issues (X found)
-   - [agent-name]: Issue description [file:line]
+**Model lookup table:**
 
-   ## Important Issues (X found)
-   - [agent-name]: Issue description [file:line]
+| Agent            | quality | balanced | budget |
+| ---------------- | ------- | -------- | ------ |
+| code-reviewer    | opus    | sonnet   | sonnet |
+| test-analyzer    | sonnet  | sonnet   | haiku  |
+| comment-analyzer | sonnet  | sonnet   | haiku  |
+| failure-hunter   | sonnet  | sonnet   | haiku  |
+| type-analyzer    | sonnet  | sonnet   | haiku  |
+| code-simplifier  | sonnet  | sonnet   | haiku  |
 
-   ## Suggestions (X found)
-   - [agent-name]: Suggestion [file:line]
+## 7. Launch Review Agents
 
-   ## Strengths
-   - What's well-done in this PR
+Spawn `general-purpose` subagents via parallel Task calls. Each agent receives its reference instructions inlined as `<agent-instructions>`, the diff, and project context.
 
-   ## Recommended Action
-   1. Fix critical issues first
-   2. Address important issues
-   3. Consider suggestions
-   4. Re-run review after fixes
-   ```
+**Task call pattern:**
 
+```
+Task(
+  prompt="<agent-instructions>\n{instructions_content}\n</agent-instructions>\n\nReview the following changes:\n\n<diff>\n{diff_content}\n</diff>\n\n<project-context>\n{project_context}\n</project-context>",
+  subagent_type="general-purpose",
+  model="{resolved_model}",
+  description="PR review: {aspect}"
+)
+```
+
+**Example parallel launch (3 agents):**
+
+```
+Task(prompt="<agent-instructions>\n{code_instructions}\n</agent-instructions>\n\nReview these changes:\n<diff>\n{diff_content}\n</diff>\n<project-context>\n{project_context}\n</project-context>", subagent_type="general-purpose", model="{code_model}", description="PR review: code")
+Task(prompt="<agent-instructions>\n{test_instructions}\n</agent-instructions>\n\nReview these changes:\n<diff>\n{diff_content}\n</diff>\n<project-context>\n{project_context}\n</project-context>", subagent_type="general-purpose", model="{test_model}", description="PR review: tests")
+Task(prompt="<agent-instructions>\n{errors_instructions}\n</agent-instructions>\n\nReview these changes:\n<diff>\n{diff_content}\n</diff>\n<project-context>\n{project_context}\n</project-context>", subagent_type="general-purpose", model="{errors_model}", description="PR review: errors")
+```
+
+All run in parallel. Task tool blocks until all complete.
+
+**Agent failure handling:**
+- If agent completes: Include results in aggregation
+- If agent times out: Report "[aspect] review timed out - consider running independently"
+- If agent fails: Report "[aspect] review failed: [error reason]"
+- If one agent fails, STILL proceed with remaining agents
+- **Never silently skip a failed agent** - always report its status
+
+## 8. Aggregate Results
+
+After agents complete, summarize:
+- **Critical Issues** (must fix before merge)
+- **Important Issues** (should fix)
+- **Suggestions** (nice to have)
+- **Positive Observations** (what's good)
+
+**Edge cases:**
+- If no issues found: "All Checks Passed" summary
+- If agents conflict: Note the disagreement and let user decide
+- If agent output malformed: Note "[aspect] output could not be parsed"
+- Always include count of agents completed vs failed
+
+## 9. Provide Action Plan
+
+Organize findings:
+
+```markdown
+# PR Review Summary
+
+## Critical Issues (X found)
+- [aspect]: Issue description [file:line]
+
+## Important Issues (X found)
+- [aspect]: Issue description [file:line]
+
+## Suggestions (X found)
+- [aspect]: Suggestion [file:line]
+
+## Strengths
+- What's well-done in this PR
+
+## Recommended Action
+1. Fix critical issues first
+2. Address important issues
+3. Consider suggestions
+4. Re-run review after fixes
+```
+
+</process>


### PR DESCRIPTION
## Summary

- Fix `gh issue list --milestone` for closed milestones (replaced with `gh api` two-step lookup)
- Fix `find-phase.sh` when state directories don't exist (guard with `[ -d ]`)
- Add workflow variant config: post-task command, extra verification, version files override
- Update `kata-review-pull-requests` skill structure
- Add v1.8.0 milestone audit and manual test artifacts
- Update CLAUDE.md with current architecture docs

## Test plan

- [ ] `npm run build:plugin` succeeds
- [ ] Skills load correctly via `claude --plugin-dir`
- [ ] Config changes reflected in `.planning/config.json`