### PR TITLE
Move model quality selection to project initialization

### DIFF
--- a/skills/kata-execute-phase/references/planning-config.md
+++ b/skills/kata-execute-phase/references/planning-config.md
@@ -28,19 +28,19 @@ Configuration options for Kata projects in `.planning/config.json`.
 }
 ```
 
-| Option                | Default    | Description                                                    |
-| --------------------- | ---------- | -------------------------------------------------------------- |
-| `mode`                | `yolo`     | `yolo` = auto-approve, `interactive` = confirm at each step    |
-| `depth`               | `standard` | `quick` (3-5 phases), `standard` (5-8), `comprehensive` (8-12) |
-| `model_profile`       | `balanced` | Which AI models for agents (see model-profiles.md)             |
-| `commit_docs`         | `true`     | Whether to commit planning artifacts to git                    |
-| `pr_workflow`         | `true`     | Use PR-based release workflow vs direct commits                |
-| `github.enabled`      | `false`    | Create GitHub Milestones/Issues when true                      |
-| `github.issueMode`    | `never`    | Issue creation mode: `auto`, `ask`, `never`                    |
-| `workflow.research`   | `true`     | Spawn researcher before planning each phase                    |
-| `workflow.plan_check` | `true`     | Verify plans achieve phase goals before execution              |
-| `workflow.verifier`   | `true`     | Confirm deliverables after phase execution                     |
-| `worktree.enabled`    | `false`    | Enable git worktree isolation per plan (requires pr_workflow: true) |
+| Option                | Default    | Description                                                           |
+| --------------------- | ---------- | --------------------------------------------------------------------- |
+| `mode`                | `yolo`     | `yolo` = auto-approve, `interactive` = confirm at each step           |
+| `depth`               | `standard` | `quick` (3-5 phases), `standard` (5-8), `comprehensive` (8-12)        |
+| `model_profile`       | `balanced` | Which AI models for agents (set during project init, see kata-set-profile) |
+| `commit_docs`         | `true`     | Whether to commit planning artifacts to git                           |
+| `pr_workflow`         | `true`     | Use PR-based release workflow vs direct commits                       |
+| `github.enabled`      | `false`    | Create GitHub Milestones/Issues when true                             |
+| `github.issueMode`    | `never`    | Issue creation mode: `auto`, `ask`, `never`                           |
+| `workflow.research`   | `true`     | Spawn researcher before planning each phase                           |
+| `workflow.plan_check` | `true`     | Verify plans achieve phase goals before execution                     |
+| `workflow.verifier`   | `true`     | Confirm deliverables after phase execution                            |
+| `worktree.enabled`    | `false`    | Enable git worktree isolation per plan (requires pr_workflow: true)   |
 
 </config_schema>
 

--- a/skills/kata-new-project/SKILL.md
+++ b/skills/kata-new-project/SKILL.md
@@ -253,7 +253,7 @@ EOF
 
 ## Phase 5: Workflow Preferences
 
-**5 questions:**
+**6 questions:**
 
 ```
 questions: [
@@ -274,6 +274,16 @@ questions: [
       { label: "Quick", description: "Ship fast (3-5 phases, 1-3 plans each)" },
       { label: "Standard", description: "Balanced scope and speed (5-8 phases, 3-5 plans each)" },
       { label: "Comprehensive", description: "Thorough coverage (8-12 phases, 5-10 plans each)" }
+    ]
+  },
+  {
+    header: "Model Quality",
+    question: "Which AI models for planning agents?",
+    multiSelect: false,
+    options: [
+      { label: "Balanced (Recommended)", description: "Opus for planning, Sonnet for execution — good quality/cost ratio" },
+      { label: "Quality", description: "Opus for research/planning — higher cost, deeper analysis" },
+      { label: "Budget", description: "Sonnet/Haiku where possible — fastest, lowest cost" }
     ]
   },
   {
@@ -388,6 +398,7 @@ Create `.planning/config.json` with settings (workflow and display defaults are 
 {
   "mode": "yolo|interactive",
   "depth": "quick|standard|comprehensive",
+  "model_profile": "quality|balanced|budget",
   "commit_docs": true|false,
   "pr_workflow": true|false,
   "workflow": {
@@ -405,7 +416,10 @@ Create `.planning/config.json` with settings (workflow and display defaults are 
 }
 ```
 
-Note: `model_profile` is intentionally absent from initial config. Its absence triggers check-or-ask in `/kata-plan-phase` on first invocation.
+Map user selections to values:
+- "Balanced (Recommended)" → `"balanced"`
+- "Quality" → `"quality"`
+- "Budget" → `"budget"`
 
 **GitHub Tracking conditional logic:**
 
@@ -642,26 +656,6 @@ Add NPM_TOKEN secret to your GitHub repository:
 
 The workflow will auto-publish when you merge PRs that bump package.json version.
 ```
-
-## Phase 5.5: Resolve Model Profile
-
-Read model profile for agent spawning:
-
-```bash
-MODEL_PROFILE=$(bash "../kata-configure-settings/scripts/read-config.sh" "model_profile" "balanced")
-```
-
-Default to "balanced" if not set.
-
-**Model lookup table:**
-
-| Agent                     | quality | balanced | budget |
-| ------------------------- | ------- | -------- | ------ |
-| kata-project-researcher   | opus    | sonnet   | haiku  |
-| kata-research-synthesizer | sonnet  | sonnet   | haiku  |
-| kata-roadmapper           | opus    | sonnet   | sonnet |
-
-Store resolved models for use in Task calls if milestone research/roadmapping is needed later.
 
 ## Phase 6: Done
 

--- a/skills/kata-plan-phase/SKILL.md
+++ b/skills/kata-plan-phase/SKILL.md
@@ -160,47 +160,6 @@ grep -A5 "Phase ${PHASE}:" .planning/ROADMAP.md 2>/dev/null
 
 **If not found:** Error with available phases. **If found:** Extract phase number, name, description.
 
-## 3.5. Check-or-Ask Model Profile
-
-Check if model_profile has been set in config:
-
-```bash
-KATA_SCRIPTS="../kata-configure-settings/scripts"
-MODEL_PROFILE_SET=$(bash "../kata-configure-settings/scripts/read-config.sh" "model_profile")
-```
-
-**If model_profile is absent (empty MODEL_PROFILE_SET):**
-
-This is the first plan-phase run. Ask the user for model_profile.
-
-Use AskUserQuestion:
-- header: "Model Profile"
-- question: "Which AI models for planning agents?"
-- options:
-  - "Balanced (Recommended)" — Sonnet for most agents — good quality/cost ratio
-  - "Quality" — Opus for research/roadmap — higher cost, deeper analysis
-  - "Budget" — Haiku where possible — fastest, lowest cost
-
-After user responds, write to config:
-
-```bash
-# Map selection to value
-# Balanced -> balanced, Quality -> quality, Budget -> budget
-bash "${KATA_SCRIPTS}/set-config.sh" "model_profile" "$CHOSEN_PROFILE"
-```
-
-Display first-run agent defaults notice:
-
-```
-+--------------------------------------------------+
-| Agent defaults active: Research, Plan Check,     |
-| Verification. Run /kata-configure-settings to    |
-| customize agent preferences.                     |
-+--------------------------------------------------+
-```
-
-**If model_profile exists:** No-op. Continue to step 4.
-
 ## 4. Ensure Phase Directory Exists
 
 ```bash


### PR DESCRIPTION
## Problem

Model quality selection was deferred until the first phase planning (`/kata-plan-phase`). This meant:
- First milestone planning (the most critical planning moment) defaulted to "balanced" profile
- User never got to choose quality level before important milestone research/roadmapping agents ran
- The workflow had an awkward "check-or-ask" step during phase planning

## Changes

**kata-new-project:**
- Added "Model Quality" question to Phase 5 workflow preferences (6 questions total now)
- Writes `model_profile` to config.json during initialization
- Removed obsolete Phase 5.5 (model resolution logic)

**kata-plan-phase:**
- Removed step 3.5 (check-or-ask for model_profile)
- Now assumes `model_profile` is always set from project init

**planning-config.md:**
- Updated documentation to reflect init-time setting

## Benefits

1. **Better first milestone planning** — User chooses quality level before critical milestone research/roadmapping
2. **Simpler workflow** — One fewer decision point during phase planning
3. **Cleaner code** — Net -47 lines by removing deferred initialization logic

## Testing

- Existing projects continue to work (model_profile already set)
- New projects will be prompted during `/kata-new-project`
- All agent spawning logic unchanged (just reads from config earlier)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Model Quality question to the project setup workflow, now comprising 6 questions
  * Introduced model selection options: Balanced (Recommended), Quality, and Budget

* **Documentation**
  * Updated documentation formatting and standardized references for consistency
  * Refined workflow descriptions to reflect streamlined process

* **Improvements**
  * Simplified the workflow by removing a model profile resolution step, expediting project initialization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->