### PR TITLE
docs: update AGENTS.md to clarify media references and reorganize SHADCN adoption section

### DIFF
--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -17,6 +17,7 @@ Linear is the single source of truth for all desktop project management: task pr
 - Workflow contract: Linear document "Desktop App Linear Workflow Contract"
 - Use the `/kata-linear` skill for ticket lifecycle (start, end, next). Use `/linear` for general Linear queries.
 - Always pass `includeRelations: true` when calling `get_issue` to see blocking dependencies.
+- Always reference the attached media as the source of truth for design specs and mocks.
 
 ### Determining What to Work on Next
 
@@ -52,14 +53,6 @@ Linear is the single source of truth for all desktop project management: task pr
 - Unit tests: `tests/unit/`
 - E2E/UAT tests: `tests/e2e/`
 
-## SHADCN Adoption
-
-- Desktop renderer UI standard is now SHADCN-first.
-- SHADCN UI primitives live in `src/renderer/components/ui/`.
-- SHADCN Blocks compositions live in `src/renderer/components/shadcnblocks/`.
-- Reuse existing SHADCN primitives/blocks before creating custom renderer UI primitives.
-- Keep utility/style composition aligned with the configured SHADCN aliases and tokens in `components.json`.
-- For new block pulls from `@shadcnblocks`, ensure `SHADCNBLOCKS_API_KEY` is available in the environment.
 
 ## Commands
 
@@ -136,6 +129,13 @@ Port 5199 is hardcoded (`strictPort: true`) to avoid the mismatch where Vite aut
 1. Test Driven Development is mandatory for all code changes. 
 2. Write tests before implementation, ensure they fail, then implement the feature until tests pass.
 3. Use the Test Driven Development Agent Skill (`test-driven-development`) for guidance.
+
+## SHADCN Adoption
+
+- Desktop renderer UI standard is now SHADCN-first.
+- SHADCN UI primitives live in `src/renderer/components/ui/`.
+- SHADCN Blocks compositions live in `src/renderer/components/shadcnblocks/`.
+- Keep utility/style composition aligned with the configured SHADCN aliases and tokens in `components.json`.
 
 ## Private Component Registry (React Source of Truth)
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves `app/AGENTS.md` by adding explicit guidance to reference Linear's attached media for design specs and reorganizes the SHADCN Adoption section for better document flow.

**Key changes:**
- Added reminder to use Linear attached media as source of truth for design specs and mocks (complements existing `_plans/design/` references)
- Moved SHADCN Adoption section after Mandatory TDD section (improves logical grouping)
- Removed two outdated bullet points about `@shadcnblocks` registry (project now uses `@kata-shadcn` private registry as detailed in the Private Component Registry section)

The removed guidance about `SHADCNBLOCKS_API_KEY` and reusing `@shadcnblocks` primitives is no longer applicable since the project has migrated to the `@kata-shadcn` private registry. The `@shadcnblocks` registry entry remains in `components.json` for backward compatibility with existing components, but new development should focus on `@kata-shadcn`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Documentation-only change that improves clarity and removes outdated guidance about `@shadcnblocks` registry usage. The project has migrated to `@kata-shadcn` private registry, making the removed bullet points obsolete.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/AGENTS.md | Documentation update: adds media reference guidance and reorganizes SHADCN section for better flow, removes outdated `@shadcnblocks` references |

</details>


</details>


<sub>Last reviewed commit: c8ea76a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->