### PR TITLE
KAT-96 wire state store into main process initialization

### DIFF
--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -51,6 +52,15 @@ function createWindow(): void {
 
 app.whenReady().then(() => {
   const stateFilePath = getNonEmptyEnv('KATA_STATE_FILE') ?? path.join(app.getPath('userData'), 'app-state.json')
+
+  // Migrate legacy state from ~/.kata/state.json if the new path doesn't exist yet
+  const legacyStatePath = path.join(app.getPath('home'), '.kata', 'state.json')
+  if (!fs.existsSync(stateFilePath) && fs.existsSync(legacyStatePath)) {
+    const dir = path.dirname(stateFilePath)
+    fs.mkdirSync(dir, { recursive: true })
+    fs.copyFileSync(legacyStatePath, stateFilePath)
+  }
+
   const workspaceBaseDir = getNonEmptyEnv('KATA_WORKSPACE_BASE_DIR')
   const repoCacheBaseDir = getNonEmptyEnv('KATA_REPO_CACHE_BASE_DIR')
   const stateStore = createStateStore(stateFilePath)

--- a/app/tests/unit/main/index.test.ts
+++ b/app/tests/unit/main/index.test.ts
@@ -7,9 +7,12 @@ type LoadMainOptions = {
   rendererUrl?: string
   whenReadyReject?: Error
   userDataPath?: string
+  homePath?: string
   kataStateFile?: string
   kataWorkspaceBaseDir?: string
   kataRepoCacheBaseDir?: string
+  legacyStateExists?: boolean
+  newStateExists?: boolean
 }
 
 type WindowInstance = {
@@ -57,16 +60,23 @@ async function loadMainModule(options: LoadMainOptions = {}) {
     }
   }
 
+  const userDataPath = options.userDataPath ?? '/tmp/kata-user-data'
+  const homePath = options.homePath ?? '/tmp/kata-home'
+
   const appMock = {
     whenReady: vi.fn(() =>
       options.whenReadyReject ? Promise.reject(options.whenReadyReject) : Promise.resolve()
     ),
     getPath: vi.fn((name: string) => {
-      if (name !== 'userData') {
-        throw new Error(`Unexpected app path key: ${name}`)
+      if (name === 'userData') {
+        return userDataPath
       }
 
-      return options.userDataPath ?? '/tmp/kata-user-data'
+      if (name === 'home') {
+        return homePath
+      }
+
+      throw new Error(`Unexpected app path key: ${name}`)
     }),
     on: vi.fn((event: string, callback: () => void) => {
       listeners.set(event, callback)
@@ -82,6 +92,26 @@ async function loadMainModule(options: LoadMainOptions = {}) {
   }
   const createStateStore = vi.fn(() => mockStateStore)
 
+  const newStatePath = options.kataStateFile ?? `${userDataPath}/app-state.json`
+  const legacyStatePath = `${homePath}/.kata/state.json`
+
+  const existsSyncMock = vi.fn((p: string) => {
+    if (p === newStatePath) {
+      return options.newStateExists ?? false
+    }
+
+    if (p === legacyStatePath) {
+      return options.legacyStateExists ?? false
+    }
+
+    return false
+  })
+  const mkdirSyncMock = vi.fn()
+  const copyFileSyncMock = vi.fn()
+
+  vi.doMock('node:fs', () => ({
+    default: { existsSync: existsSyncMock, mkdirSync: mkdirSyncMock, copyFileSync: copyFileSyncMock }
+  }))
   vi.doMock('electron', () => ({
     app: appMock,
     BrowserWindow: MockBrowserWindow
@@ -155,6 +185,7 @@ async function loadMainModule(options: LoadMainOptions = {}) {
       configurable: true
     })
     consoleErrorSpy.mockRestore()
+    vi.unmock('node:fs')
     vi.unmock('electron')
     vi.unmock('../../../src/main/ipc-handlers')
     vi.unmock('../../../src/main/state-store')
@@ -170,6 +201,9 @@ async function loadMainModule(options: LoadMainOptions = {}) {
     setVisibleWindows(next: WindowInstance[]) {
       visibleWindows = next
     },
+    existsSyncMock,
+    mkdirSyncMock,
+    copyFileSyncMock,
     consoleErrorSpy,
     restore
   }
@@ -268,6 +302,50 @@ describe('main process startup', () => {
         workspaceBaseDir: '/tmp/custom-workspaces',
         repoCacheBaseDir: '/tmp/custom-repos'
       })
+    } finally {
+      harness.restore()
+    }
+  })
+
+  it('passes only provided KATA_* base dir overrides', async () => {
+    const harness = await loadMainModule({
+      kataWorkspaceBaseDir: '/tmp/custom-workspaces'
+    })
+
+    try {
+      expect(harness.registerIpcHandlers).toHaveBeenCalledWith(harness.mockStateStore, {
+        workspaceBaseDir: '/tmp/custom-workspaces'
+      })
+    } finally {
+      harness.restore()
+    }
+  })
+
+  it('migrates legacy ~/.kata/state.json when new state file does not exist', async () => {
+    const harness = await loadMainModule({
+      legacyStateExists: true,
+      newStateExists: false
+    })
+
+    try {
+      expect(harness.mkdirSyncMock).toHaveBeenCalledWith('/tmp/kata-user-data', { recursive: true })
+      expect(harness.copyFileSyncMock).toHaveBeenCalledWith(
+        '/tmp/kata-home/.kata/state.json',
+        '/tmp/kata-user-data/app-state.json'
+      )
+    } finally {
+      harness.restore()
+    }
+  })
+
+  it('skips migration when new state file already exists', async () => {
+    const harness = await loadMainModule({
+      legacyStateExists: true,
+      newStateExists: true
+    })
+
+    try {
+      expect(harness.copyFileSyncMock).not.toHaveBeenCalled()
     } finally {
       harness.restore()
     }


### PR DESCRIPTION
## Summary
- wire main startup to create state store at `app.getPath('userData')/app-state.json`
- register IPC handlers with the injected state store via `registerIpcHandlers(stateStore)`
- update main startup unit tests to assert the new state file path and IPC registration signature

## Verification
- npm run test -- tests/unit/main/index.test.ts
- npm run test -- tests/unit/main
- npm run lint
- npm run dev (manual startup check: main/preload/renderer started, no startup or IPC registration errors)

## Acceptance Criteria Coverage (KAT-96)
- Import `createStateStore` in `src/main/index.ts`\n  - already present and used
- Create store in `app.whenReady()` with userData-backed path\n  - implemented as `path.join(app.getPath('userData'), 'app-state.json')`
- Pass store to `registerIpcHandlers(store)`\n  - implemented as `registerIpcHandlers(stateStore)`

Refs: KAT-96

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * State is now stored in the system user-data directory (app-state.json); previous env-based defaults for workspace/cache are no longer used by default.

* **New Features**
  * Automatic migration of legacy state from the user's home folder to the new user-data location.
  * Optional environment overrides for state/workspace/cache paths are still supported.

* **Refactor**
  * Startup and IPC registration simplified to only include optional path overrides when present.

* **Tests**
  * Unit tests expanded to cover migration, override behavior, and updated startup expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires the state store into the main process by switching the state file path to `app.getPath('userData')/app-state.json` (the standard Electron user-data location) and simplifying the `registerIpcHandlers` call to accept only the injected store — removing the previously-threaded `workspaceBaseDir`/`repoCacheBaseDir` env-var options. The unit tests are correctly updated to match the new signature and assert the new path construction via a mocked `app.getPath`.

**Key changes:**
- `app/src/main/index.ts`: replaces `process.env.KATA_STATE_FILE ?? os.homedir()/.kata/state.json` with `app.getPath('userData')/app-state.json`; drops the second argument to `registerIpcHandlers`; removes the unused `os` import
- `app/tests/unit/main/index.test.ts`: adds an `app.getPath` mock (guarded to `userData` only), pins the expected state path, and removes all env-var setup/teardown scaffolding

**Issue found:**
- The E2E fixture (`tests/e2e/fixtures/electron.ts`) launches the app with `KATA_STATE_FILE`, `KATA_WORKSPACE_BASE_DIR`, and `KATA_REPO_CACHE_BASE_DIR` set to isolated temp directories for test isolation. Both code paths that consumed these vars have been removed in this PR, so E2E tests will now write state to the developer's real `userData` directory and provision workspaces under `~/.kata/` — bypassing the fixture's cleanup and potentially contaminating real user data across test runs.

<h3>Confidence Score: 3/5</h3>

- Safe to merge for app functionality, but breaks E2E test isolation — tests will write to real user data directories until the fixture is updated.
- The production code change is correct and the unit tests are thorough. The score is reduced because removing the env-var consumption paths silently breaks the existing E2E fixture's isolation strategy: `KATA_STATE_FILE`, `KATA_WORKSPACE_BASE_DIR`, and `KATA_REPO_CACHE_BASE_DIR` are still injected by the fixture but are now completely ignored, causing test state to leak into the developer's real `userData` and `~/.kata` directories with no automated cleanup.
- Pay close attention to `app/tests/e2e/fixtures/electron.ts` — the env-var-based isolation for `KATA_STATE_FILE`, `KATA_WORKSPACE_BASE_DIR`, and `KATA_REPO_CACHE_BASE_DIR` needs to be replaced (e.g., via `--user-data-dir` CLI flag or `app.setPath` early in the main process) before E2E tests can run safely.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/src/main/index.ts | Correctly migrates state file path to `app.getPath('userData')/app-state.json` and removes env-var pass-through to `registerIpcHandlers`, but the removal of `KATA_STATE_FILE`, `KATA_WORKSPACE_BASE_DIR`, and `KATA_REPO_CACHE_BASE_DIR` env-var consumption breaks E2E test isolation — the fixture still sets these vars expecting the app to honour them. |
| app/tests/unit/main/index.test.ts | Unit tests are correctly updated: adds `getPath` mock with a strict `userData`-only guard, pins the expected state file path to the mocked userData dir, and verifies the simplified `registerIpcHandlers(stateStore)` signature. Test coverage aligns well with the implementation changes. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Electron as Electron Runtime
    participant Main as src/main/index.ts
    participant StateStore as createStateStore()
    participant IPC as registerIpcHandlers()
    participant FS as Filesystem

    Electron->>Main: app.whenReady()
    Main->>Electron: app.getPath('userData')
    Electron-->>Main: /path/to/userData
    Main->>Main: path.join(userData, 'app-state.json')
    Main->>StateStore: createStateStore(stateFilePath)
    StateStore-->>Main: stateStore { load, save }
    Main->>IPC: registerIpcHandlers(stateStore)
    Note over IPC: workspaceBaseDir defaults to ~/.kata/workspaces<br/>repoCacheBaseDir defaults to ~/.kata/repos
    IPC-->>Main: handlers registered
    Main->>Electron: createWindow()

    Note over Main,FS: On space:create IPC call
    IPC->>StateStore: stateStore.load()
    StateStore->>FS: readFileSync(userData/app-state.json)
    FS-->>StateStore: raw JSON
    StateStore-->>IPC: AppState
    IPC->>StateStore: stateStore.save(nextState)
    StateStore->>FS: writeFileSync (atomic rename via .tmp)
```

<sub>Last reviewed commit: 7ea0c17</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->