### PR TITLE
chore: update sync-worktrees script to improve branch switching and pulling logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ __pycache__/
 app/.env*
 !app/.env.example
 .env
+test-results/.last-run.json


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Improved `sync-worktrees.sh` script to be more robust by adding explicit branch switching and validation checks.

**Key changes:**
- Added explicit `git switch main` before pulling main branch
- Changed from `git reset --hard main` to `git pull --ff-only` approach for syncing worktrees
- Added validation to check if standby branches exist before processing
- Script now switches worktrees to standby branch instead of skipping them when on wrong branch
- Added `test-results/.last-run.json` to `.gitignore`

**Issue found:**
- Line 62 uses `git pull --ff-only` without specifying remote/branch, which requires upstream tracking to be configured. If standby branches lack tracking configuration, this command will fail.

<h3>Confidence Score: 3/5</h3>

- Safe to merge with one logical issue that could cause runtime failures in specific configurations
- The changes improve the script's robustness with better validation and explicit branch switching. However, line 62's `git pull --ff-only` assumes upstream tracking is configured, which could cause failures if standby branches don't have tracking set up. The `.gitignore` change is completely safe.
- Pay close attention to `bin/sync-worktrees.sh` - verify that standby branches have upstream tracking configured, or update the pull command to explicitly specify `origin main`

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| bin/sync-worktrees.sh | Improved branch switching logic and added validation checks, but `git pull --ff-only` on line 62 may fail if standby branches lack upstream tracking configuration |
| .gitignore | Added `test-results/.last-run.json` to gitignore - clean and safe change |

</details>


</details>


<sub>Last reviewed commit: 4b633c0</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->