### PR TITLE
test(app): add KAT-101 integration quality gate coverage

### DIFF
--- a/app/docs/plans/2026-02-27-kat-101-integration-verification-quality-gate-design.md
+++ b/app/docs/plans/2026-02-27-kat-101-integration-verification-quality-gate-design.md
@@ -1,0 +1,95 @@
+# KAT-101 Design: Integration Verification and Quality Gate
+
+Date: 2026-02-27
+Issue: KAT-101
+
+## Goal
+Establish a reliable Slice 0 integration gate that proves the desktop app starts on Home, can create a space, persists that space across relaunch, and writes persisted state to `app-state.json` with valid space data.
+
+## Confirmed Scope
+- Run and keep green: `npm run test:ci:local` (lint, coverage, quality-gate E2E, full UAT E2E).
+- Add automated E2E assertions (not manual-only checks) for:
+  - Home view on startup
+  - create space flow
+  - quit and relaunch
+  - persistence after relaunch
+  - state file existence with expected space data
+- Capture machine-readable evidence artifacts for successful runs.
+- Fix any blocking integration issues discovered while implementing this gate.
+
+## Approaches Considered
+1. Extend existing managed provisioning E2E suite (selected)
+- Reuse existing Electron fixture, Home helpers, and relaunch coverage.
+- Lowest risk and least duplication while still enabling stronger assertions and artifacts.
+
+2. Add a separate integration verifier script outside Playwright
+- Single-purpose script could be explicit, but would duplicate fixture/bootstrap logic and increase maintenance surface.
+
+3. Manual smoke verification with minimal automation
+- Fastest to author, but insufficient for regression prevention and does not satisfy the required automated-evidence bar.
+
+## Architecture
+Keep `npm run test:ci:local` as the top-level quality gate. Strengthen the Playwright integration path so KAT-101 is enforced by automation, not runbook-only checks.
+
+Use two persistence validation paths:
+1. Controlled-path validation (CI-stable): launch Electron with `KATA_STATE_FILE=<tmp>/state.json` and assert file existence plus JSON space payload.
+2. Default userData-path validation: launch Electron without `KATA_STATE_FILE`, resolve `app.getPath('userData')`, and assert `<userData>/app-state.json` exists and includes created space.
+
+This dual-path strategy verifies both deterministic CI behavior and production-default persistence behavior.
+
+## Components and Data Flow
+- `tests/e2e/managed-provisioning.spec.ts` (or a dedicated integration file if separation improves readability):
+  - Add/upgrade a `@quality-gate @ci` integration test for startup -> create -> relaunch -> persistence.
+  - Add filesystem JSON assertions for state persistence.
+- `tests/e2e/fixtures/electron.ts`:
+  - Keep isolated temp paths for managed workspace/repo/state fixtures.
+  - Support launching without `KATA_STATE_FILE` for default-path assertions.
+- New E2E helper for evidence capture under `tests/e2e/helpers/`:
+  - Persist JSON artifacts to `test-results/kat-101/` with state path and key persistence facts.
+
+## Evidence Model
+For each integration test run, record a small JSON artifact that includes:
+- state file path used
+- created space name/id
+- pre-relaunch and post-relaunch space counts
+- persisted space snapshot (`name`, `rootPath`, `branch`, `workspaceMode`)
+- timestamp and test title
+
+Playwright trace/video/screenshot on failure remain enabled via existing config. The added JSON artifact provides positive evidence for successful runs.
+
+## Error Handling and Remediation Policy
+Any defect that blocks KAT-101 assertions is in scope to fix now, including:
+- startup routing regressions (Home not shown)
+- create-space UI or IPC path failures
+- state-store write/read mismatches
+- relaunch persistence regressions
+
+Each remediation follows mandatory TDD:
+1. add/adjust failing test
+2. implement minimal fix
+3. rerun targeted test
+4. rerun `npm run test:ci:local`
+
+## Testing Strategy
+### Required gate
+- `npm run test:ci:local`
+
+### Focused integration runs during implementation
+- `npm run test:e2e:quality-gate -- --grep "persist|integration|managed provisioning"`
+- `npm run test:e2e:ci -- --grep "persist|integration|managed provisioning"`
+
+### Assertion targets
+- Home heading visible on startup.
+- Newly created space visible before and after relaunch.
+- `window.kata.spaceList()` includes created space on both launches.
+- State file exists and JSON includes persisted space record.
+- Default `userData/app-state.json` persistence path is verified when env override is absent.
+
+## Out of Scope
+- Orchestrator functional slices (A/B/C) implementation work.
+- PR workflow changes.
+- Non-persistence UI redesign.
+- Broad refactors unrelated to integration verification.
+
+## Expected Outcome
+KAT-101 becomes a reliable integration gate for Slice 0 completion: CI and local quality gate runs prove startup behavior, end-to-end space persistence, and persisted state-file correctness with concrete, machine-readable evidence artifacts.

