### PR TITLE
chore(workspace): update workspace configuration for worktrees

### DIFF
--- a/kata-orchestrator.code-workspace
+++ b/kata-orchestrator.code-workspace
@@ -5,12 +5,16 @@
 			"path": "."
 		},
 		{
-			"name": "kata-burner",
-			"path": "../kata-burner"
+			"name": "wt-a",
+			"path": "../kata-orchestrator.worktrees/wt-a"
 		},
 		{
-			"name": ".claude",
-			"path": "../../../.claude"
+			"name": "wt-b",
+			"path": "../kata-orchestrator.worktrees/wt-b"
+		},
+		{
+			"name": "wt-c",
+			"path": "../kata-orchestrator.worktrees/wt-c"
 		}
 	]
 }


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workspace configuration to reorganize development environment folder structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updated VS Code workspace configuration to use git worktrees instead of external project references, replacing `kata-burner` and `.claude` folders with three worktree paths (`wt-a`, `wt-b`, `wt-c`).

- Removed references to `../kata-burner` and `../../../.claude`
- Added three worktree folder references under `../kata-orchestrator.worktrees/`
- Enables parallel development across multiple branches using git worktrees

Note: The documentation in `CLAUDE.md` and `AGENTS.md` still references `../kata-burner/` for test projects (lines 271 and 267 respectively), which may need updating if the test workflow has changed.

<h3>Confidence Score: 4/5</h3>

- Safe to merge - simple workspace configuration change for developer tooling
- This is a low-risk configuration change that only affects VS Code workspace settings for local development. The worktree paths are developer-specific and won't impact production code or CI/CD. Score is 4 instead of 5 because the worktree directories need to exist for the workspace to function properly.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| kata-orchestrator.code-workspace | Updated workspace folders from `kata-burner` and `.claude` to worktree references (`wt-a`, `wt-b`, `wt-c`) for parallel development workflow |

</details>


</details>


<sub>Last reviewed commit: c410d5c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->