### PR TITLE
fix(app): KAT-71 follow-up review fixes

### DIFF
--- a/app/src/renderer/components/left/ChangesTab.tsx
+++ b/app/src/renderer/components/left/ChangesTab.tsx
@@ -32,6 +32,7 @@ type ChangesView = {
   showPullRequestAuthPrompt: boolean
 }
 
+// PREVIEW_STATE_REMAP intentionally reorders ChangesPreviewState to match the mock click-through sequence.
 const PREVIEW_STATE_REMAP: Record<ChangesPreviewState, ChangesPreviewState> = {
   0: 2,
   1: 3,
@@ -113,7 +114,7 @@ function getChangesView(previewState: ChangesPreviewState, git: GitSnapshot): Ch
     showCreatePrAction: false,
     showMergeAction: true,
     showConnectRemoteAction: true,
-    showPullRequestAuthPrompt: false
+    showPullRequestAuthPrompt: true
   }
 }
 
@@ -197,7 +198,7 @@ export function ChangesTab({ git, previewState = 0 }: ChangesTabProps) {
         </span>
         <span className="h-px flex-1 bg-border/70" />
         <ArrowRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-        <span>main</span>
+        <span>{git.targetBranch ?? 'main'}</span>
       </div>
       <p className={cn('mt-1', LEFT_PANEL_TYPOGRAPHY.meta)}>and will be merged into:</p>
 
@@ -226,6 +227,7 @@ export function ChangesTab({ git, previewState = 0 }: ChangesTabProps) {
             {renderFileChanges(view.unstaged)}
             {view.unstaged.length > 0 ? (
               <div className="mt-3 flex flex-wrap gap-2">
+                {/* @scaffold -- action handlers are intentionally deferred until git workflow wiring. */}
                 <Button
                   type="button"
                   variant="outline"

--- a/app/src/renderer/mock/git.ts
+++ b/app/src/renderer/mock/git.ts
@@ -2,6 +2,7 @@ import type { GitSnapshot } from '../types/git'
 
 export const mockGit: GitSnapshot = {
   branch: 'feat/wave-2A-contracts',
+  targetBranch: 'main',
   ahead: 2,
   behind: 0,
   staged: [

--- a/app/src/renderer/types/git.ts
+++ b/app/src/renderer/types/git.ts
@@ -7,6 +7,7 @@ export type GitFileChange = {
 
 export type GitSnapshot = {
   branch: string
+  targetBranch?: string
   ahead: number
   behind: number
   staged: GitFileChange[]

--- a/app/tests/unit/renderer/left/ChangesTab.test.tsx
+++ b/app/tests/unit/renderer/left/ChangesTab.test.tsx
@@ -82,7 +82,21 @@ describe('ChangesTab', () => {
     expect(screen.getByRole('button', { name: 'Unstage all' })).toBeTruthy()
     expect(screen.getByRole('button', { name: 'Commit' }).hasAttribute('disabled')).toBe(false)
     expect(screen.getByRole('button', { name: 'Export' })).toBeTruthy()
-    expect(screen.getByRole('button', { name: 'Merge' })).toBeTruthy()
+    expect(screen.getAllByRole('button', { name: 'Merge' })).toHaveLength(2)
     expect(screen.getByRole('button', { name: 'Connect Remote' })).toBeTruthy()
+    expect(screen.getByText('PULL REQUESTS')).toBeTruthy()
+    expect(screen.getByText('Please authenticate with Augment first.')).toBeTruthy()
+    expect(screen.getByText('Run auggie login in your terminal.')).toBeTruthy()
+  })
+
+  it('renders a git-provided merge target branch when available', () => {
+    render(
+      <ChangesTab
+        git={{ ...mockGit, targetBranch: 'develop' }}
+        previewState={3}
+      />
+    )
+
+    expect(screen.getByText('develop')).toBeTruthy()
   })
 })


### PR DESCRIPTION
## Summary
- derive merge target branch in `ChangesTab` from git snapshot (`targetBranch`) with `main` fallback
- make PR auth prompt reachable in the full/staged preview path
- add explicit remap rationale and scaffold intent comments in `ChangesTab`
- extend unit coverage for merge target rendering and PR auth prompt visibility

## Validation
- `npm run test -- tests/unit/renderer/left/ChangesTab.test.tsx tests/unit/renderer/left/LeftPanel.test.tsx`
- `npm run lint`

## Context
Follow-up commit after merge of #210 to preserve uncommitted review-fix changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Follow-up review fixes for KAT-71 that improve the Changes tab by deriving the merge target branch from git snapshot data with a fallback to 'main', making the PR auth prompt visible in the full/staged preview path (previewState 3), and adding explicit comments for remap rationale and scaffold intent.

- Added optional `targetBranch` field to `GitSnapshot` type
- Updated `ChangesTab` to render dynamic merge target branch (`git.targetBranch ?? 'main'`)
- Made PR auth prompt visible in the default state (mapped previewState 0)
- Added clarifying comments for `PREVIEW_STATE_REMAP` and deferred action handlers
- Extended unit test coverage for merge target rendering and PR auth prompt visibility

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Clean follow-up commit that adds optional fields, clarifying comments, and extends test coverage. All changes are well-tested, backward-compatible (targetBranch is optional with fallback), and pass type checking and unit tests. The changes improve code clarity and maintainability without introducing breaking changes or logical issues.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/src/renderer/components/left/ChangesTab.tsx | Added dynamic merge target branch rendering with fallback, PR auth prompt visibility, and clarifying comments |
| app/src/renderer/types/git.ts | Added optional targetBranch field to GitSnapshot type |
| app/src/renderer/mock/git.ts | Added targetBranch property to mock data |
| app/tests/unit/renderer/left/ChangesTab.test.tsx | Extended test coverage for PR auth prompt visibility and custom merge target branch rendering |

</details>


</details>


<sub>Last reviewed commit: f77563e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->