--- a/app/docs/plans/2026-02-27-kat-101-integration-verification-quality-gate-implementation-plan.md
+++ b/app/docs/plans/2026-02-27-kat-101-integration-verification-quality-gate-implementation-plan.md
@@ -1,0 +1,279 @@
+# KAT-101 Integration Verification and Quality Gate Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Prove Slice 0 integration end-to-end by enforcing automated quality-gate assertions for Home startup, create-space persistence across relaunch, and persisted state-file correctness with evidence artifacts.
+
+**Architecture:** Extend the existing Playwright managed-provisioning integration suite instead of introducing a new harness. Keep deterministic temp-dir fixtures for CI/local reproducibility, then add one controlled-state-file persistence path and one default-userData persistence path. Emit structured evidence JSON per run so success cases produce artifacts, not just failure traces.
+
+**Tech Stack:** Electron, Playwright (`@playwright/test`), Node `fs/path`, TypeScript, existing `npm run test:ci:local` gate.
+
+---
+
+Implementation guidance:
+- Apply @test-driven-development for each task.
+- Apply @verification-before-completion before claiming done.
+- Use @playwright for E2E authoring/debugging.
+- Keep commits small and frequent.
+
+### Task 1: Add failing quality-gate persistence assertions for controlled state path
+
+**Files:**
+- Modify: `tests/e2e/managed-provisioning.spec.ts`
+
+**Step 1: Write the failing test assertions**
+
+Add/adjust the existing persistence test so it includes `@quality-gate` and requires state-file payload verification:
+
+```ts
+test('persists spaces across app restart @quality-gate', async ({
+  appWindow,
+  electronApp,
+  managedStateFilePath,
+  // ...
+}) => {
+  // existing create-space flow
+
+  await expect.poll(() => fs.existsSync(managedStateFilePath)).toBe(true)
+  const persistedRaw = await fsPromises.readFile(managedStateFilePath, 'utf8')
+  const persisted = JSON.parse(persistedRaw) as {
+    spaces: Record<string, { name: string; workspaceMode?: string; branch: string; rootPath: string }>
+  }
+
+  const persistedSpace = Object.values(persisted.spaces).find((space) => space.name === 'Persisted Space')
+  expect(persistedSpace).toBeDefined()
+  expect(persistedSpace?.workspaceMode).toBe('managed')
+  expect(persistedSpace?.branch).toBe('main')
+  expect(persistedSpace?.rootPath.endsWith('/repo')).toBe(true)
+})
+```
+
+**Step 2: Run test to verify it fails first**
+
+Run: `npm run test:e2e:quality-gate -- --grep "persists spaces across app restart"`
+Expected: FAIL before implementation is complete (missing assertions/tag or assertion failure).
+
+**Step 3: Implement minimal code to satisfy the test**
+
+In `tests/e2e/managed-provisioning.spec.ts`:
+- add `@quality-gate` tag to the persistence test name
+- add file existence + JSON payload assertions (as above)
+- keep relaunch verification (`Select space Persisted Space`) intact
+
+**Step 4: Re-run test to verify pass**
+
+Run: `npm run test:e2e:quality-gate -- --grep "persists spaces across app restart"`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tests/e2e/managed-provisioning.spec.ts
+git commit -m "test(app): enforce quality-gate persistence assertions for KAT-101"
+```
+
+### Task 2: Add default userData `app-state.json` integration test (no KATA_STATE_FILE override)
+
+**Files:**
+- Modify: `tests/e2e/managed-provisioning.spec.ts`
+
+**Step 1: Write failing E2E test**
+
+Add a new test that launches Electron without a usable `KATA_STATE_FILE`, creates a space, then verifies default userData state path:
+
+```ts
+test('writes state to default userData/app-state.json when KATA_STATE_FILE is absent @quality-gate @ci', async ({
+  managedTestRootDir,
+  managedWorkspaceBaseDir,
+  managedRepoCacheBaseDir
+}) => {
+  const launchArgs = process.env.CI ? ['--no-sandbox', '--disable-setuid-sandbox', mainEntry] : [mainEntry]
+
+  const appWithoutOverride = await electron.launch({
+    args: launchArgs,
+    env: {
+      ...process.env,
+      HOME: managedTestRootDir,
+      KATA_STATE_FILE: '',
+      KATA_WORKSPACE_BASE_DIR: managedWorkspaceBaseDir,
+      KATA_REPO_CACHE_BASE_DIR: managedRepoCacheBaseDir
+    }
+  })
+
+  const userDataPath = await appWithoutOverride.evaluate(async ({ app }) => app.getPath('userData'))
+  const defaultStatePath = path.join(userDataPath, 'app-state.json')
+
+  // create space via UI, close app, then assert defaultStatePath exists and contains created space
+})
+```
+
+**Step 2: Run test to verify it fails first**
+
+Run: `npm run test:e2e:ci -- --grep "default userData/app-state.json"`
+Expected: FAIL before implementation is complete.
+
+**Step 3: Implement minimal test flow**
+
+In `tests/e2e/managed-provisioning.spec.ts`:
+- complete the test flow: Home visible -> create managed space -> close app
+- assert `defaultStatePath` exists
+- parse JSON and assert created space data exists
+- keep cleanup safe with `finally` and `close().catch(...)`
+
+**Step 4: Re-run test to verify pass**
+
+Run: `npm run test:e2e:ci -- --grep "default userData/app-state.json"`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tests/e2e/managed-provisioning.spec.ts
+git commit -m "test(app): verify default userData app-state persistence path"
+```
+
+### Task 3: Add structured evidence artifact output for successful integration runs
+
+**Files:**
+- Create: `tests/e2e/helpers/evidence.ts`
+- Modify: `tests/e2e/managed-provisioning.spec.ts`
+
+**Step 1: Write failing usage in test**
+
+In `tests/e2e/managed-provisioning.spec.ts`, call a helper that does not yet exist:
+
+```ts
+import { writeKat101Evidence } from './helpers/evidence'
+
+await writeKat101Evidence({
+  testName: 'persists-spaces-across-app-restart',
+  stateFilePath: managedStateFilePath,
+  spaceName: 'Persisted Space',
+  preRelaunchCount,
+  postRelaunchCount,
+  persistedSpace
+})
+```
+
+**Step 2: Run test to verify it fails first**
+
+Run: `npm run test:e2e:quality-gate -- --grep "persists spaces across app restart"`
+Expected: FAIL (missing helper/module).
+
+**Step 3: Implement minimal helper and wire both KAT-101 tests**
+
+Create `tests/e2e/helpers/evidence.ts`:
+
+```ts
+import fs from 'node:fs/promises'
+import path from 'node:path'
+
+export async function writeKat101Evidence(input: {
+  testName: string
+  stateFilePath: string
+  spaceName: string
+  preRelaunchCount: number
+  postRelaunchCount: number
+  persistedSpace: unknown
+}): Promise<string> {
+  const outDir = path.resolve(process.cwd(), 'test-results/kat-101')
+  await fs.mkdir(outDir, { recursive: true })
+  const outPath = path.join(outDir, `${input.testName}-${Date.now()}.json`)
+  await fs.writeFile(
+    outPath,
+    JSON.stringify(
+      {
+        generatedAt: new Date().toISOString(),
+        ...input
+      },
+      null,
+      2
+    ),
+    'utf8'
+  )
+  return outPath
+}
+```
+
+Then call `writeKat101Evidence(...)` from both KAT-101 integration tests.
+
+**Step 4: Re-run targeted tests to verify pass**
+
+Run: `npm run test:e2e:quality-gate -- --grep "persist|default userData/app-state.json"`
+Expected: PASS; JSON evidence files appear under `test-results/kat-101/`.
+
+**Step 5: Commit**
+
+```bash
+git add tests/e2e/helpers/evidence.ts tests/e2e/managed-provisioning.spec.ts
+git commit -m "test(app): emit KAT-101 integration evidence artifacts"
+```
+
+### Task 4: Run full local CI gate and remediate any integration failures with TDD loops
+
+**Files:**
+- Modify (as needed): `tests/e2e/managed-provisioning.spec.ts`
+- Modify (as needed): `tests/e2e/helpers/shell-view.ts`
+- Modify (as needed): `src/main/index.ts`
+- Modify (as needed): `src/main/ipc-handlers.ts`
+- Modify (as needed): `src/main/state-store.ts`
+- Modify/Create tests matching each discovered defect under `tests/unit/main/` or `tests/e2e/`
+
+**Step 1: Run full gate and capture first failure (if any)**
+
+Run: `npm run test:ci:local`
+Expected: PASS when complete; if FAIL, capture first actionable error.
+
+**Step 2: Add/adjust a failing regression test for the first failure**
+
+Examples:
+- startup regression -> extend `tests/e2e/managed-provisioning.spec.ts`
+- persistence serialization bug -> add/extend `tests/unit/main/state-store.test.ts`
+- IPC behavior mismatch -> add/extend `tests/unit/main/ipc-handlers.test.ts`
+
+**Step 3: Implement minimal production fix**
+
+Apply the smallest change in the corresponding source file (`src/main/index.ts`, `src/main/ipc-handlers.ts`, `src/main/state-store.ts`, or renderer wiring files).
+
+**Step 4: Re-run targeted test, then full gate**
+
+Run targeted test first, then:
+
+Run: `npm run test:ci:local`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add <tests-and-source-files-for-fix>
+git commit -m "fix(app): resolve KAT-101 integration gate regression"
+```
+
+### Task 5: Final verification and evidence review before completion
+
+**Files:**
+- Review: `test-results/kat-101/*.json`
+- Review: `playwright-report/` (if failures occurred)
+
+**Step 1: Verify evidence artifacts are present and coherent**
+
+Check that at least one artifact includes:
+- resolved state file path
+- persisted space snapshot
+- pre/post relaunch counts
+
+**Step 2: Re-run final confidence checks**
+
+Run:
+- `npm run test:e2e:quality-gate -- --grep "persist|default userData/app-state.json"`
+- `npm run test:ci:local`
+
+Expected: PASS.
+
+**Step 3: Commit any last test-only updates (if needed)**
+
+```bash
+git add tests/e2e test-results/kat-101
+git commit -m "test(app): finalize KAT-101 integration verification evidence"
+```
+

--- a/app/tests/e2e/fixtures/electron.ts
+++ b/app/tests/e2e/fixtures/electron.ts
@@ -42,9 +42,26 @@ export const test = base.extend<ElectronFixtures>({
   },
   managedStateFilePath: async ({ managedTestRootDir }, use) => {
     const stateFilePath = path.join(managedTestRootDir, 'state.json')
+    await fs.writeFile(
+      stateFilePath,
+      JSON.stringify(
+        {
+          spaces: {},
+          sessions: {},
+          activeSpaceId: null,
+          activeSessionId: null
+        },
+        null,
+        2
+      ),
+      'utf8'
+    )
     await use(stateFilePath)
   },
-  electronApp: async ({ managedWorkspaceBaseDir, managedRepoCacheBaseDir, managedStateFilePath }, use) => {
+  electronApp: async (
+    { managedTestRootDir, managedWorkspaceBaseDir, managedRepoCacheBaseDir, managedStateFilePath },
+    use
+  ) => {
     const launchArgs = process.env.CI
       ? ['--no-sandbox', '--disable-setuid-sandbox', mainEntry]
       : [mainEntry]
@@ -52,6 +69,7 @@ export const test = base.extend<ElectronFixtures>({
       args: launchArgs,
       env: {
         ...process.env,
+        HOME: managedTestRootDir,
         KATA_WORKSPACE_BASE_DIR: managedWorkspaceBaseDir,
         KATA_REPO_CACHE_BASE_DIR: managedRepoCacheBaseDir,
         KATA_STATE_FILE: managedStateFilePath

--- a/app/tests/e2e/helpers/evidence.ts
+++ b/app/tests/e2e/helpers/evidence.ts
@@ -1,0 +1,32 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+
+type Kat101EvidenceInput = {
+  testName: string
+  stateFilePath: string
+  spaceName: string
+  preRelaunchCount: number
+  postRelaunchCount: number
+  persistedSpace: unknown
+}
+
+export async function writeKat101Evidence(input: Kat101EvidenceInput): Promise<string> {
+  const outputDir = path.resolve(process.cwd(), 'test-results/kat-101')
+  await fs.mkdir(outputDir, { recursive: true })
+
+  const outputPath = path.join(outputDir, `${input.testName}-${Date.now()}.json`)
+  await fs.writeFile(
+    outputPath,
+    JSON.stringify(
+      {
+        generatedAt: new Date().toISOString(),
+        ...input
+      },
+      null,
+      2
+    ),
+    'utf8'
+  )
+
+  return outputPath
+}

--- a/app/tests/e2e/managed-provisioning.spec.ts
+++ b/app/tests/e2e/managed-provisioning.spec.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url'
 
 import { _electron as electron, type ElectronApplication } from '@playwright/test'
 import { expect, test } from './fixtures/electron'
+import { writeKat101Evidence } from './helpers/evidence'
 import { ensureHomeSpacesView } from './helpers/shell-view'
 
 type SpaceListEntry = {
@@ -14,6 +15,19 @@ type SpaceListEntry = {
   rootPath: string
   branch: string
   workspaceMode?: string
+}
+
+type PersistedState = {
+  spaces: Record<
+    string,
+    {
+      id: string
+      name: string
+      rootPath: string
+      branch: string
+      workspaceMode?: string
+    }
+  >
 }
 
 const __filename = fileURLToPath(import.meta.url)
@@ -66,6 +80,20 @@ async function getSpaceByName(appWindow: import('@playwright/test').Page, name: 
   const matched = ((allSpaces as SpaceListEntry[] | undefined) ?? []).find((space) => space.name === name)
   expect(matched).toBeDefined()
   return matched as SpaceListEntry
+}
+
+async function listSpaces(appWindow: import('@playwright/test').Page): Promise<SpaceListEntry[]> {
+  const allSpaces = await appWindow.evaluate(async () => {
+    const api = (window as { kata?: { spaceList?: () => Promise<unknown> } }).kata
+    return await api?.spaceList?.()
+  })
+
+  return (allSpaces as SpaceListEntry[] | undefined) ?? []
+}
+
+async function readPersistedState(stateFilePath: string): Promise<PersistedState> {
+  const raw = await fsPromises.readFile(stateFilePath, 'utf8')
+  return JSON.parse(raw) as PersistedState
 }
 
 test.describe('managed provisioning @uat @ci', () => {
@@ -163,7 +191,7 @@ test.describe('managed provisioning @uat @ci', () => {
     expect(runGit(createdSpace.rootPath, ['rev-parse', '--abbrev-ref', 'HEAD']).trim()).toBe('main')
   })
 
-  test('persists spaces across app restart', async ({
+  test('persists spaces across app restart @quality-gate', async ({
     appWindow,
     electronApp,
     managedTestRootDir,
@@ -172,14 +200,24 @@ test.describe('managed provisioning @uat @ci', () => {
     managedStateFilePath
   }) => {
     const localSourcePath = path.join(managedTestRootDir, 'fixtures', 'persist-source')
+    const persistedSpaceName = `Persisted Space ${Date.now()}`
     await createSeedRepo(localSourcePath)
 
     await ensureHomeSpacesView(appWindow)
 
-    await appWindow.getByRole('textbox', { name: 'Space name' }).fill('Persisted Space')
+    await appWindow.getByRole('textbox', { name: 'Space name' }).fill(persistedSpaceName)
     await appWindow.getByRole('textbox', { name: 'Local repo path' }).fill(localSourcePath)
     await appWindow.getByRole('button', { name: 'Create space' }).click()
-    await expect(appWindow.getByRole('button', { name: 'Select space Persisted Space' })).toBeVisible()
+    await expect(appWindow.getByRole('button', { name: `Select space ${persistedSpaceName}` })).toBeVisible()
+
+    const preRelaunchSpaces = await listSpaces(appWindow)
+    await expect.poll(() => fs.existsSync(managedStateFilePath)).toBe(true)
+    const persistedState = await readPersistedState(managedStateFilePath)
+    const persistedSpace = Object.values(persistedState.spaces).find((space) => space.name === persistedSpaceName)
+    expect(persistedSpace).toBeDefined()
+    expect(persistedSpace?.workspaceMode).toBe('managed')
+    expect(persistedSpace?.branch).toBe('main')
+    expect(persistedSpace?.rootPath.endsWith('/repo')).toBe(true)
 
     await electronApp.close()
 
@@ -201,11 +239,124 @@ test.describe('managed provisioning @uat @ci', () => {
       const relaunchedWindow = await relaunched.firstWindow()
       await relaunchedWindow.waitForLoadState('load')
       await ensureHomeSpacesView(relaunchedWindow)
-      await expect(relaunchedWindow.getByRole('button', { name: 'Select space Persisted Space' })).toBeVisible()
+      await expect(
+        relaunchedWindow.getByRole('button', { name: `Select space ${persistedSpaceName}` })
+      ).toBeVisible()
+      const postRelaunchSpaces = await listSpaces(relaunchedWindow)
+      await writeKat101Evidence({
+        testName: 'persists-spaces-across-app-restart',
+        stateFilePath: managedStateFilePath,
+        spaceName: persistedSpaceName,
+        preRelaunchCount: preRelaunchSpaces.length,
+        postRelaunchCount: postRelaunchSpaces.length,
+        persistedSpace
+      })
     } finally {
       await relaunched.close().catch((error) => {
         console.warn('[fixture teardown] relaunched.close() failed:', error)
       })
+    }
+  })
+
+  test('writes state to default userData/app-state.json when KATA_STATE_FILE is absent @quality-gate @ci', async ({
+    managedTestRootDir,
+    managedWorkspaceBaseDir,
+    managedRepoCacheBaseDir
+  }) => {
+    const localSourcePath = path.join(managedTestRootDir, 'fixtures', 'default-state-path-source')
+    const defaultPathSpaceName = `Default State Path Space ${Date.now()}`
+    await createSeedRepo(localSourcePath)
+
+    const launchArgs = process.env.CI
+      ? ['--no-sandbox', '--disable-setuid-sandbox', mainEntry]
+      : [mainEntry]
+
+    const appWithoutStateOverride: ElectronApplication = await electron.launch({
+      args: launchArgs,
+      env: {
+        ...process.env,
+        HOME: managedTestRootDir,
+        KATA_STATE_FILE: '',
+        KATA_WORKSPACE_BASE_DIR: managedWorkspaceBaseDir,
+        KATA_REPO_CACHE_BASE_DIR: managedRepoCacheBaseDir
+      }
+    })
+
+    let appWithoutStateOverrideClosed = false
+    let defaultStatePath = ''
+    let preRelaunchCount = 0
+    let persistedSpace:
+      | {
+          id: string
+          name: string
+          rootPath: string
+          branch: string
+          workspaceMode?: string
+        }
+      | undefined
+
+    try {
+      const appWindow = await appWithoutStateOverride.firstWindow()
+      await appWindow.waitForLoadState('load')
+      await ensureHomeSpacesView(appWindow)
+
+      await appWindow.getByRole('textbox', { name: 'Space name' }).fill(defaultPathSpaceName)
+      await appWindow.getByRole('textbox', { name: 'Local repo path' }).fill(localSourcePath)
+      await appWindow.getByRole('button', { name: 'Create space' }).click()
+      await expect(appWindow.getByRole('button', { name: `Select space ${defaultPathSpaceName}` })).toBeVisible()
+
+      const userDataPath = await appWithoutStateOverride.evaluate(async ({ app }) => app.getPath('userData'))
+      defaultStatePath = path.join(userDataPath, 'app-state.json')
+      preRelaunchCount = (await listSpaces(appWindow)).length
+      await appWithoutStateOverride.close()
+      appWithoutStateOverrideClosed = true
+
+      await expect.poll(() => fs.existsSync(defaultStatePath)).toBe(true)
+      const persistedState = await readPersistedState(defaultStatePath)
+      persistedSpace = Object.values(persistedState.spaces).find((space) => space.name === defaultPathSpaceName)
+      expect(persistedSpace).toBeDefined()
+      expect(persistedSpace?.workspaceMode).toBe('managed')
+      expect(persistedSpace?.branch).toBe('main')
+      expect(persistedSpace?.rootPath.endsWith('/repo')).toBe(true)
+
+      const relaunched: ElectronApplication = await electron.launch({
+        args: launchArgs,
+        env: {
+          ...process.env,
+          HOME: managedTestRootDir,
+          KATA_STATE_FILE: '',
+          KATA_WORKSPACE_BASE_DIR: managedWorkspaceBaseDir,
+          KATA_REPO_CACHE_BASE_DIR: managedRepoCacheBaseDir
+        }
+      })
+
+      try {
+        const relaunchedWindow = await relaunched.firstWindow()
+        await relaunchedWindow.waitForLoadState('load')
+        await ensureHomeSpacesView(relaunchedWindow)
+        await expect(
+          relaunchedWindow.getByRole('button', { name: `Select space ${defaultPathSpaceName}` })
+        ).toBeVisible()
+        const postRelaunchSpaces = await listSpaces(relaunchedWindow)
+        await writeKat101Evidence({
+          testName: 'writes-default-userdata-state-path',
+          stateFilePath: defaultStatePath,
+          spaceName: defaultPathSpaceName,
+          preRelaunchCount,
+          postRelaunchCount: postRelaunchSpaces.length,
+          persistedSpace
+        })
+      } finally {
+        await relaunched.close().catch((error) => {
+          console.warn('[fixture teardown] relaunched.close() failed:', error)
+        })
+      }
+    } finally {
+      if (!appWithoutStateOverrideClosed) {
+        await appWithoutStateOverride.close().catch((error) => {
+          console.warn('[fixture teardown] appWithoutStateOverride.close() failed:', error)
+        })
+      }
     }
   })
 })


### PR DESCRIPTION
## Summary
- add KAT-101 E2E coverage for create -> relaunch persistence with explicit state-file JSON assertions
- add default userData `app-state.json` persistence verification when `KATA_STATE_FILE` is absent
- add `tests/e2e/helpers/evidence.ts` and emit machine-readable artifacts under `test-results/kat-101/`
- harden Electron E2E fixture isolation by seeding empty state and setting `HOME` to per-test temp root
- add design + implementation plan docs for KAT-101 under `docs/plans/`

## Test Plan
- npm run test:ci:local

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR establishes KAT-101 integration quality gate coverage for Slice 0, adding automated E2E assertions for create -> relaunch persistence with explicit state-file JSON verification.

**Major changes:**
- Added `@quality-gate` tag and state file assertions to persistence test
- New test validates default `userData/app-state.json` path when `KATA_STATE_FILE` is absent
- Fixture now seeds empty state and sets `HOME` to per-test temp root for stronger isolation
- New evidence helper emits machine-readable artifacts to `test-results/kat-101/` for successful runs
- Added design doc and implementation plan under `app/docs/plans/`

**Key improvements:**
- Explicit JSON assertions verify persisted space data (`workspaceMode`, `branch`, `rootPath`)
- Dual-path validation strategy covers both controlled CI path and production-default behavior
- Enhanced error handling with try-finally blocks and cleanup guards

<h3>Confidence Score: 4/5</h3>

- Safe to merge after fixing HOME env inconsistency in relaunch
- Well-structured test improvements with good isolation and error handling. One environment variable inconsistency should be resolved for test reliability.
- Pay close attention to `app/tests/e2e/managed-provisioning.spec.ts` - ensure HOME env is set consistently in all relaunches

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/tests/e2e/fixtures/electron.ts | Enhanced test isolation by seeding empty state file and setting HOME env to per-test temp directory |
| app/tests/e2e/helpers/evidence.ts | New helper to emit machine-readable JSON artifacts for KAT-101 integration evidence under test-results/kat-101/ |
| app/tests/e2e/managed-provisioning.spec.ts | Added quality-gate persistence assertions, default userData path test, and evidence artifacts. Missing HOME in first relaunch. |

</details>


</details>


<sub>Last reviewed commit: 2bfc28e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->