### PR TITLE
chore(sync-worktrees): add script to sync worktrees with main branch

### DIFF
--- a/bin/sync-worktrees.sh
+++ b/bin/sync-worktrees.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MAIN_DIR="/Users/gannonhall/dev/kata/kata-orchestrator"
+WT_DIR="/Users/gannonhall/dev/kata/kata-orchestrator.worktrees"
+WORKTREES=("wt-a" "wt-b" "wt-c")
+
+errors=0
+
+die() { echo "FATAL: $*" >&2; exit 1; }
+warn() { echo "ERROR: $*" >&2; errors=$((errors + 1)); }
+
+# -- Step 1: Pull main from GitHub ---------------------------------------
+echo "==> Pulling main"
+if ! git -C "$MAIN_DIR" pull origin main 2>&1; then
+  die "pull failed"
+fi
+
+target_sha=$(git -C "$MAIN_DIR" rev-parse HEAD)
+echo "    main is at ${target_sha:0:7}"
+
+# -- Step 2: Reset each worktree's standby branch to main ----------------
+for wt in "${WORKTREES[@]}"; do
+  wt_path="$WT_DIR/$wt"
+  branch="${wt}-standby"
+
+  if [ ! -d "$wt_path" ]; then
+    warn "$wt: directory not found"
+    continue
+  fi
+
+  if ! git -C "$wt_path" diff --quiet || ! git -C "$wt_path" diff --cached --quiet; then
+    warn "$wt: has uncommitted changes - skipping"
+    continue
+  fi
+
+  current=$(git -C "$wt_path" branch --show-current)
+  if [ "$current" != "$branch" ]; then
+    warn "$wt: on branch '$current', expected '$branch' - skipping"
+    continue
+  fi
+
+  echo "==> Resetting $wt"
+  if ! git -C "$wt_path" reset --hard main 2>&1; then
+    warn "$wt: reset failed"
+    continue
+  fi
+
+  wt_sha=$(git -C "$wt_path" rev-parse HEAD)
+  if [ "$wt_sha" != "$target_sha" ]; then
+    warn "$wt: expected ${target_sha:0:7} but got ${wt_sha:0:7}"
+  else
+    echo "    $wt now at ${target_sha:0:7}"
+  fi
+done
+
+# -- Summary --------------------------------------------------------------
+echo ""
+if [ "$errors" -gt 0 ]; then
+  echo "FAILED: $errors error(s) above. Fix them before starting work."
+  exit 1
+else
+  echo "All worktrees synced to main (${target_sha:0:7})."
+fi


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automated git worktree synchronization tool that pulls the latest main branch and syncs all configured worktrees. Features include validation checks to prevent syncing with uncommitted changes, detailed per-worktree status reporting, and robust error handling with summary confirmation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added utility script `bin/sync-worktrees.sh` to pull latest main and reset multiple worktree standby branches to match.

- Pulls latest `main` branch from remote
- Iterates through configured worktrees (`wt-a`, `wt-b`, `wt-c`)
- Validates each worktree has no uncommitted changes and is on expected standby branch
- Resets each worktree to match `main` using `git reset --hard`
- Reports any errors and exits with failure if issues found

**Issue:** Script contains hardcoded paths (`/Users/gannonhall/...`) that will fail for other users or environments. This makes the script non-portable and will break in CI/CD or for other contributors.

<h3>Confidence Score: 2/5</h3>

- Unsafe to merge due to hardcoded user-specific paths that will break for other users
- The script contains hardcoded absolute paths specific to the author's machine (`/Users/gannonhall/dev/kata/...`). While the logic appears sound for syncing worktrees, the hardcoded paths make this script completely non-functional for any other user or environment. This is a critical portability issue that prevents the script from working as intended in a shared codebase.
- bin/sync-worktrees.sh requires path configuration fixes before merge

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| bin/sync-worktrees.sh | Added new script with hardcoded user-specific paths that will fail for other users |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    Start([sync-worktrees.sh]) --> Pull[Pull main from GitHub]
    Pull --> GetSHA[Get target SHA from main]
    GetSHA --> Loop{For each worktree<br/>wt-a, wt-b, wt-c}
    
    Loop --> CheckDir{Directory exists?}
    CheckDir -->|No| WarnDir[Warn: directory not found]
    WarnDir --> Next1[Continue to next]
    
    CheckDir -->|Yes| CheckClean{Uncommitted<br/>changes?}
    CheckClean -->|Yes| WarnDirty[Warn: uncommitted changes]
    WarnDirty --> Next2[Continue to next]
    
    CheckClean -->|No| CheckBranch{On correct<br/>standby branch?}
    CheckBranch -->|No| WarnBranch[Warn: wrong branch]
    WarnBranch --> Next3[Continue to next]
    
    CheckBranch -->|Yes| Reset[git reset --hard main]
    Reset --> VerifySHA{SHA matches<br/>target?}
    VerifySHA -->|No| WarnSHA[Warn: SHA mismatch]
    VerifySHA -->|Yes| Success[Report synced]
    
    WarnSHA --> Next4[Continue to next]
    Success --> Next5[Continue to next]
    Next1 --> Loop
    Next2 --> Loop
    Next3 --> Loop
    Next4 --> Loop
    Next5 --> Loop
    
    Loop -->|Done| CheckErrors{Any errors?}
    CheckErrors -->|Yes| Fail([Exit 1])
    CheckErrors -->|No| Done([Exit 0: All synced])
```

<sub>Last reviewed commit: caafdc4</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->