### PR TITLE
fix: remove kata-silent-failure-hunter from test mappings (v1.10.1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kata",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Spec-driven development framework for Claude Code. Provides structured workflows for requirements gathering, research, planning, execution, and verification.",
   "author": {
     "name": "gannonh",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gannonh/kata",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "type": "module",
   "description": "Spec-driven development framework for Claude Code.",
   "scripts": {

--- a/tests/migration-validation.test.js
+++ b/tests/migration-validation.test.js
@@ -37,7 +37,6 @@ const AGENT_MAPPINGS = {
   'kata-pr-test-analyzer': 'kata-review-pull-requests',
   'kata-type-design-analyzer': 'kata-review-pull-requests',
   'kata-failure-finder': 'kata-review-pull-requests',
-  'kata-silent-failure-hunter': 'kata-review-pull-requests',
   'kata-entity-generator': 'kata-review-pull-requests'
 };
 
@@ -59,9 +58,9 @@ function findMarkdownFiles(dir, files = []) {
 }
 
 describe('Migration validation: agent-to-instruction-file mappings', () => {
-  test('all 19 agents have corresponding instruction files', () => {
+  test('all 18 agents have corresponding instruction files', () => {
     const agentNames = Object.keys(AGENT_MAPPINGS);
-    assert.strictEqual(agentNames.length, 19, `Expected 19 agent mappings, got ${agentNames.length}`);
+    assert.strictEqual(agentNames.length, 18, `Expected 18 agent mappings, got ${agentNames.length}`);
 
     const errors = [];
 


### PR DESCRIPTION
## Summary

Fixes CI test failure after kata-silent-failure-hunter agent was removed.

The `kata-silent-failure-hunter` agent was a duplicate that has been removed. This PR updates the migration validation test to expect 18 agents instead of 19.

## Changes

- Remove `kata-silent-failure-hunter` from AGENT_MAPPINGS
- Update test assertion from 19 to 18 agents
- Bump version to 1.10.1

## Testing

```bash
npm test
```

All tests passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped version to 1.10.1 across release manifests and package configuration.

* **Tests**
  * Updated test assertions to reflect the removal of an agent mapping, reducing total agent count from 19 to 18.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->