### PR TITLE
fix: update migration test agent count to 17

### DIFF
--- a/tests/migration-validation.test.js
+++ b/tests/migration-validation.test.js
@@ -57,9 +57,9 @@ function findMarkdownFiles(dir, files = []) {
 }
 
 describe('Migration validation: agent-to-instruction-file mappings', () => {
-  test('all 18 agents have corresponding instruction files', () => {
+  test('all 17 agents have corresponding instruction files', () => {
     const agentNames = Object.keys(AGENT_MAPPINGS);
-    assert.strictEqual(agentNames.length, 18, `Expected 18 agent mappings, got ${agentNames.length}`);
+    assert.strictEqual(agentNames.length, 17, `Expected 17 agent mappings, got ${agentNames.length}`);
 
     const errors = [];
 


### PR DESCRIPTION
## Summary

Fixes the hardcoded agent count in migration-validation.test.js after `kata-entity-generator` was removed from `AGENT_MAPPINGS` in #180.

The assertion still expected 18 but `Object.keys(AGENT_MAPPINGS).length` is 17, causing CI to fail on the v1.12.0 release merge.

## Changes

- `tests/migration-validation.test.js`: update test name and assertion from 18 → 17

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes CI failure caused by a hardcoded agent count mismatch in `tests/migration-validation.test.js`. PR #180 removed `kata-entity-generator` from `AGENT_MAPPINGS` (18 → 17 entries) but did not update the assertion and test name that still expected 18. This PR corrects both.

- Updated test name from "all 18 agents" to "all 17 agents"
- Updated `assert.strictEqual` expectation from 18 to 17
- No functional or behavioral changes; strictly a test fix to match the already-correct `AGENT_MAPPINGS` object

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a minimal, correct test fix with no functional impact.
- The change is a two-line fix updating a hardcoded number (18 → 17) in a test assertion and its description. The AGENT_MAPPINGS object already contains exactly 17 entries, confirmed by counting the keys in the file. The fix directly addresses the CI failure documented in the PR description. No logic, security, or behavioral changes are introduced.
- No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| tests/migration-validation.test.js | Hardcoded agent count in test name and assertion updated from 18 to 17 to match actual AGENT_MAPPINGS size after kata-entity-generator removal. No issues found. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
flowchart TD
    A["PR #180: Remove kata-entity-generator"] --> B["AGENT_MAPPINGS reduced to 17 entries"]
    B --> C["Test assertion still expected 18"]
    C --> D["CI failure on v1.12.0 merge"]
    D --> E["PR #183: Update assertion to 17"]
    E --> F["Test passes: agentNames.length === 17"]
```

<sub>Last reviewed commit: bc619f2</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->