### PR TITLE
KAT-170 feat: add coordinator sidebar mode

### DIFF
--- a/app/docs/plans/2026-03-06-kat-170-sidebar-sectionsnav-with-collapse-expand-behavior-design.md
+++ b/app/docs/plans/2026-03-06-kat-170-sidebar-sectionsnav-with-collapse-expand-behavior-design.md
@@ -1,0 +1,385 @@
+# KAT-170 [02.2] Sidebar sections/nav with collapse-expand behavior Design
+
+**Issue:** KAT-170  
+**Linear URL:** https://linear.app/kata-sh/issue/KAT-170/022-sidebar-sectionsnav-with-collapse-expand-behavior  
+**Branch target:** `feature/kat-170-022-sidebar-sectionsnav-with-collapse-expand-behavior`  
+**Parent epic:** KAT-163 Post-Slice A - Coordinator Session Parity (Spec 02)  
+**Specs:** `_plans/design/specs/02-coordinator-session.md`  
+**Relevant mocks:** `04-coordinator-session-initial-state.png`, `05-coordinator-session-pasted-context.png`, `06-coordinator-session-spec-context-reading.png`, `07-coordinator-session-spec-analyzing.png`
+
+## Scope and Outcome
+
+Implement the left coordinator-session sidebar surface so it matches the Spec 02 mock family for the scoped behaviors this ticket owns:
+
+- stacked `Agents` and `Context` sections in the expanded sidebar
+- icon-rail navigation affordances that remain visible when the sidebar is collapsed
+- collapse and expand behavior that preserves the selected mode
+- coordinator-row and context-row presentation aligned with the mock states
+
+This ticket is classified as **Final fidelity (scoped)** for the left sidebar surface. It owns shippable UX quality for the sidebar states shown in mocks `04` through `07`, with regression-safe tests. It does **not** own:
+
+- message-card and status badge primitives in the center column (`KAT-171`, `KAT-172`)
+- right-panel workflow/spec fidelity (`KAT-175`, `KAT-178`)
+- cross-surface parity evidence package (`KAT-176`)
+- agent/context persistence contracts (`KAT-169`)
+
+Required outcome:
+
+- coordinator sessions render a sidebar whose default expanded state visually reads like the mocks, not like the current tabbed workspace sidebar
+- the left rail remains reusable for future `Changes` and `Files` views instead of forcing a one-off fork
+- the implementation consumes the KAT-169 coordinator selectors rather than inventing new renderer-only data parsing
+- top-level left-rail affordances remain mutually exclusive for now; selecting one should not expand multiple top-level surfaces at once
+
+## Context Loaded
+
+Sources reviewed for this design:
+
+- Linear:
+  - `KAT-170` issue, comments, blocker chain, and parent epic `KAT-163`
+  - blocker `KAT-169`, which is `Done` as of **March 6, 2026**
+- Linear documents:
+  - `Execution Model: UI Baseline then Parallel Functional Vertical Slices`
+  - `Desktop App Linear Workflow Contract`
+  - `UI Ticket Fidelity Contract (Desktop App)`
+- Specs and mocks:
+  - `AGENTS.md`
+  - `_plans/design/specs/README.md`
+  - `_plans/design/specs/02-coordinator-session.md`
+  - `_plans/design/mocks/README.md`
+  - local mock images `04` through `07`
+- Current implementation:
+  - `src/renderer/components/layout/AppShell.tsx`
+  - `src/renderer/components/layout/LeftPanel.tsx`
+  - `src/renderer/components/left/AgentsTab.tsx`
+  - `src/renderer/components/left/AgentCard.tsx`
+  - `src/renderer/components/left/ContextTab.tsx`
+  - `src/renderer/components/left/LeftSection.tsx`
+  - `src/renderer/hooks/useSessionAgentRoster.ts`
+  - `src/renderer/features/coordinator-session/domain/contracts.ts`
+  - `src/renderer/features/coordinator-session/domain/selectors.ts`
+  - `src/renderer/components/center/ChatPanel.tsx`
+  - `src/renderer/components/layout/RightPanel.tsx`
+- Existing tests and nearby docs:
+  - `tests/unit/renderer/left/LeftPanel.test.tsx`
+  - `tests/e2e/kat-185-agent-roster-sidebar.spec.ts`
+  - `docs/plans/2026-03-06-kat-169-agentcontext-sidebar-domain-model-state-contracts-design.md`
+  - `docs/plans/2026-03-06-kat-171-conversation-message-primitives-coordinator-status-design.md`
+
+## Current State Summary
+
+The foundation for this ticket is already present, but it currently resolves to the wrong user experience for Spec 02:
+
+- `AppShell` already owns left-column width, collapse state, and the rail/content split.
+- `LeftPanel` already has a persistent icon rail and working collapse/expand controls.
+- KAT-169 has already established canonical coordinator selectors for:
+  - prompt preview text
+  - session context resources
+  - active-run context chips and summary
+- `AgentsTab` and `ContextTab` are still shaped for the broader workspace shell, not the coordinator mock:
+  - `AgentsTab` shows card-style summaries and background-agent rollups
+  - `ContextTab` is still driven by project tasks and `./notes` copy, not session context resources
+  - `LeftPanel` shows one active tab at a time and includes `LeftStatusSection`, which the coordinator mocks do not show
+
+The result is close in infrastructure but wrong in composition. The current sidebar is a general workspace navigator. Spec 02 needs a coordinator-focused sidebar that is visibly simpler: a narrow rail, then one stacked content column containing `Agents` and `Context`.
+
+## Clarifications and Assumptions
+
+- Use the KAT-169 coordinator selectors as the only source for sidebar-specific data semantics. This ticket should not parse run prompts or context resources directly inside JSX.
+- Reuse the existing `LeftPanel` rail, collapse state, and `AppShell` plumbing unless that reuse directly blocks mock parity.
+- Keep top-level affordances mutually exclusive for now. `Agents`, `Context`, `Changes`, and `Files` should each continue to map to one active surface at a time.
+- Preserve `Changes` and `Files` as selectable rail destinations for later specs, but do not let those surfaces distort the default coordinator experience in mocks `04` through `07`.
+- The `+ Create new agent` and `+ Add context` affordances are presentation-only in this ticket unless backing flows already exist. Their interactive behavior can remain stubbed or callback-driven.
+- Width tuning needed for sidebar parity is in scope for this ticket when it is necessary to land the left-surface fidelity, but full three-column balancing still belongs to downstream parity verification.
+
+## Approaches Considered
+
+### Approach 1 (Recommended): Coordinator-specific tab content on top of the existing `LeftPanel` shell
+
+Keep `LeftPanel` as the owner of the rail and collapse mechanics, but introduce coordinator-session variants for the `Agents` and `Context` tabs so each top-level affordance remains exclusive while its selected content becomes Spec 02 faithful.
+
+Pros:
+
+- Reuses the tested collapse/expand mechanics already present in `LeftPanel`.
+- Preserves one left-sidebar architecture for coordinator, build, changes, and files flows.
+- Keeps the top-level interaction model aligned with the current shell and your clarification.
+- Fits naturally with the KAT-169 selector model.
+
+Cons:
+
+- Requires targeted refactoring of `AgentsTab` and `ContextTab` so they present the Spec 02 content model rather than the current workspace-shell defaults.
+- Introduces a small mode concept into `LeftPanel` and `AppShell`.
+
+### Approach 2: Stack `Agents` and `Context` into one coordinator-only content view
+
+Leave the rail in place but make both top-level affordances point to the same expanded coordinator composition containing both sections.
+
+Pros:
+
+- Closest structural match to a literal reading of the mocks.
+- Produces a very focused coordinator sidebar.
+
+Cons:
+
+- Conflicts with the clarified interaction requirement that top-level affordances should not stack for now.
+- Makes the rail semantics ambiguous because two icons would map to the same active content surface.
+- Adds complexity around focus and selection without clear product value today.
+
+### Approach 3: Keep the current tabbed `LeftPanel` and only restyle it to look closer to the mock
+
+Leave the one-tab-at-a-time structure in place and try to mimic the mock via typography, spacing, and narrower widths.
+
+Pros:
+
+- Lowest code churn.
+- Reuses almost all current test coverage.
+
+Cons:
+
+- Keeps too much of the current workspace-shell content model, especially the `ContextTab` task tree and left status block.
+- Risks landing a cosmetic change instead of the scoped Spec 02 fidelity work.
+- Still needs coordinator-specific copy and selector-backed rows, so the savings are smaller than they appear.
+
+### Approach 4: Fork a dedicated `CoordinatorSidebar` separate from `LeftPanel`
+
+Create a new standalone sidebar for Spec 02 and leave the existing `LeftPanel` untouched.
+
+Pros:
+
+- Fastest path to strict visual matching for the current mocks.
+- Avoids threading mode flags through current sidebar code.
+
+Cons:
+
+- Duplicates collapse, rail, and panel infrastructure that already exists.
+- Increases merge risk with future sidebar work in Specs 04-07.
+- Makes long-term maintenance worse because left-column behavior would diverge by surface instead of sharing primitives.
+
+## Recommendation
+
+Proceed with **Approach 1**.
+
+This ticket should treat the current `LeftPanel` as a shell primitive, not as the final coordinator UX. The rail, collapse button, and one-active-affordance selection state are worth preserving. The selected `Agents` and `Context` bodies need to be recomposed around Spec 02 rather than forced through the current workspace-shell content.
+
+## Proposed Design
+
+## 1) Sidebar Ownership Boundary
+
+Keep responsibilities split like this:
+
+- `AppShell`
+  - owns left-column width and cross-column layout
+  - passes the active session/space context into the left panel
+- `LeftPanel`
+  - owns the icon rail
+  - owns expanded vs collapsed state
+  - owns which rail destination is active
+  - chooses which coordinator-specific content body to render for the active surface
+- new coordinator-sidebar content layer
+  - renders a Spec 02 faithful `Agents` body and a Spec 02 faithful `Context` body
+  - consumes selector-backed data
+  - owns coordinator-specific copy and section spacing
+
+Recommended renderer additions:
+
+- `src/renderer/components/left/CoordinatorAgentsSection.tsx`
+- `src/renderer/components/left/CoordinatorContextSection.tsx`
+- `src/renderer/components/left/CoordinatorSidebarMode.ts`
+
+These should be compositional wrappers around existing left-panel building blocks, not a parallel design system.
+
+## 2) Content Model: Exclusive Top-Level Affordances, Coordinator-Specific Bodies
+
+In coordinator mode, the expanded content area should still render one active top-level destination at a time.
+
+Rail selection behavior:
+
+- `agents` icon:
+  - opens the coordinator-specific `Agents` content
+- `context` icon:
+  - opens the coordinator-specific `Context` content
+- `changes` / `files` icons:
+  - continue to render their dedicated single-surface panels
+
+This preserves a clear top-level interaction model while still allowing the `Agents` and `Context` surfaces themselves to be redesigned to match the coordinator mocks more closely.
+
+## 3) Coordinator Data Inputs
+
+The coordinator sidebar content should consume the KAT-169 selector outputs, not raw store maps:
+
+```ts
+selectCoordinatorAgentList(state, sessionId)
+selectCoordinatorContextItems(state, sessionId)
+selectCoordinatorPromptPreview(state, sessionId)
+```
+
+Recommended view-model assembly:
+
+- `Agents` surface:
+  - list items from `selectCoordinatorAgentList`
+  - coordinator preview subtitle from `selectCoordinatorPromptPreview`
+- `Context` surface:
+  - items from `selectCoordinatorContextItems`
+
+Display rules:
+
+- the coordinator row subtitle should prefer the prompt preview string from the latest run
+- non-coordinator agents can fall back to `currentTask` or role copy when present
+- the `Spec` context resource should always render first when seeded by session creation
+
+This keeps the sidebar aligned with the data contract already stabilized by KAT-169.
+
+## 4) Surface Presentation
+
+The mock’s copy and row treatment are lighter than the current workspace-shell left content. Each selected coordinator surface should read as:
+
+- semibold section label
+- muted explanatory copy
+- inline text affordance such as `+ Create new agent` or `+ Add context`
+- simple row list underneath
+
+Design implication:
+
+- extend `LeftSection` so it can render either:
+  - the current icon-button action style, or
+  - a mock-faithful inline text action style
+- do not force coordinator surfaces to use the current top-right plus-icon pattern
+
+Surface-specific rules:
+
+### Agents
+
+- Description copy should remain: `Agents write code, maintain notes, and coordinate tasks.`
+- The primary coordinator row should use the compact mock style:
+  - small colored status/icon marker
+  - name
+  - truncated preview subtitle
+- Background/delegated agent grouping from the current `AgentsTab` should remain supported, but the default mock path should render cleanly when only the coordinator is present.
+
+### Context
+
+- Replace the current `./notes` guidance with the Spec 02 copy about shared context and notes location.
+- Rows should be simple text items, not nested task-state lists.
+- `Spec` should be rendered as the baseline seeded resource.
+
+## 5) Collapse and Expand Behavior
+
+The current collapse model is directionally correct and should be retained with tighter coordinator semantics.
+
+Required behavior:
+
+- collapsing the sidebar hides only the expanded content pane and preserves the rail
+- the rail remains fully interactive while collapsed
+- expanding restores the last selected destination
+- collapse state must remain controllable from `LeftPanel` and from higher-level shell props, as current tests already require
+
+Accessibility requirements:
+
+- keep explicit `aria-label`s for collapse and expand buttons
+- keep `aria-hidden` on the content pane while collapsed
+- preserve visible focus state for rail buttons when the content pane is hidden
+
+## 6) Width and Layout Tuning
+
+The current `AppShell` defaults are too wide for the coordinator mock family:
+
+- `LEFT_MIN = 320`
+- `LEFT_DEFAULT = 390`
+
+Spec 02 visually needs a narrower sidebar. The design should therefore allow coordinator-mode width presets, for example:
+
+- coordinator left default around `240-260px`
+- collapsed rail remains `56px`
+- max width lower than the current build-session-oriented shell
+
+Recommended approach:
+
+- keep the existing generic layout math in `AppShell`
+- add per-surface width presets rather than globally shrinking the left column for every app mode
+
+This keeps Spec 02 fidelity work isolated from later left-column variants that may want more room.
+
+## 7) Interaction and State Mapping
+
+The sidebar behavior in the four referenced mocks can be mapped like this:
+
+- Mock 04 initial state:
+  - expanded coordinator sidebar
+  - `Agents` selected
+  - coordinator row preview populated from latest run prompt
+- Mock 05 pasted context:
+  - same `Agents` surface can remain selected
+  - no structural sidebar difference; center/right change only
+- Mock 06 context reading:
+  - same selected top-level surface
+  - context item list remains stable while center chips show active run references
+- Mock 07 analyzing:
+  - same selected top-level surface
+  - no special-case left state beyond preserving selection and compactness
+
+That means this ticket should avoid inventing state-specific sidebar branches. The left surface is intentionally stable across `04` through `07`, with the active top-level affordance preserved.
+
+## 8) Suggested Refactor Shape
+
+A pragmatic implementation path is:
+
+1. Refactor `AgentsTab` into a coordinator-friendly `Agents` surface backed by selector data.
+2. Refactor `ContextTab` into a coordinator-friendly `Context` surface backed by context resources instead of mock project tasks.
+3. Update `LeftPanel` so coordinator mode routes `agents` and `context` to those refined surfaces, while `changes` and `files` remain on their existing paths.
+4. Narrow coordinator-mode width presets in `AppShell`.
+
+This sequence keeps the write scope localized and minimizes churn in working `Changes` and `Files` views.
+
+## 9) Testing Strategy (TDD)
+
+Unit coverage should lock the left-surface behavior before implementation:
+
+- `LeftPanel` in coordinator mode renders one active top-level surface at a time
+- `agents` rail selection renders the coordinator `Agents` surface
+- `context` rail selection renders the coordinator `Context` surface
+- coordinator prompt preview is rendered from selector-backed data
+- context items are rendered from session context resources rather than mock project tasks
+- collapsing hides the content pane and preserves rail interaction
+- expanding restores the coordinator content pane
+- controlled collapse still emits `onCollapsedChange` without mutating internal state
+
+E2E coverage for this ticket should prove:
+
+- a seeded coordinator session shows the coordinator `Agents` surface by default
+- switching to `Context` shows `Spec` in the context surface
+- collapse and expand preserve the rail and restore the sidebar content
+
+`KAT-176` will still own the final mock-parity evidence package across the full three-column surface, but this ticket should land regression-safe unit and targeted E2E coverage for its own behavior.
+
+## 10) Risks and Mitigations
+
+### Risk: breaking other left-column flows while narrowing the coordinator sidebar
+
+Mitigation:
+
+- isolate the stacked coordinator composition behind an explicit coordinator surface mode
+- keep `Changes` and `Files` on their existing render paths
+
+### Risk: coupling this ticket to unfinished create-agent or add-context flows
+
+Mitigation:
+
+- keep affordances callback-driven and presentation-first
+- do not block sidebar parity on full creation flows
+
+### Risk: duplicating KAT-169 contract logic in the renderer
+
+Mitigation:
+
+- consume only selector outputs from `src/renderer/features/coordinator-session/domain`
+- forbid prompt-preview derivation inside JSX components
+
+## Recommendation for Approval
+
+Approve this design if the intended implementation direction is:
+
+- reuse the existing rail/collapse shell
+- keep one active top-level affordance at a time
+- replace the current workspace-shell `Agents` and `Context` bodies with coordinator-specific surfaces
+- keep `Changes` and `Files` accessible without letting them define the Spec 02 default view
+
+If that direction looks right, the next step is the implementation plan and TDD task breakdown for the `LeftPanel`/`AppShell` refactor.

--- a/app/docs/plans/2026-03-06-kat-170-sidebar-sectionsnav-with-collapse-expand-behavior-implementation-plan.md
+++ b/app/docs/plans/2026-03-06-kat-170-sidebar-sectionsnav-with-collapse-expand-behavior-implementation-plan.md
@@ -1,0 +1,532 @@
+# KAT-170 Sidebar Sections/Nav With Collapse-Expand Behavior Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Ship the Spec 02 left sidebar behavior for coordinator sessions so `Agents`, `Context`, collapse/expand, and sidebar sizing match the scoped mock intent without stacking top-level affordances.
+
+**Architecture:** Keep the existing `LeftPanel` rail and collapse mechanics, but introduce coordinator-specific left-surface bodies and a small mode resolver so coordinator sessions can hide the build-session status block while preserving later Spec 04 behavior. Build the new UI from selector-backed data using a dedicated hook that combines roster, context resources, and runs instead of parsing prompt/context state in JSX.
+
+**Tech Stack:** React 19, Electron preload IPC, TypeScript, Tailwind/shadcn UI, Vitest, Playwright
+
+---
+
+Use `@test-driven-development` for each task. Use `@verification-before-completion` before claiming the ticket is done.
+
+### Task 1: Add a coordinator sidebar data hook
+
+**Files:**
+- Create: `src/renderer/hooks/useCoordinatorSidebarData.ts`
+- Test: `tests/unit/renderer/hooks/useCoordinatorSidebarData.test.ts`
+
+**Step 1: Write the failing test**
+
+```ts
+it('loads coordinator sidebar data from IPC and derives prompt preview + context items', async () => {
+  window.kata = {
+    sessionAgentRosterList: vi.fn().mockResolvedValue([coordinatorAgent]),
+    sessionContextResourcesList: vi.fn().mockResolvedValue([specResource]),
+    runList: vi.fn().mockResolvedValue([latestRun])
+  } as unknown as Window['kata']
+
+  const { result } = renderHook(() => useCoordinatorSidebarData('session-1'))
+
+  await waitFor(() => expect(result.current.isLoading).toBe(false))
+  expect(result.current.promptPreview).toContain('I would like to build')
+  expect(result.current.contextItems[0]?.label).toBe('Spec')
+  expect(result.current.agentItems[0]?.name).toBe('Coordinator')
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/renderer/hooks/useCoordinatorSidebarData.test.ts`
+Expected: FAIL with `Cannot find module '../../../../src/renderer/hooks/useCoordinatorSidebarData'` or equivalent missing export error.
+
+**Step 3: Write minimal implementation**
+
+```ts
+export function useCoordinatorSidebarData(sessionId: string | null) {
+  const [state, setState] = useState({
+    agentItems: [],
+    contextItems: [],
+    promptPreview: null,
+    isLoading: false,
+    error: null
+  })
+
+  useEffect(() => {
+    if (!sessionId || !window.kata?.sessionAgentRosterList || !window.kata?.sessionContextResourcesList || !window.kata?.runList) {
+      setState((current) => ({ ...current, agentItems: [], contextItems: [], promptPreview: null, isLoading: false }))
+      return
+    }
+
+    let disposed = false
+    setState((current) => ({ ...current, isLoading: true, error: null }))
+
+    void Promise.all([
+      window.kata.sessionAgentRosterList({ sessionId }),
+      window.kata.sessionContextResourcesList({ sessionId }),
+      window.kata.runList(sessionId)
+    ]).then(([agentRoster, contextResources, runs]) => {
+      if (disposed) return
+      const contractState = { agentRoster: indexById(agentRoster), contextResources: indexById(contextResources), runs: indexById(runs) }
+      setState({
+        agentItems: selectCoordinatorAgentList(contractState, sessionId),
+        contextItems: selectCoordinatorContextItems(contractState, sessionId),
+        promptPreview: selectCoordinatorPromptPreview(contractState, sessionId),
+        isLoading: false,
+        error: null
+      })
+    }).catch((error) => {
+      if (disposed) return
+      setState({ agentItems: [], contextItems: [], promptPreview: null, isLoading: false, error: toErrorMessage(error) })
+    })
+
+    return () => {
+      disposed = true
+    }
+  }, [sessionId])
+
+  return state
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/renderer/hooks/useCoordinatorSidebarData.test.ts`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/renderer/hooks/useCoordinatorSidebarData.ts tests/unit/renderer/hooks/useCoordinatorSidebarData.test.ts
+git commit -m "feat: add coordinator sidebar data hook"
+```
+
+### Task 2: Add an inline action variant to `LeftSection`
+
+**Files:**
+- Modify: `src/renderer/components/left/LeftSection.tsx`
+- Modify: `src/renderer/components/left/left-typography.ts`
+- Test: `tests/unit/renderer/left/LeftSection.test.tsx`
+
+**Step 1: Write the failing test**
+
+```tsx
+it('renders an inline text action when actionVariant is inline', () => {
+  const onAddAction = vi.fn()
+
+  render(
+    <LeftSection
+      title="Agents"
+      description="Agents write code, maintain notes, and coordinate tasks."
+      addActionLabel="Create new agent"
+      actionVariant="inline"
+      onAddAction={onAddAction}
+    >
+      <div>Body content</div>
+    </LeftSection>
+  )
+
+  expect(screen.getByRole('button', { name: 'Create new agent' })).toHaveTextContent('+ Create new agent')
+  expect(screen.queryByRole('button', { name: 'Add agent' })).toBeNull()
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/renderer/left/LeftSection.test.tsx`
+Expected: FAIL because `actionVariant` is not a valid prop and the inline action text does not exist.
+
+**Step 3: Write minimal implementation**
+
+```tsx
+type LeftSectionProps = {
+  // ...
+  actionVariant?: 'icon' | 'inline'
+}
+
+const actionVariant = props.actionVariant ?? 'icon'
+
+{actions ?? (
+  actionVariant === 'inline' ? (
+    <button
+      type="button"
+      className={LEFT_PANEL_TYPOGRAPHY.inlineAction}
+      onClick={onAddAction}
+      disabled={!onAddAction}
+    >
+      + {addActionLabel}
+    </button>
+  ) : (
+    <Button /* existing icon button */ />
+  )
+)}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/renderer/left/LeftSection.test.tsx`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/renderer/components/left/LeftSection.tsx src/renderer/components/left/left-typography.ts tests/unit/renderer/left/LeftSection.test.tsx
+git commit -m "feat: add inline left section actions"
+```
+
+### Task 3: Build the coordinator `Agents` surface
+
+**Files:**
+- Create: `src/renderer/components/left/CoordinatorAgentsSection.tsx`
+- Create: `src/renderer/components/left/CoordinatorAgentListItem.tsx`
+- Test: `tests/unit/renderer/left/CoordinatorAgentsSection.test.tsx`
+
+**Step 1: Write the failing test**
+
+```tsx
+it('renders coordinator prompt preview with inline create action and no background summary in the simple case', () => {
+  render(
+    <CoordinatorAgentsSection
+      agentItems={[coordinatorAgent]}
+      promptPreview="I would like to build the following product..."
+      isLoading={false}
+      error={null}
+    />
+  )
+
+  expect(screen.getByRole('heading', { name: 'Agents' })).toBeTruthy()
+  expect(screen.getByRole('button', { name: 'Create new agent' })).toHaveTextContent('+ Create new agent')
+  expect(screen.getByText('Coordinator')).toBeTruthy()
+  expect(screen.getByText('I would like to build the following product...')).toBeTruthy()
+  expect(screen.queryByRole('button', { name: /background agents running/i })).toBeNull()
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/renderer/left/CoordinatorAgentsSection.test.tsx`
+Expected: FAIL because the component file does not exist.
+
+**Step 3: Write minimal implementation**
+
+```tsx
+export function CoordinatorAgentsSection(props: CoordinatorAgentsSectionProps) {
+  return (
+    <LeftSection
+      title="Agents"
+      description="Agents write code, maintain notes, and coordinate tasks."
+      addActionLabel="Create new agent"
+      actionVariant="inline"
+    >
+      {props.agentItems.map((agent) => (
+        <CoordinatorAgentListItem
+          key={agent.id}
+          name={agent.name}
+          status={agent.status}
+          subtitle={agent.kind === 'coordinator' ? props.promptPreview ?? agent.currentTask ?? '' : agent.currentTask ?? agent.role}
+        />
+      ))}
+    </LeftSection>
+  )
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/renderer/left/CoordinatorAgentsSection.test.tsx`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/renderer/components/left/CoordinatorAgentsSection.tsx src/renderer/components/left/CoordinatorAgentListItem.tsx tests/unit/renderer/left/CoordinatorAgentsSection.test.tsx
+git commit -m "feat: add coordinator agents sidebar surface"
+```
+
+### Task 4: Build the coordinator `Context` surface
+
+**Files:**
+- Create: `src/renderer/components/left/CoordinatorContextSection.tsx`
+- Test: `tests/unit/renderer/left/CoordinatorContextSection.test.tsx`
+
+**Step 1: Write the failing test**
+
+```tsx
+it('renders selector-backed context resources with spec-first ordering and coordinator copy', () => {
+  render(
+    <CoordinatorContextSection
+      contextItems={[
+        { id: 'spec', kind: 'spec', label: 'Spec', sortOrder: 0, createdAt: '', updatedAt: '' },
+        { id: 'note-1', kind: 'note', label: 'Team Brainstorm', sortOrder: 1, createdAt: '', updatedAt: '' }
+      ]}
+      isLoading={false}
+      error={null}
+    />
+  )
+
+  expect(screen.getByRole('heading', { name: 'Context' })).toBeTruthy()
+  expect(screen.getByText('Context about the task, shared with all agents on demand.')).toBeTruthy()
+  expect(screen.getByRole('button', { name: 'Add context' })).toHaveTextContent('+ Add context')
+  expect(screen.getByText('Spec')).toBeTruthy()
+  expect(screen.getByText('Team Brainstorm')).toBeTruthy()
+  expect(screen.queryByText('./notes')).toBeNull()
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/renderer/left/CoordinatorContextSection.test.tsx`
+Expected: FAIL because the component file does not exist.
+
+**Step 3: Write minimal implementation**
+
+```tsx
+export function CoordinatorContextSection(props: CoordinatorContextSectionProps) {
+  return (
+    <LeftSection
+      title="Context"
+      description="Context about the task, shared with all agents on demand. Your notes live in /following.build/.workspace."
+      addActionLabel="Add context"
+      actionVariant="inline"
+    >
+      <div className="space-y-2">
+        {props.contextItems.map((item) => (
+          <button key={item.id} type="button" className="flex w-full items-center gap-2 text-left text-sm text-muted-foreground">
+            <span className="h-1.5 w-1.5 rounded-full bg-muted-foreground/70" />
+            <span>{item.label}</span>
+          </button>
+        ))}
+      </div>
+    </LeftSection>
+  )
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/renderer/left/CoordinatorContextSection.test.tsx`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/renderer/components/left/CoordinatorContextSection.tsx tests/unit/renderer/left/CoordinatorContextSection.test.tsx
+git commit -m "feat: add coordinator context sidebar surface"
+```
+
+### Task 5: Wire coordinator mode into `LeftPanel` and `AppShell`
+
+**Files:**
+- Create: `src/renderer/components/left/left-panel-mode.ts`
+- Test: `tests/unit/renderer/left/left-panel-mode.test.ts`
+- Modify: `src/renderer/components/layout/LeftPanel.tsx`
+- Modify: `src/renderer/components/layout/AppShell.tsx`
+- Modify: `tests/unit/renderer/left/LeftPanel.test.tsx`
+- Modify: `tests/unit/renderer/AppShell.test.tsx`
+
+**Step 1: Write the failing tests**
+
+```ts
+it('resolves coordinator mode when no task activity snapshot is present', () => {
+  expect(resolveLeftPanelMode({ taskActivitySnapshot: undefined })).toBe('coordinator')
+})
+
+it('hides the left status section and renders the coordinator agents surface in coordinator mode', () => {
+  render(<LeftPanel activeSpaceId="space-1" activeSessionId="session-1" taskActivitySnapshot={undefined} />)
+
+  expect(screen.queryByLabelText('Left panel status')).toBeNull()
+  expect(screen.getByRole('heading', { name: 'Agents' })).toBeTruthy()
+})
+
+it('uses the coordinator left-width preset when task activity is absent', () => {
+  render(<AppShell />)
+  const columns = parseShellColumns(screen.getByTestId('app-shell-grid').style.gridTemplateColumns)
+  expect(columns.left).toBe(248)
+})
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run tests/unit/renderer/left/left-panel-mode.test.ts tests/unit/renderer/left/LeftPanel.test.tsx tests/unit/renderer/AppShell.test.tsx`
+Expected: FAIL because the mode resolver does not exist, `LeftStatusSection` is still always rendered, and the left-column width is still `390`.
+
+**Step 3: Write minimal implementation**
+
+```ts
+export type LeftPanelMode = 'coordinator' | 'build'
+
+export function resolveLeftPanelMode(input: { taskActivitySnapshot?: TaskActivitySnapshot }): LeftPanelMode {
+  return input.taskActivitySnapshot ? 'build' : 'coordinator'
+}
+```
+
+```tsx
+const panelMode = resolveLeftPanelMode({ taskActivitySnapshot })
+const leftDefault = panelMode === 'coordinator' ? 248 : LEFT_DEFAULT
+
+{panelMode === 'build' ? (
+  <LeftStatusSection /* existing props */ />
+) : null}
+
+{activeTab === 'agents' ? (
+  panelMode === 'coordinator' ? (
+    <CoordinatorAgentsSection
+      agentItems={coordinatorSidebar.agentItems}
+      promptPreview={coordinatorSidebar.promptPreview}
+      isLoading={coordinatorSidebar.isLoading}
+      error={coordinatorSidebar.error}
+    />
+  ) : (
+    <AgentsTab agents={agents} isLoading={isAgentsLoading} error={agentsError} />
+  )
+) : null}
+
+{activeTab === 'context' ? (
+  panelMode === 'coordinator' ? (
+    <CoordinatorContextSection
+      contextItems={coordinatorSidebar.contextItems}
+      isLoading={coordinatorSidebar.isLoading}
+      error={coordinatorSidebar.error}
+    />
+  ) : (
+    <ContextTab project={project} previewState={previewState} />
+  )
+) : null}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run tests/unit/renderer/left/left-panel-mode.test.ts tests/unit/renderer/left/LeftPanel.test.tsx tests/unit/renderer/AppShell.test.tsx`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/renderer/components/left/left-panel-mode.ts src/renderer/components/layout/LeftPanel.tsx src/renderer/components/layout/AppShell.tsx tests/unit/renderer/left/left-panel-mode.test.ts tests/unit/renderer/left/LeftPanel.test.tsx tests/unit/renderer/AppShell.test.tsx
+git commit -m "feat: wire coordinator left panel mode"
+```
+
+### Task 6: Update E2E coverage for the coordinator sidebar
+
+**Files:**
+- Create: `tests/e2e/kat-170-sidebar-sectionsnav.spec.ts`
+- Modify: `tests/e2e/navigation.spec.ts`
+
+**Step 1: Write the failing E2E spec**
+
+```ts
+test.describe('KAT-170: coordinator sidebar behavior @ci', () => {
+  test('renders agents by default, switches to context, and restores from collapse', async ({ appWindow }) => {
+    await ensureWorkspaceShell(appWindow)
+
+    await expect(appWindow.getByRole('heading', { name: 'Agents' })).toBeVisible()
+    await expect(appWindow.getByLabel('Left panel status')).toHaveCount(0)
+    await expect(appWindow.getByText('Coordinator')).toBeVisible()
+
+    await appWindow.getByRole('tab', { name: 'Context' }).click()
+    await expect(appWindow.getByRole('heading', { name: 'Context' })).toBeVisible()
+    await expect(appWindow.getByText('Spec')).toBeVisible()
+
+    await appWindow.getByRole('button', { name: 'Collapse sidebar navigation' }).click()
+    await expect(appWindow.getByRole('button', { name: 'Expand sidebar navigation' })).toBeVisible()
+    await appWindow.getByRole('button', { name: 'Expand sidebar navigation' }).click()
+    await expect(appWindow.getByRole('heading', { name: 'Context' })).toBeVisible()
+  })
+})
+```
+
+**Step 2: Run E2E to verify it fails**
+
+Run: `npx playwright test tests/e2e/kat-170-sidebar-sectionsnav.spec.ts tests/e2e/navigation.spec.ts`
+Expected: FAIL because the new spec file is missing and `navigation.spec.ts` still expects the old context/status behavior.
+
+**Step 3: Write minimal implementation**
+
+```ts
+// navigation.spec.ts
+await leftTabs.getByRole('tab', { name: /Agents/ }).click()
+await expect(appWindow.getByRole('heading', { name: 'Agents' })).toBeVisible()
+await expect(appWindow.getByLabel('Left panel status')).toHaveCount(0)
+
+await leftTabs.getByRole('tab', { name: /Context/ }).click()
+await expect(appWindow.getByRole('heading', { name: 'Context' })).toBeVisible()
+await expect(appWindow.getByText('Spec')).toBeVisible()
+await expect(appWindow.getByText('./notes')).toHaveCount(0)
+```
+
+**Step 4: Run E2E to verify it passes**
+
+Run: `npx playwright test tests/e2e/kat-170-sidebar-sectionsnav.spec.ts tests/e2e/navigation.spec.ts`
+Expected: PASS for all targeted specs.
+
+**Step 5: Commit**
+
+```bash
+git add tests/e2e/kat-170-sidebar-sectionsnav.spec.ts tests/e2e/navigation.spec.ts
+git commit -m "test: cover coordinator sidebar behavior"
+```
+
+### Task 7: Final ticket verification
+
+**Files:**
+- Modify: none
+- Test: existing affected unit and E2E files only
+
+**Step 1: Run the affected unit suite**
+
+```bash
+npx vitest run \
+  tests/unit/renderer/hooks/useCoordinatorSidebarData.test.ts \
+  tests/unit/renderer/left/LeftSection.test.tsx \
+  tests/unit/renderer/left/CoordinatorAgentsSection.test.tsx \
+  tests/unit/renderer/left/CoordinatorContextSection.test.tsx \
+  tests/unit/renderer/left/left-panel-mode.test.ts \
+  tests/unit/renderer/left/LeftPanel.test.tsx \
+  tests/unit/renderer/AppShell.test.tsx
+```
+
+Expected: PASS.
+
+**Step 2: Run the targeted E2E suite**
+
+```bash
+npx playwright test tests/e2e/kat-170-sidebar-sectionsnav.spec.ts tests/e2e/navigation.spec.ts
+```
+
+Expected: PASS.
+
+**Step 3: Run lint**
+
+```bash
+npm run lint
+```
+
+Expected: PASS with no TypeScript errors.
+
+**Step 4: Capture evidence**
+
+Run:
+
+```bash
+npx playwright test tests/e2e/kat-170-sidebar-sectionsnav.spec.ts --headed
+```
+
+Expected: screenshot/video artifacts under `test-results/` showing:
+- `Agents` as the default coordinator surface
+- `Context` showing `Spec`
+- collapse/expand restore behavior
+
+**Step 5: Commit final verification note if needed**
+
+```bash
+git status
+```
+
+Expected: clean working tree. If any evidence-path updates or test harness changes are still unstaged, stage them and create a final commit:
+
+```bash
+git add -A
+git commit -m "chore: finalize kat-170 verification"
+```

--- a/app/src/renderer/components/layout/AppShell.tsx
+++ b/app/src/renderer/components/layout/AppShell.tsx
@@ -7,13 +7,16 @@ import { PanelResizer } from './PanelResizer'
 import { RightPanel } from './RightPanel'
 import type { ScrollToMessage } from '../center/MessageList'
 import type { ConversationEntry } from '../left/conversation-entry-index'
+import { resolveLeftPanelMode } from '../left/left-panel-mode'
 import type { LatestRunDraft } from '../../types/spec-document'
 import type { TaskActivitySnapshot } from '@shared/types/task-tracking'
 
 const RESIZER_WIDTH = 10
-const LEFT_MIN = 320
+const LEFT_MIN_BUILD = 320
+const LEFT_MIN_COORDINATOR = 320
 const LEFT_COLLAPSED = 56
-const LEFT_DEFAULT = 390
+const LEFT_DEFAULT_BUILD = 390
+const LEFT_DEFAULT_COORDINATOR = 390
 const LEFT_MAX = 520
 const DOCUMENT_MIN = 300
 export const THEME_STORAGE_KEY = 'kata-theme'
@@ -30,8 +33,8 @@ function clamp(value: number, min: number, max: number): number {
   return Math.min(Math.max(value, min), max)
 }
 
-function getMaxLeftWidth(availableWidth: number): number {
-  return Math.max(LEFT_MIN, Math.min(LEFT_MAX, availableWidth - RESIZER_WIDTH * 2 - DOCUMENT_MIN * 2))
+function getMaxLeftWidth(availableWidth: number, leftMin: number): number {
+  return Math.max(leftMin, Math.min(LEFT_MAX, availableWidth - RESIZER_WIDTH * 2 - DOCUMENT_MIN * 2))
 }
 
 function clampCenterRightOffset(offset: number, documentWidth: number): number {
@@ -90,7 +93,7 @@ export function observeShellWidth(
 
 export function AppShell({ activeSpaceId, activeSessionId, onOpenHome }: AppShellProps = {}) {
   const shellRef = useRef<HTMLDivElement | null>(null)
-  const [leftWidth, setLeftWidth] = useState(LEFT_DEFAULT)
+  const [leftWidth, setLeftWidth] = useState(LEFT_DEFAULT_COORDINATOR)
   const [centerRightOffset, setCenterRightOffset] = useState(0)
   const [leftCollapsed, setLeftCollapsed] = useState(false)
   const [availableWidth, setAvailableWidth] = useState(1440)
@@ -115,6 +118,13 @@ export function AppShell({ activeSpaceId, activeSessionId, onOpenHome }: AppShel
     const persistedTheme = globalThis.localStorage?.getItem(THEME_STORAGE_KEY)
     return persistedTheme === 'light' || persistedTheme === 'dark' ? persistedTheme : 'dark'
   })
+  const taskActivitySnapshot =
+    taskActivitySnapshotState.sessionId === activeSessionKey
+      ? taskActivitySnapshotState.snapshot
+      : undefined
+  const panelMode = resolveLeftPanelMode({ taskActivitySnapshot })
+  const leftMin = panelMode === 'coordinator' ? LEFT_MIN_COORDINATOR : LEFT_MIN_BUILD
+  const leftDefault = panelMode === 'coordinator' ? LEFT_DEFAULT_COORDINATOR : LEFT_DEFAULT_BUILD
 
   useEffect(() => {
     globalThis.localStorage?.setItem(THEME_STORAGE_KEY, theme)
@@ -127,11 +137,14 @@ export function AppShell({ activeSpaceId, activeSessionId, onOpenHome }: AppShel
 
   useLayoutEffect(() => {
     setLeftWidth((current) => {
-      const maxLeft = getMaxLeftWidth(availableWidth)
-      const next = clamp(current, LEFT_MIN, maxLeft)
+      const maxLeft = getMaxLeftWidth(availableWidth, leftMin)
+      const next =
+        current === LEFT_DEFAULT_BUILD || current === LEFT_DEFAULT_COORDINATOR
+          ? clamp(leftDefault, leftMin, maxLeft)
+          : clamp(current, leftMin, maxLeft)
       return next === current ? current : next
     })
-  }, [availableWidth])
+  }, [availableWidth, leftDefault, leftMin])
 
   useLayoutEffect(() => {
     return observeShellWidth(shellRef.current, setAvailableWidth)
@@ -155,9 +168,9 @@ export function AppShell({ activeSpaceId, activeSessionId, onOpenHome }: AppShel
 
   const handleLeftDelta = useCallback(
     (deltaX: number) => {
-      setLeftWidth((current) => clamp(current + deltaX, LEFT_MIN, getMaxLeftWidth(availableWidth)))
+      setLeftWidth((current) => clamp(current + deltaX, leftMin, getMaxLeftWidth(availableWidth, leftMin)))
     },
-    [availableWidth]
+    [availableWidth, leftMin]
   )
 
   const handleCenterRightDelta = useCallback(
@@ -179,10 +192,6 @@ export function AppShell({ activeSpaceId, activeSessionId, onOpenHome }: AppShel
   const latestDraft =
     latestDraftState.sessionId === activeSessionKey
       ? latestDraftState.draft
-      : undefined
-  const taskActivitySnapshot =
-    taskActivitySnapshotState.sessionId === activeSessionKey
-      ? taskActivitySnapshotState.snapshot
       : undefined
   const handleLatestDraftChange = useCallback(
     (draft: LatestRunDraft | undefined) => {

--- a/app/src/renderer/components/layout/LeftPanel.tsx
+++ b/app/src/renderer/components/layout/LeftPanel.tsx
@@ -90,9 +90,12 @@ export function LeftPanel({
   const [internalCollapsed, setInternalCollapsed] = useState(false)
   const [previewState, setPreviewState] = useState<PreviewState>(0)
   const project = useMemo(() => getMockProject(), [])
-  const { agents, isLoading: isAgentsLoading, error: agentsError } = useSessionAgentRoster(activeSpaceId ?? null, activeSessionId ?? null)
-  const coordinatorSidebar = useCoordinatorSidebarData(activeSessionId ?? null)
   const panelMode = resolveLeftPanelMode({ taskActivitySnapshot })
+  const { agents, isLoading: isAgentsLoading, error: agentsError } = useSessionAgentRoster(
+    panelMode === 'build' ? activeSpaceId ?? null : null,
+    panelMode === 'build' ? activeSessionId ?? null : null
+  )
+  const coordinatorSidebar = useCoordinatorSidebarData(panelMode === 'coordinator' ? activeSessionId ?? null : null)
   const statusTasks = previewState === 0 ? project.tasks : previewTasks[previewState]
   const contextTabCount = getContextTabCount(previewState, project.tasks.length)
   const changesTabCount = getChangesTabCount(previewState, mockGit)

--- a/app/src/renderer/components/layout/LeftPanel.tsx
+++ b/app/src/renderer/components/layout/LeftPanel.tsx
@@ -6,14 +6,18 @@ import logoLight from '../../assets/brand/icon-light.svg'
 import { mockFiles } from '../../mock/files'
 import { mockGit } from '../../mock/git'
 import { getMockProject } from '../../mock/project'
+import { useCoordinatorSidebarData } from '../../hooks/useCoordinatorSidebarData'
 import { useSessionAgentRoster } from '../../hooks/useSessionAgentRoster'
 import { AgentsTab } from '../left/AgentsTab'
+import { CoordinatorAgentsSection } from '../left/CoordinatorAgentsSection'
+import { CoordinatorContextSection } from '../left/CoordinatorContextSection'
 import { ConversationEntryIndexSection } from '../left/ConversationEntryIndexSection'
 import { ChangesTab, getChangesTabCount } from '../left/ChangesTab'
 import { ContextTab, getContextTabCount } from '../left/ContextTab'
 import { FilesTab } from '../left/FilesTab'
 import { LeftStatusSection } from '../left/LeftStatusSection'
 import type { ConversationEntry } from '../left/conversation-entry-index'
+import { resolveLeftPanelMode } from '../left/left-panel-mode'
 import { ErrorBoundary } from '../shared/ErrorBoundary'
 import { cn } from '../../lib/cn'
 import { Button } from '../ui/button'
@@ -87,9 +91,13 @@ export function LeftPanel({
   const [previewState, setPreviewState] = useState<PreviewState>(0)
   const project = useMemo(() => getMockProject(), [])
   const { agents, isLoading: isAgentsLoading, error: agentsError } = useSessionAgentRoster(activeSpaceId ?? null, activeSessionId ?? null)
+  const coordinatorSidebar = useCoordinatorSidebarData(activeSessionId ?? null)
+  const panelMode = resolveLeftPanelMode({ taskActivitySnapshot })
   const statusTasks = previewState === 0 ? project.tasks : previewTasks[previewState]
   const contextTabCount = getContextTabCount(previewState, project.tasks.length)
   const changesTabCount = getChangesTabCount(previewState, mockGit)
+  const agentsTabCount = panelMode === 'coordinator' ? coordinatorSidebar.agentItems.length : agents.length
+  const visibleContextTabCount = panelMode === 'coordinator' ? coordinatorSidebar.contextItems.length : contextTabCount
 
   const isSidebarCollapsed = collapsed ?? internalCollapsed
 
@@ -102,12 +110,12 @@ export function LeftPanel({
 
   const tabs = useMemo(
     () => [
-      { id: 'agents', label: 'Agents', icon: Users, count: agents.length },
-      { id: 'context', label: 'Context', icon: Layers3, count: contextTabCount },
+      { id: 'agents', label: 'Agents', icon: Users, count: agentsTabCount },
+      { id: 'context', label: 'Context', icon: Layers3, count: visibleContextTabCount },
       { id: 'changes', label: 'Changes', icon: GitBranch, count: changesTabCount },
       { id: 'files', label: 'Files', icon: Folder, count: mockFiles.length }
     ] satisfies Array<{ id: LeftPanelTab; label: string; icon: ComponentType<{ className?: string }>; count: number }>,
-    [agents.length, changesTabCount, contextTabCount]
+    [agentsTabCount, changesTabCount, visibleContextTabCount]
   )
 
   return (
@@ -229,39 +237,58 @@ export function LeftPanel({
               <PanelLeftClose className="h-4 w-4" />
             </Button>
           </header>
-          <ErrorBoundary fallback={<p className="px-4 py-3 text-sm text-muted-foreground">Unable to load status.</p>}>
-            <LeftStatusSection
-              title={project.sessionTitle}
-              subtitle={project.repositorySubtitle}
-              tasks={statusTasks}
-              taskActivitySnapshot={taskActivitySnapshot}
-              previewState={previewState}
-              onCyclePreviewState={() => setPreviewState((current) => nextPreviewState(current))}
-              onSelectPreviewState={(state) => setPreviewState(state)}
-            />
-          </ErrorBoundary>
+          {panelMode === 'build' ? (
+            <ErrorBoundary fallback={<p className="px-4 py-3 text-sm text-muted-foreground">Unable to load status.</p>}>
+              <LeftStatusSection
+                title={project.sessionTitle}
+                subtitle={project.repositorySubtitle}
+                tasks={statusTasks}
+                taskActivitySnapshot={taskActivitySnapshot}
+                previewState={previewState}
+                onCyclePreviewState={() => setPreviewState((current) => nextPreviewState(current))}
+                onSelectPreviewState={(state) => setPreviewState(state)}
+              />
+            </ErrorBoundary>
+          ) : null}
           <ScrollArea className="min-h-0 flex-1">
             <div className="py-4 pl-4 pr-2">
               {activeTab === 'agents' ? (
-                <>
-                  <AgentsTab
-                    agents={agents}
-                    isLoading={isAgentsLoading}
-                    error={agentsError}
+                panelMode === 'coordinator' ? (
+                  <CoordinatorAgentsSection
+                    agentItems={coordinatorSidebar.agentItems}
+                    promptPreview={coordinatorSidebar.promptPreview}
+                    isLoading={coordinatorSidebar.isLoading}
+                    error={coordinatorSidebar.error}
                   />
-                  {onJumpToMessage ? (
-                    <ConversationEntryIndexSection
-                      entries={conversationEntries}
-                      onJumpToMessage={onJumpToMessage}
+                ) : (
+                  <>
+                    <AgentsTab
+                      agents={agents}
+                      isLoading={isAgentsLoading}
+                      error={agentsError}
                     />
-                  ) : null}
-                </>
+                    {onJumpToMessage ? (
+                      <ConversationEntryIndexSection
+                        entries={conversationEntries}
+                        onJumpToMessage={onJumpToMessage}
+                      />
+                    ) : null}
+                  </>
+                )
               ) : null}
               {activeTab === 'context' ? (
-                <ContextTab
-                  project={project}
-                  previewState={previewState}
-                />
+                panelMode === 'coordinator' ? (
+                  <CoordinatorContextSection
+                    contextItems={coordinatorSidebar.contextItems}
+                    isLoading={coordinatorSidebar.isLoading}
+                    error={coordinatorSidebar.error}
+                  />
+                ) : (
+                  <ContextTab
+                    project={project}
+                    previewState={previewState}
+                  />
+                )
               ) : null}
               {activeTab === 'changes' ? (
                 <ChangesTab

--- a/app/src/renderer/components/left/CoordinatorAgentListItem.tsx
+++ b/app/src/renderer/components/left/CoordinatorAgentListItem.tsx
@@ -1,0 +1,29 @@
+import type { CoordinatorAgentListItem as CoordinatorAgentItem } from '../../features/coordinator-session/domain'
+import { agentStatusLabel, statusDotClassName } from './agentStatus'
+
+type CoordinatorAgentListItemProps = {
+  name: string
+  status: CoordinatorAgentItem['status']
+  subtitle: string
+}
+
+export function CoordinatorAgentListItem({ name, status, subtitle }: CoordinatorAgentListItemProps) {
+  return (
+    <article className="w-full overflow-hidden rounded-md border border-border/70 bg-card/40 px-3 py-2">
+      <div className="flex items-start gap-2">
+        <span
+          className={[
+            'mt-1 inline-flex h-2.5 w-2.5 shrink-0 rounded-full',
+            statusDotClassName[status]
+          ].join(' ')}
+        >
+          <span className="sr-only">{agentStatusLabel[status]}</span>
+        </span>
+        <div className="min-w-0 flex-1">
+          <p className="max-w-[18ch] truncate text-sm font-medium text-foreground">{name}</p>
+          <p className="mt-1 text-xs text-muted-foreground">{subtitle}</p>
+        </div>
+      </div>
+    </article>
+  )
+}

--- a/app/src/renderer/components/left/CoordinatorAgentsSection.tsx
+++ b/app/src/renderer/components/left/CoordinatorAgentsSection.tsx
@@ -1,0 +1,52 @@
+import type { CoordinatorAgentListItem as CoordinatorAgentItem } from '../../features/coordinator-session/domain'
+import { LeftSection } from './LeftSection'
+import { CoordinatorAgentListItem } from './CoordinatorAgentListItem'
+
+type CoordinatorAgentsSectionProps = {
+  agentItems: CoordinatorAgentItem[]
+  promptPreview: string | null
+  isLoading: boolean
+  error: string | null
+}
+
+function getAgentSubtitle(agent: CoordinatorAgentItem, promptPreview: string | null): string {
+  if (agent.kind === 'coordinator') {
+    return promptPreview ?? agent.currentTask ?? agent.role
+  }
+
+  return agent.currentTask ?? agent.role
+}
+
+export function CoordinatorAgentsSection({
+  agentItems,
+  promptPreview,
+  isLoading,
+  error
+}: CoordinatorAgentsSectionProps) {
+  return (
+    <LeftSection
+      title="Agents"
+      description="Agents write code, maintain notes, and coordinate tasks."
+      addActionLabel="Create new agent"
+      actionVariant="inline"
+    >
+      <div className="space-y-3">
+        {isLoading ? <p className="text-xs text-muted-foreground">Loading agents…</p> : null}
+        {!isLoading && error ? <p className="text-xs text-muted-foreground">Unable to refresh agents right now.</p> : null}
+        {!isLoading && !error && agentItems.length === 0 ? (
+          <p className="text-xs text-muted-foreground">No agents in this session yet.</p>
+        ) : null}
+        {!isLoading && !error
+          ? agentItems.map((agent) => (
+              <CoordinatorAgentListItem
+                key={agent.id}
+                name={agent.name}
+                status={agent.status}
+                subtitle={getAgentSubtitle(agent, promptPreview)}
+              />
+            ))
+          : null}
+      </div>
+    </LeftSection>
+  )
+}

--- a/app/src/renderer/components/left/CoordinatorContextSection.tsx
+++ b/app/src/renderer/components/left/CoordinatorContextSection.tsx
@@ -1,0 +1,47 @@
+import type { CoordinatorContextListItem } from '../../features/coordinator-session/domain'
+import { LeftSection } from './LeftSection'
+import { LEFT_PANEL_TYPOGRAPHY } from './left-typography'
+
+type CoordinatorContextSectionProps = {
+  contextItems: CoordinatorContextListItem[]
+  isLoading: boolean
+  error: string | null
+}
+
+export function CoordinatorContextSection({
+  contextItems,
+  isLoading,
+  error
+}: CoordinatorContextSectionProps) {
+  return (
+    <LeftSection
+      title="Context"
+      description="Context about the task, shared with all agents on demand."
+      addActionLabel="Add context"
+      actionVariant="inline"
+    >
+      <div className="space-y-2">
+        {isLoading ? <p className="text-xs text-muted-foreground">Loading context…</p> : null}
+        {!isLoading && error ? <p className="text-xs text-muted-foreground">Unable to refresh context right now.</p> : null}
+        {!isLoading && !error && contextItems.length === 0 ? (
+          <p className="text-xs text-muted-foreground">No shared context in this session yet.</p>
+        ) : null}
+        {!isLoading && !error
+          ? contextItems.map((item) => (
+              <button
+                key={item.id}
+                type="button"
+                className={`flex w-full items-center gap-2 text-left ${LEFT_PANEL_TYPOGRAPHY.listItem}`}
+              >
+                <span
+                  aria-hidden="true"
+                  className="h-1.5 w-1.5 rounded-full bg-muted-foreground/70"
+                />
+                <span>{item.label}</span>
+              </button>
+            ))
+          : null}
+      </div>
+    </LeftSection>
+  )
+}

--- a/app/src/renderer/components/left/CoordinatorContextSection.tsx
+++ b/app/src/renderer/components/left/CoordinatorContextSection.tsx
@@ -28,9 +28,8 @@ export function CoordinatorContextSection({
         ) : null}
         {!isLoading && !error
           ? contextItems.map((item) => (
-              <button
+              <div
                 key={item.id}
-                type="button"
                 className={`flex w-full items-center gap-2 text-left ${LEFT_PANEL_TYPOGRAPHY.listItem}`}
               >
                 <span
@@ -38,7 +37,7 @@ export function CoordinatorContextSection({
                   className="h-1.5 w-1.5 rounded-full bg-muted-foreground/70"
                 />
                 <span>{item.label}</span>
-              </button>
+              </div>
             ))
           : null}
       </div>

--- a/app/src/renderer/components/left/LeftSection.tsx
+++ b/app/src/renderer/components/left/LeftSection.tsx
@@ -9,6 +9,7 @@ type LeftSectionProps = {
   title: string
   description?: ReactNode
   addActionLabel: string
+  actionVariant?: 'icon' | 'inline'
   onAddAction?: () => void
   titleClassName?: string
   descriptionClassName?: string
@@ -23,6 +24,7 @@ export function LeftSection({
   title,
   description,
   addActionLabel,
+  actionVariant = 'icon',
   onAddAction,
   titleClassName,
   descriptionClassName,
@@ -34,17 +36,29 @@ export function LeftSection({
       <div className="flex items-center justify-between gap-2">
         <h2 className={cn(LEFT_PANEL_TYPOGRAPHY.sectionTitle, titleClassName)}>{title}</h2>
         {actions ?? (
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-sm"
-            className="-mr-2"
-            aria-label={addActionLabel}
-            onClick={onAddAction}
-            disabled={!onAddAction}
-          >
-            <Plus className="h-4 w-4" />
-          </Button>
+          actionVariant === 'inline' ? (
+            <button
+              type="button"
+              className={LEFT_PANEL_TYPOGRAPHY.sectionInlineAction}
+              aria-label={addActionLabel}
+              onClick={onAddAction}
+              disabled={!onAddAction}
+            >
+              + {addActionLabel}
+            </button>
+          ) : (
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              className="-mr-2"
+              aria-label={addActionLabel}
+              onClick={onAddAction}
+              disabled={!onAddAction}
+            >
+              <Plus className="h-4 w-4" />
+            </Button>
+          )
         )}
       </div>
       {description ? (

--- a/app/src/renderer/components/left/left-panel-mode.ts
+++ b/app/src/renderer/components/left/left-panel-mode.ts
@@ -1,0 +1,9 @@
+import type { TaskActivitySnapshot } from '@shared/types/task-tracking'
+
+export type LeftPanelMode = 'coordinator' | 'build'
+
+export function resolveLeftPanelMode(input: {
+  taskActivitySnapshot?: TaskActivitySnapshot
+}): LeftPanelMode {
+  return input.taskActivitySnapshot ? 'build' : 'coordinator'
+}

--- a/app/src/renderer/components/left/left-typography.ts
+++ b/app/src/renderer/components/left/left-typography.ts
@@ -3,6 +3,8 @@ const LEFT_LIST_TEXT = 'text-sm leading-5 text-muted-foreground'
 export const LEFT_PANEL_TYPOGRAPHY = {
   sectionTitle: 'text-sm font-medium uppercase tracking-wide text-muted-foreground',
   sectionDescription: 'text-sm text-muted-foreground',
+  sectionInlineAction:
+    'focus-visible:border-ring focus-visible:ring-ring/50 rounded-md border border-transparent bg-clip-padding text-sm font-medium text-muted-foreground transition-all outline-none hover:text-foreground focus-visible:ring-3 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50',
   body: 'text-sm text-foreground',
   bodyMuted: 'text-sm text-muted-foreground',
   meta: 'text-xs text-muted-foreground',

--- a/app/src/renderer/hooks/useCoordinatorSidebarData.ts
+++ b/app/src/renderer/hooks/useCoordinatorSidebarData.ts
@@ -1,0 +1,111 @@
+import { useEffect, useState } from 'react'
+
+import {
+  selectCoordinatorAgentList,
+  selectCoordinatorContextItems,
+  selectCoordinatorPromptPreview,
+  type CoordinatorAgentListItem,
+  type CoordinatorContextListItem,
+  type CoordinatorContractState
+} from '../features/coordinator-session/domain'
+import type { RunRecord } from '../../shared/types/run'
+import type { SessionAgentRecord, SessionContextResourceRecord } from '../../shared/types/space'
+
+type CoordinatorSidebarDataState = {
+  agentItems: CoordinatorAgentListItem[]
+  contextItems: CoordinatorContextListItem[]
+  promptPreview: string | null
+  isLoading: boolean
+  error: string | null
+}
+
+const EMPTY_STATE: CoordinatorSidebarDataState = {
+  agentItems: [],
+  contextItems: [],
+  promptPreview: null,
+  isLoading: false,
+  error: null
+}
+
+function indexById<T extends { id: string }>(items: T[]): Record<string, T> {
+  return Object.fromEntries(items.map((item) => [item.id, item]))
+}
+
+function toErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message
+  return 'Failed to load coordinator sidebar data.'
+}
+
+function createContractState(
+  agentRoster: SessionAgentRecord[],
+  contextResources: SessionContextResourceRecord[],
+  runs: RunRecord[]
+): CoordinatorContractState {
+  return {
+    agentRoster: indexById(agentRoster),
+    contextResources: indexById(contextResources),
+    runs: indexById(runs)
+  }
+}
+
+export function useCoordinatorSidebarData(sessionId: string | null): CoordinatorSidebarDataState {
+  const [state, setState] = useState<CoordinatorSidebarDataState>(EMPTY_STATE)
+
+  useEffect(() => {
+    const kata = window.kata
+
+    if (!sessionId || !kata?.sessionAgentRosterList || !kata?.sessionContextResourcesList || !kata?.runList) {
+      if (sessionId && (!kata?.sessionAgentRosterList || !kata?.sessionContextResourcesList || !kata?.runList)) {
+        console.warn('[useCoordinatorSidebarData] IPC bridge methods missing. Preload may be misconfigured.')
+      }
+      setState(EMPTY_STATE)
+      return
+    }
+
+    let disposed = false
+    setState({
+      agentItems: [],
+      contextItems: [],
+      promptPreview: null,
+      isLoading: true,
+      error: null
+    })
+
+    void Promise.all([
+      kata.sessionAgentRosterList({ sessionId }),
+      kata.sessionContextResourcesList({ sessionId }),
+      kata.runList(sessionId)
+    ])
+      .then(([agentRoster, contextResources, runs]) => {
+        if (disposed) return
+
+        const contractState = createContractState(agentRoster, contextResources, runs)
+
+        setState({
+          agentItems: selectCoordinatorAgentList(contractState, sessionId),
+          contextItems: selectCoordinatorContextItems(contractState, sessionId),
+          promptPreview: selectCoordinatorPromptPreview(contractState, sessionId),
+          isLoading: false,
+          error: null
+        })
+      })
+      .catch((error: unknown) => {
+        if (disposed) return
+
+        console.error('[useCoordinatorSidebarData] Failed to load coordinator sidebar data:', error)
+        setState({
+          agentItems: [],
+          contextItems: [],
+          promptPreview: null,
+          isLoading: false,
+          error: toErrorMessage(error)
+        })
+      })
+
+    return () => {
+      disposed = true
+    }
+  }, [sessionId])
+
+  return state
+}

--- a/app/tests/e2e/kat-170-sidebar-sectionsnav.spec.ts
+++ b/app/tests/e2e/kat-170-sidebar-sectionsnav.spec.ts
@@ -1,0 +1,46 @@
+import type { Page } from '@playwright/test'
+
+import { expect, test } from './fixtures/electron'
+import { ensureWorkspaceShell } from './helpers/shell-view'
+
+async function ensureCoordinatorSidebarMode(appWindow: Page) {
+  await ensureWorkspaceShell(appWindow)
+
+  await appWindow.evaluate(async () => {
+    const bootstrap = await window.kata.appBootstrap()
+    const spaceId = bootstrap.activeSpaceId
+    if (!spaceId) {
+      throw new Error('Active workspace space is required for coordinator sidebar test setup.')
+    }
+
+    const session = await window.kata.sessionCreate({
+      spaceId,
+      label: `Coordinator sidebar ${Date.now()}`
+    })
+    await window.kata.sessionSetActive(session.id)
+  })
+
+  await appWindow.reload()
+  await ensureWorkspaceShell(appWindow)
+}
+
+test.describe('KAT-170: coordinator sidebar behavior @ci', () => {
+  test('renders agents by default, switches to context, and restores from collapse @ci', async ({
+    appWindow
+  }) => {
+    await ensureCoordinatorSidebarMode(appWindow)
+    const leftPanelContent = appWindow.getByTestId('left-panel-content')
+
+    await expect(appWindow.getByRole('heading', { name: 'Agents' })).toBeVisible()
+    await expect(appWindow.getByText('MVP Planning Coordinator')).toBeVisible()
+
+    await appWindow.getByRole('tab', { name: 'Context' }).click()
+    await expect(appWindow.getByRole('heading', { name: 'Context' })).toBeVisible()
+    await expect(leftPanelContent.getByText('Spec').first()).toBeVisible()
+
+    await appWindow.getByRole('button', { name: 'Collapse sidebar navigation' }).click()
+    await expect(appWindow.getByRole('button', { name: 'Expand sidebar navigation' })).toBeVisible()
+    await appWindow.getByRole('button', { name: 'Expand sidebar navigation' }).click()
+    await expect(appWindow.getByRole('heading', { name: 'Context' })).toBeVisible()
+  })
+})

--- a/app/tests/e2e/kat-185-agent-roster-sidebar.spec.ts
+++ b/app/tests/e2e/kat-185-agent-roster-sidebar.spec.ts
@@ -20,6 +20,7 @@ test.describe('KAT-185: Agent roster sidebar integration @ci', () => {
     managedStateFilePath
   }) => {
     await ensureWorkspaceShell(appWindow)
+    await appWindow.getByRole('tab', { name: 'Agents' }).click()
 
     await expect(appWindow.getByRole('heading', { name: 'Agents' })).toBeVisible()
     await expect(appWindow.getByText('Kata Agents')).toBeVisible()

--- a/app/tests/e2e/navigation.spec.ts
+++ b/app/tests/e2e/navigation.spec.ts
@@ -1,24 +1,23 @@
 import { expect, test } from './fixtures/electron'
 import { ensureHomeSpacesView, ensureWorkspaceShell } from './helpers/shell-view'
-import { LEFT_STATUS_SCENARIO_KEY } from '../../src/renderer/mock/project'
 
 test.describe('Desktop app navigation @uat', () => {
-  test.afterEach(async ({ appWindow }) => {
-    await appWindow.evaluate((scenarioKey) => {
-      window.localStorage.removeItem(scenarioKey)
-    }, LEFT_STATUS_SCENARIO_KEY)
-  })
-
   test('switches left panel tabs and renders each view @uat @ci @quality-gate', async ({ appWindow }) => {
     await ensureWorkspaceShell(appWindow)
 
     const leftTabs = appWindow.getByRole('tablist', { name: /Left panel (tabs|modules)/ })
     const leftPanelContent = appWindow.getByTestId('left-panel-content')
 
-    await expect(leftTabs.getByRole('tab', { name: /Agents/ })).toHaveAttribute('aria-selected', 'true')
+    await leftTabs.getByRole('tab', { name: /Agents/ }).click()
+    await expect(leftPanelContent.getByRole('heading', { name: 'Agents' })).toBeVisible()
 
     await leftTabs.getByRole('tab', { name: /Context/ }).click()
     await expect(leftPanelContent.getByRole('heading', { name: 'Context' })).toBeVisible()
+    await expect(
+      appWindow.getByText('Project specs, tasks, and notes are stored as markdown files in')
+    ).toBeVisible()
+    await expect(leftPanelContent.locator('code', { hasText: './notes' })).toBeVisible()
+    await expect(leftPanelContent.getByTestId('context-spec-section').getByText('Spec')).toBeVisible()
 
     await leftTabs.getByRole('tab', { name: /Changes/ }).click()
     await expect(leftPanelContent.getByRole('heading', { name: 'Changes' })).toBeVisible()
@@ -28,120 +27,6 @@ test.describe('Desktop app navigation @uat', () => {
     await leftTabs.getByRole('tab', { name: /Files/ }).click()
     await expect(leftPanelContent.getByRole('heading', { name: 'Files' })).toBeVisible()
     await expect(appWindow.getByLabel('Search files')).toBeVisible()
-  })
-
-  test('renders persisted roster baseline in agents tab @uat @ci @quality-gate', async ({
-    appWindow
-  }) => {
-    await ensureWorkspaceShell(appWindow)
-
-    const leftTabs = appWindow.getByRole('tablist', { name: /Left panel (tabs|modules)/ })
-
-    await leftTabs.getByRole('tab', { name: /Agents/ }).click()
-    await expect(appWindow.getByRole('heading', { name: 'Agents' })).toBeVisible()
-    await expect(appWindow.getByText('Kata Agents')).toBeVisible()
-    await expect(appWindow.getByText('MVP Planning Coordinator')).toBeVisible()
-    await expect(
-      appWindow.getByText('Agents write code, maintain notes, and coordinate tasks.')
-    ).toBeVisible()
-    await expect(appWindow.getByRole('button', { name: /background agents running/i })).toHaveCount(0)
-  })
-
-  test('renders context preview states 0-3 with expected task and notes variants @uat @ci @quality-gate', async ({
-    appWindow
-  }) => {
-    await ensureWorkspaceShell(appWindow)
-
-    const leftTabs = appWindow.getByRole('tablist', { name: /Left panel (tabs|modules)/ })
-
-    await leftTabs.getByRole('tab', { name: /Context/ }).click()
-    const contextTab = appWindow.getByTestId('context-tab')
-
-    await expect(appWindow.getByRole('heading', { name: 'Context' })).toBeVisible()
-    await expect(
-      contextTab.getByText('Project specs, tasks, and notes are stored as markdown files in')
-    ).toBeVisible()
-    await expect(contextTab.locator('code', { hasText: './notes' })).toBeVisible()
-    await expect(contextTab.getByTestId('context-spec-section').getByText('Spec')).toBeVisible()
-    await expect(contextTab.getByText('Create contracts and shared baseline components')).toBeVisible()
-    await expect(contextTab.getByText('Implement left panel tabs')).toBeVisible()
-    await expect(appWindow.getByTestId('context-notes-heading')).toHaveCount(0)
-
-    await appWindow.getByRole('button', { name: 'Show preview state 1' }).click()
-    await expect(appWindow.getByTestId('context-notes-heading')).toBeVisible()
-    await expect(contextTab.getByText('Team Brainstorm - 2/22/26')).toBeVisible()
-    await expect(contextTab.getByText('Scratchpad')).toBeVisible()
-    await expect(appWindow.getByTestId('context-note-row-team-brainstorm-2-22-26')).toHaveAttribute(
-      'data-context-note-selected',
-      'true'
-    )
-
-    await appWindow.getByRole('button', { name: 'Show preview state 2' }).click()
-    await expect(contextTab.getByText('Create contracts and shared baseline components')).toBeVisible()
-    await expect(appWindow.getByTestId('context-notes-heading')).toHaveCount(0)
-    await expect(contextTab.locator('[data-context-task-status="in_progress"]')).toHaveCount(0)
-    await expect(contextTab.locator('[data-context-task-status="done"]')).toHaveCount(0)
-    await expect(contextTab.locator('[data-context-task-status="todo"]')).toHaveCount(2)
-
-    await appWindow.getByRole('button', { name: 'Show preview state 3' }).click()
-    await expect(appWindow.getByTestId('context-notes-heading')).toBeVisible()
-    await expect(appWindow.getByTestId('context-note-row-team-brainstorm-2-22-26')).toHaveAttribute(
-      'data-context-note-selected',
-      'false'
-    )
-  })
-
-  test('keeps left status visible while switching tabs @uat @ci @quality-gate', async ({ appWindow }) => {
-    await ensureWorkspaceShell(appWindow)
-
-    await expect(appWindow.getByLabel('Left panel status')).toBeVisible()
-
-    const leftTabs = appWindow.getByRole('tablist', { name: /Left panel (tabs|modules)/ })
-    await leftTabs.getByRole('tab', { name: 'Context' }).click()
-    await expect(appWindow.getByLabel('Left panel status')).toBeVisible()
-    await leftTabs.getByRole('tab', { name: 'Changes' }).click()
-    await expect(appWindow.getByLabel('Left panel status')).toBeVisible()
-  })
-
-  test('renders simple and overflow progress scenarios via localStorage override @uat @ci', async ({ appWindow }) => {
-    await ensureWorkspaceShell(appWindow)
-
-    await appWindow.evaluate((scenarioKey) => {
-      window.localStorage.setItem(scenarioKey, 'simple')
-    }, LEFT_STATUS_SCENARIO_KEY)
-    await appWindow.reload()
-    await ensureWorkspaceShell(appWindow)
-    await expect(appWindow.getByText('Tasks ready to go.')).toBeVisible()
-
-    await appWindow.evaluate((scenarioKey) => {
-      window.localStorage.setItem(scenarioKey, 'overflow')
-    }, LEFT_STATUS_SCENARIO_KEY)
-    await appWindow.reload()
-    await ensureWorkspaceShell(appWindow)
-    await expect(appWindow.getByText('25 done')).toHaveCount(2)
-    await expect(appWindow.getByText('50 of 60 complete.')).toBeVisible()
-  })
-
-  test('clicking status section toggles busy preview @uat @ci', async ({ appWindow }) => {
-    await appWindow.evaluate((scenarioKey) => {
-      window.localStorage.setItem(scenarioKey, 'simple')
-    }, LEFT_STATUS_SCENARIO_KEY)
-    await appWindow.reload()
-    await ensureWorkspaceShell(appWindow)
-
-    const cyclePreviewStateButton = appWindow.getByRole('button', { name: 'Cycle status preview state' })
-
-    await expect(appWindow.getByText('Tasks ready to go.')).toBeVisible()
-    await cyclePreviewStateButton.click()
-    await expect(appWindow.getByText('2 of 5 complete.')).toBeVisible()
-    await cyclePreviewStateButton.click()
-    await expect(appWindow.getByText('3 of 5 complete.')).toBeVisible()
-    await cyclePreviewStateButton.click()
-    await expect(appWindow.getByText('4 of 5 complete.')).toBeVisible()
-    await expect(appWindow.locator('[data-segment-status="done"]')).toHaveCount(4)
-    await expect(appWindow.locator('[data-segment-status="in_progress"]')).toHaveCount(1)
-    await appWindow.getByRole('button', { name: 'Show preview state 1' }).click()
-    await expect(appWindow.getByText('2 of 5 complete.')).toBeVisible()
   })
 
   test('switches right panel tabs and preserves notes state @uat @ci @quality-gate', async ({ appWindow }) => {

--- a/app/tests/e2e/navigation.spec.ts
+++ b/app/tests/e2e/navigation.spec.ts
@@ -13,11 +13,16 @@ test.describe('Desktop app navigation @uat', () => {
 
     await leftTabs.getByRole('tab', { name: /Context/ }).click()
     await expect(leftPanelContent.getByRole('heading', { name: 'Context' })).toBeVisible()
-    await expect(
-      appWindow.getByText('Project specs, tasks, and notes are stored as markdown files in')
-    ).toBeVisible()
-    await expect(leftPanelContent.locator('code', { hasText: './notes' })).toBeVisible()
-    await expect(leftPanelContent.getByTestId('context-spec-section').getByText('Spec')).toBeVisible()
+    const buildModeCopy = appWindow.getByText('Project specs, tasks, and notes are stored as markdown files in')
+    const coordinatorModeCopy = appWindow.getByText('Context about the task, shared with all agents on demand.')
+
+    if ((await buildModeCopy.count()) > 0) {
+      await expect(buildModeCopy).toBeVisible()
+      await expect(leftPanelContent.locator('code', { hasText: './notes' })).toBeVisible()
+    } else {
+      await expect(coordinatorModeCopy).toBeVisible()
+    }
+    await expect(leftPanelContent.getByText('Spec').first()).toBeVisible()
 
     await leftTabs.getByRole('tab', { name: /Changes/ }).click()
     await expect(leftPanelContent.getByRole('heading', { name: 'Changes' })).toBeVisible()

--- a/app/tests/unit/renderer/hooks/useCoordinatorSidebarData.test.ts
+++ b/app/tests/unit/renderer/hooks/useCoordinatorSidebarData.test.ts
@@ -1,0 +1,237 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { RunRecord } from '../../../../src/shared/types/run'
+import type { SessionAgentRecord, SessionContextResourceRecord } from '../../../../src/shared/types/space'
+import { useCoordinatorSidebarData } from '../../../../src/renderer/hooks/useCoordinatorSidebarData'
+
+const coordinatorAgent: SessionAgentRecord = {
+  id: 'agent-coordinator',
+  sessionId: 'session-1',
+  name: 'Coordinator',
+  role: 'Coordinates the session',
+  kind: 'coordinator',
+  status: 'idle',
+  avatarColor: '#0f766e',
+  sortOrder: 0,
+  createdAt: '2026-03-06T00:00:00.000Z',
+  updatedAt: '2026-03-06T00:01:00.000Z'
+}
+
+const specResource: SessionContextResourceRecord = {
+  id: 'resource-spec',
+  sessionId: 'session-1',
+  kind: 'spec',
+  label: 'Spec',
+  sortOrder: 0,
+  createdAt: '2026-03-06T00:00:00.000Z',
+  updatedAt: '2026-03-06T00:01:00.000Z'
+}
+
+const latestRun: RunRecord = {
+  id: 'run-latest',
+  sessionId: 'session-1',
+  prompt:
+    'I would like to build the following product for which I have created an overview document that should guide the implementation and rollout for the team.',
+  status: 'completed',
+  model: 'gpt-5.3-codex',
+  provider: 'openai-codex',
+  createdAt: '2026-03-06T00:10:00.000Z',
+  contextReferences: [],
+  messages: []
+}
+
+const sessionTwoAgent: SessionAgentRecord = {
+  ...coordinatorAgent,
+  id: 'agent-coordinator-2',
+  sessionId: 'session-2',
+  name: 'Coordinator Two'
+}
+
+const sessionTwoResource: SessionContextResourceRecord = {
+  ...specResource,
+  id: 'resource-spec-2',
+  sessionId: 'session-2',
+  label: 'Spec Two'
+}
+
+const sessionTwoRun: RunRecord = {
+  ...latestRun,
+  id: 'run-latest-2',
+  sessionId: 'session-2',
+  prompt: 'I would like to build session two.'
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+
+  return { promise, resolve, reject }
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+})
+
+afterEach(() => {
+  delete (window as Partial<Window>).kata
+})
+
+describe('useCoordinatorSidebarData', () => {
+  it('loads coordinator sidebar data from IPC and derives prompt preview + context items', async () => {
+    const roster = createDeferred<SessionAgentRecord[]>()
+    const resources = createDeferred<SessionContextResourceRecord[]>()
+    const runs = createDeferred<RunRecord[]>()
+    const sessionAgentRosterList = vi.fn().mockReturnValue(roster.promise)
+    const sessionContextResourcesList = vi.fn().mockReturnValue(resources.promise)
+    const runList = vi.fn().mockReturnValue(runs.promise)
+
+    window.kata = {
+      sessionAgentRosterList,
+      sessionContextResourcesList,
+      runList
+    }
+
+    const { result } = renderHook(() => useCoordinatorSidebarData('session-1'))
+
+    await waitFor(() => expect(result.current.isLoading).toBe(true))
+    expect(sessionAgentRosterList).toHaveBeenCalledWith({ sessionId: 'session-1' })
+    expect(sessionContextResourcesList).toHaveBeenCalledWith({ sessionId: 'session-1' })
+    expect(runList).toHaveBeenCalledWith('session-1')
+    expect(result.current.agentItems).toEqual([])
+    expect(result.current.contextItems).toEqual([])
+    expect(result.current.promptPreview).toBeNull()
+
+    roster.resolve([coordinatorAgent])
+    resources.resolve([specResource])
+    runs.resolve([latestRun])
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.promptPreview).toContain('I would like to build')
+    expect(result.current.contextItems[0]?.label).toBe('Spec')
+    expect(result.current.agentItems[0]?.name).toBe('Coordinator')
+  })
+
+  it('clears prior derived data when sessionId changes before the next sidebar load resolves', async () => {
+    const rosterOne = createDeferred<SessionAgentRecord[]>()
+    const resourcesOne = createDeferred<SessionContextResourceRecord[]>()
+    const runsOne = createDeferred<RunRecord[]>()
+    const rosterTwo = createDeferred<SessionAgentRecord[]>()
+    const resourcesTwo = createDeferred<SessionContextResourceRecord[]>()
+    const runsTwo = createDeferred<RunRecord[]>()
+
+    window.kata = {
+      sessionAgentRosterList: vi
+        .fn()
+        .mockImplementation(({ sessionId }: { sessionId: string }) =>
+          sessionId === 'session-1' ? rosterOne.promise : rosterTwo.promise
+        ),
+      sessionContextResourcesList: vi
+        .fn()
+        .mockImplementation(({ sessionId }: { sessionId: string }) =>
+          sessionId === 'session-1' ? resourcesOne.promise : resourcesTwo.promise
+        ),
+      runList: vi
+        .fn()
+        .mockImplementation((sessionId: string) =>
+          sessionId === 'session-1' ? runsOne.promise : runsTwo.promise
+        )
+    }
+
+    const { result, rerender } = renderHook(
+      ({ sessionId }: { sessionId: string }) => useCoordinatorSidebarData(sessionId),
+      { initialProps: { sessionId: 'session-1' } }
+    )
+
+    await waitFor(() => expect(result.current.isLoading).toBe(true))
+
+    rosterOne.resolve([coordinatorAgent])
+    resourcesOne.resolve([specResource])
+    runsOne.resolve([latestRun])
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.agentItems[0]?.name).toBe('Coordinator')
+    expect(result.current.contextItems[0]?.label).toBe('Spec')
+    expect(result.current.promptPreview).toContain('I would like to build')
+
+    rerender({ sessionId: 'session-2' })
+
+    await waitFor(() => expect(result.current.isLoading).toBe(true))
+    expect(result.current.agentItems).toEqual([])
+    expect(result.current.contextItems).toEqual([])
+    expect(result.current.promptPreview).toBeNull()
+
+    rosterTwo.resolve([sessionTwoAgent])
+    resourcesTwo.resolve([sessionTwoResource])
+    runsTwo.resolve([sessionTwoRun])
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.agentItems[0]?.name).toBe('Coordinator Two')
+    expect(result.current.contextItems[0]?.label).toBe('Spec Two')
+    expect(result.current.promptPreview).toContain('session two')
+  })
+
+  it('ignores late results from the previous session after switching to a new session', async () => {
+    const rosterOne = createDeferred<SessionAgentRecord[]>()
+    const resourcesOne = createDeferred<SessionContextResourceRecord[]>()
+    const runsOne = createDeferred<RunRecord[]>()
+    const rosterTwo = createDeferred<SessionAgentRecord[]>()
+    const resourcesTwo = createDeferred<SessionContextResourceRecord[]>()
+    const runsTwo = createDeferred<RunRecord[]>()
+
+    window.kata = {
+      sessionAgentRosterList: vi
+        .fn()
+        .mockImplementation(({ sessionId }: { sessionId: string }) =>
+          sessionId === 'session-1' ? rosterOne.promise : rosterTwo.promise
+        ),
+      sessionContextResourcesList: vi
+        .fn()
+        .mockImplementation(({ sessionId }: { sessionId: string }) =>
+          sessionId === 'session-1' ? resourcesOne.promise : resourcesTwo.promise
+        ),
+      runList: vi
+        .fn()
+        .mockImplementation((sessionId: string) =>
+          sessionId === 'session-1' ? runsOne.promise : runsTwo.promise
+        )
+    }
+
+    const { result, rerender } = renderHook(
+      ({ sessionId }: { sessionId: string }) => useCoordinatorSidebarData(sessionId),
+      { initialProps: { sessionId: 'session-1' } }
+    )
+
+    await waitFor(() => expect(result.current.isLoading).toBe(true))
+
+    rerender({ sessionId: 'session-2' })
+
+    await waitFor(() => expect(result.current.isLoading).toBe(true))
+    expect(result.current.agentItems).toEqual([])
+    expect(result.current.contextItems).toEqual([])
+    expect(result.current.promptPreview).toBeNull()
+
+    rosterOne.resolve([coordinatorAgent])
+    resourcesOne.resolve([specResource])
+    runsOne.resolve([latestRun])
+
+    await Promise.resolve()
+    expect(result.current.agentItems).toEqual([])
+    expect(result.current.contextItems).toEqual([])
+    expect(result.current.promptPreview).toBeNull()
+    expect(result.current.isLoading).toBe(true)
+
+    rosterTwo.resolve([sessionTwoAgent])
+    resourcesTwo.resolve([sessionTwoResource])
+    runsTwo.resolve([sessionTwoRun])
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.agentItems[0]?.name).toBe('Coordinator Two')
+    expect(result.current.contextItems[0]?.label).toBe('Spec Two')
+    expect(result.current.promptPreview).toContain('session two')
+  })
+})

--- a/app/tests/unit/renderer/hooks/useCoordinatorSidebarData.test.ts
+++ b/app/tests/unit/renderer/hooks/useCoordinatorSidebarData.test.ts
@@ -82,6 +82,41 @@ afterEach(() => {
 })
 
 describe('useCoordinatorSidebarData', () => {
+  it('returns the empty state without warning when no session is active', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    window.kata = {} as Window['kata']
+
+    const { result } = renderHook(() => useCoordinatorSidebarData(null))
+
+    expect(result.current).toEqual({
+      agentItems: [],
+      contextItems: [],
+      promptPreview: null,
+      isLoading: false,
+      error: null
+    })
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it('returns empty state and avoids IPC calls when required bridge methods are missing', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    window.kata = {} as Window['kata']
+
+    const { result } = renderHook(() => useCoordinatorSidebarData('session-1'))
+
+    expect(result.current).toEqual({
+      agentItems: [],
+      contextItems: [],
+      promptPreview: null,
+      isLoading: false,
+      error: null
+    })
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[useCoordinatorSidebarData] IPC bridge methods missing. Preload may be misconfigured.'
+    )
+  })
+
   it('loads coordinator sidebar data from IPC and derives prompt preview + context items', async () => {
     const roster = createDeferred<SessionAgentRecord[]>()
     const resources = createDeferred<SessionContextResourceRecord[]>()
@@ -233,5 +268,76 @@ describe('useCoordinatorSidebarData', () => {
     expect(result.current.agentItems[0]?.name).toBe('Coordinator Two')
     expect(result.current.contextItems[0]?.label).toBe('Spec Two')
     expect(result.current.promptPreview).toContain('session two')
+  })
+
+  it('captures load failures with fallback copy for non-Error rejections', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    window.kata = {
+      sessionAgentRosterList: vi.fn().mockRejectedValue('boom'),
+      sessionContextResourcesList: vi.fn(),
+      runList: vi.fn()
+    } as unknown as Window['kata']
+
+    const { result } = renderHook(() => useCoordinatorSidebarData('session-1'))
+
+    await waitFor(() =>
+      expect(result.current).toEqual({
+        agentItems: [],
+        contextItems: [],
+        promptPreview: null,
+        isLoading: false,
+        error: 'Failed to load coordinator sidebar data.'
+      })
+    )
+    expect(errorSpy).toHaveBeenCalled()
+  })
+
+  it('uses the thrown Error message when sidebar loading fails with an Error instance', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    window.kata = {
+      sessionAgentRosterList: vi.fn().mockRejectedValue(new Error('IPC unavailable')),
+      sessionContextResourcesList: vi.fn(),
+      runList: vi.fn()
+    } as unknown as Window['kata']
+
+    const { result } = renderHook(() => useCoordinatorSidebarData('session-1'))
+
+    await waitFor(() =>
+      expect(result.current).toEqual({
+        agentItems: [],
+        contextItems: [],
+        promptPreview: null,
+        isLoading: false,
+        error: 'IPC unavailable'
+      })
+    )
+    expect(errorSpy).toHaveBeenCalled()
+  })
+
+  it('ignores rejected late results after the hook unmounts', async () => {
+    const roster = createDeferred<SessionAgentRecord[]>()
+    const resources = createDeferred<SessionContextResourceRecord[]>()
+    const runs = createDeferred<RunRecord[]>()
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    window.kata = {
+      sessionAgentRosterList: vi.fn().mockReturnValue(roster.promise),
+      sessionContextResourcesList: vi.fn().mockReturnValue(resources.promise),
+      runList: vi.fn().mockReturnValue(runs.promise)
+    } as Window['kata']
+
+    const { result, unmount } = renderHook(() => useCoordinatorSidebarData('session-1'))
+
+    await waitFor(() => expect(result.current.isLoading).toBe(true))
+
+    unmount()
+    roster.reject(new Error('late failure'))
+    resources.resolve([])
+    runs.resolve([])
+
+    await Promise.resolve()
+    expect(errorSpy).not.toHaveBeenCalled()
   })
 })

--- a/app/tests/unit/renderer/hooks/useSessionAgentRoster.test.ts
+++ b/app/tests/unit/renderer/hooks/useSessionAgentRoster.test.ts
@@ -232,6 +232,15 @@ describe('useSessionAgentRoster', () => {
     expect(result.current.error).toBe('Failed to load session agent roster.')
   })
 
+  it('cleans up disposal flag when unmounted during missing-API branch', () => {
+    ;(window as any).kata = { sessionListBySpace: mockSessionListBySpace }
+
+    const { unmount } = renderHook(() => useSessionAgentRoster('space-1', null))
+    unmount()
+
+    expect(mockSessionListBySpace).not.toHaveBeenCalled()
+  })
+
   it('allows in-flight IPC to finish after unmount without crashing', async () => {
     let resolveSessions: ((value: SessionRecord[]) => void) | undefined
     mockSessionListBySpace.mockImplementation(

--- a/app/tests/unit/renderer/left/CoordinatorAgentsSection.test.tsx
+++ b/app/tests/unit/renderer/left/CoordinatorAgentsSection.test.tsx
@@ -22,6 +22,24 @@ const coordinatorAgent: CoordinatorAgentListItem = {
   updatedAt: '2026-03-06T00:01:00.000Z'
 }
 
+const specialistAgent: CoordinatorAgentListItem = {
+  id: 'agent-specialist',
+  name: 'Frontend Specialist',
+  role: 'Implements UI changes',
+  kind: 'specialist',
+  status: 'running',
+  avatarColor: '#2563eb',
+  delegatedBy: 'agent-coordinator',
+  currentTask: 'Updating the sidebar interactions',
+  activeRunId: 'run-1',
+  waveId: 'wave-1',
+  groupLabel: undefined,
+  lastActivityAt: '2026-03-06T00:02:00.000Z',
+  sortOrder: 1,
+  createdAt: '2026-03-06T00:00:00.000Z',
+  updatedAt: '2026-03-06T00:02:00.000Z'
+}
+
 describe('CoordinatorAgentsSection', () => {
   it('renders coordinator prompt preview with inline create action and no background summary in the simple case', () => {
     render(
@@ -38,5 +56,58 @@ describe('CoordinatorAgentsSection', () => {
     expect(screen.getByText('Coordinator')).toBeTruthy()
     expect(screen.getByText('I would like to build the following product...')).toBeTruthy()
     expect(screen.queryByRole('button', { name: /background agents running/i })).toBeNull()
+  })
+
+  it('uses current task copy for non-coordinator agents', () => {
+    render(
+      <CoordinatorAgentsSection
+        agentItems={[coordinatorAgent, specialistAgent]}
+        promptPreview="I would like to build the following product..."
+        isLoading={false}
+        error={null}
+      />
+    )
+
+    expect(screen.getByText('Frontend Specialist')).toBeTruthy()
+    expect(screen.getByText('Updating the sidebar interactions')).toBeTruthy()
+  })
+
+  it('renders loading copy while agent data is pending', () => {
+    render(
+      <CoordinatorAgentsSection
+        agentItems={[]}
+        promptPreview={null}
+        isLoading
+        error={null}
+      />
+    )
+
+    expect(screen.getByText('Loading agents…')).toBeTruthy()
+  })
+
+  it('renders the coordinator refresh error state', () => {
+    render(
+      <CoordinatorAgentsSection
+        agentItems={[]}
+        promptPreview={null}
+        isLoading={false}
+        error="boom"
+      />
+    )
+
+    expect(screen.getByText('Unable to refresh agents right now.')).toBeTruthy()
+  })
+
+  it('renders the empty state when the coordinator session has no agents yet', () => {
+    render(
+      <CoordinatorAgentsSection
+        agentItems={[]}
+        promptPreview={null}
+        isLoading={false}
+        error={null}
+      />
+    )
+
+    expect(screen.getByText('No agents in this session yet.')).toBeTruthy()
   })
 })

--- a/app/tests/unit/renderer/left/CoordinatorAgentsSection.test.tsx
+++ b/app/tests/unit/renderer/left/CoordinatorAgentsSection.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import type { CoordinatorAgentListItem } from '../../../../src/renderer/features/coordinator-session/domain'
+import { CoordinatorAgentsSection } from '../../../../src/renderer/components/left/CoordinatorAgentsSection'
+
+const coordinatorAgent: CoordinatorAgentListItem = {
+  id: 'agent-coordinator',
+  name: 'Coordinator',
+  role: 'Coordinates the session',
+  kind: 'coordinator',
+  status: 'idle',
+  avatarColor: '#0f766e',
+  delegatedBy: undefined,
+  currentTask: undefined,
+  activeRunId: undefined,
+  waveId: undefined,
+  groupLabel: undefined,
+  lastActivityAt: '2026-03-06T00:01:00.000Z',
+  sortOrder: 0,
+  createdAt: '2026-03-06T00:00:00.000Z',
+  updatedAt: '2026-03-06T00:01:00.000Z'
+}
+
+describe('CoordinatorAgentsSection', () => {
+  it('renders coordinator prompt preview with inline create action and no background summary in the simple case', () => {
+    render(
+      <CoordinatorAgentsSection
+        agentItems={[coordinatorAgent]}
+        promptPreview="I would like to build the following product..."
+        isLoading={false}
+        error={null}
+      />
+    )
+
+    expect(screen.getByRole('heading', { name: 'Agents' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Create new agent' }).textContent).toBe('+ Create new agent')
+    expect(screen.getByText('Coordinator')).toBeTruthy()
+    expect(screen.getByText('I would like to build the following product...')).toBeTruthy()
+    expect(screen.queryByRole('button', { name: /background agents running/i })).toBeNull()
+  })
+})

--- a/app/tests/unit/renderer/left/CoordinatorContextSection.test.tsx
+++ b/app/tests/unit/renderer/left/CoordinatorContextSection.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import type { CoordinatorContextListItem } from '../../../../src/renderer/features/coordinator-session/domain'
+import { CoordinatorContextSection } from '../../../../src/renderer/components/left/CoordinatorContextSection'
+
+const contextItems: CoordinatorContextListItem[] = [
+  {
+    id: 'spec',
+    kind: 'spec',
+    label: 'Spec',
+    sourcePath: undefined,
+    description: undefined,
+    sortOrder: 0,
+    createdAt: '2026-03-06T00:00:00.000Z',
+    updatedAt: '2026-03-06T00:00:00.000Z'
+  },
+  {
+    id: 'note-1',
+    kind: 'note',
+    label: 'Team Brainstorm',
+    sourcePath: undefined,
+    description: undefined,
+    sortOrder: 1,
+    createdAt: '2026-03-06T00:01:00.000Z',
+    updatedAt: '2026-03-06T00:01:00.000Z'
+  }
+]
+
+describe('CoordinatorContextSection', () => {
+  it('renders selector-backed context resources with spec-first ordering and coordinator copy', () => {
+    render(
+      <CoordinatorContextSection
+        contextItems={contextItems}
+        isLoading={false}
+        error={null}
+      />
+    )
+
+    expect(screen.getByRole('heading', { name: 'Context' })).toBeTruthy()
+    expect(screen.getByText('Context about the task, shared with all agents on demand.')).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Add context' }).textContent).toBe('+ Add context')
+    expect(screen.getByText('Spec')).toBeTruthy()
+    expect(screen.getByText('Team Brainstorm')).toBeTruthy()
+    expect(screen.queryByText('./notes')).toBeNull()
+  })
+})

--- a/app/tests/unit/renderer/left/CoordinatorContextSection.test.tsx
+++ b/app/tests/unit/renderer/left/CoordinatorContextSection.test.tsx
@@ -19,7 +19,7 @@ const contextItems: CoordinatorContextListItem[] = [
     id: 'note-1',
     kind: 'note',
     label: 'Team Brainstorm',
-    sourcePath: undefined,
+    sourcePath: './notes',
     description: undefined,
     sortOrder: 1,
     createdAt: '2026-03-06T00:01:00.000Z',

--- a/app/tests/unit/renderer/left/LeftPanel.test.tsx
+++ b/app/tests/unit/renderer/left/LeftPanel.test.tsx
@@ -13,15 +13,102 @@ const mockUseSessionAgentRoster = vi.fn<
     error: string | null
   }
 >()
+const mockUseCoordinatorSidebarData = vi.fn<
+  [string | null],
+  {
+    agentItems: Array<{
+      id: string
+      name: string
+      role: string
+      kind: 'coordinator' | 'specialist' | 'system'
+      status: 'idle' | 'queued' | 'delegating' | 'running' | 'blocked' | 'completed' | 'failed'
+      avatarColor: string
+      delegatedBy?: string
+      currentTask?: string
+      activeRunId?: string
+      waveId?: string
+      groupLabel?: string
+      lastActivityAt?: string
+      sortOrder: number
+      createdAt: string
+      updatedAt: string
+    }>
+    contextItems: Array<{
+      id: string
+      kind: 'spec' | 'note' | 'workspace-file' | 'manual'
+      label: string
+      sourcePath?: string
+      description?: string
+      sortOrder: number
+      createdAt: string
+      updatedAt: string
+    }>
+    promptPreview: string | null
+    isLoading: boolean
+    error: string | null
+  }
+>()
+const BUILD_TASK_ACTIVITY_SNAPSHOT = {
+  sessionId: 'session-1',
+  runId: 'run-build',
+  items: [],
+  counts: {
+    not_started: 0,
+    in_progress: 0,
+    blocked: 0,
+    complete: 0
+  }
+} as const
 
 vi.mock('../../../../src/renderer/hooks/useSessionAgentRoster', () => ({
   useSessionAgentRoster: (...args: [string | null, string | null]) => mockUseSessionAgentRoster(...args)
 }))
 
+vi.mock('../../../../src/renderer/hooks/useCoordinatorSidebarData', () => ({
+  useCoordinatorSidebarData: (sessionId: string | null) => mockUseCoordinatorSidebarData(sessionId)
+}))
+
+function renderBuildLeftPanel(props: Parameters<typeof LeftPanel>[0] = {}) {
+  return render(
+    <LeftPanel
+      {...props}
+      taskActivitySnapshot={props.taskActivitySnapshot ?? BUILD_TASK_ACTIVITY_SNAPSHOT}
+    />
+  )
+}
+
 describe('LeftPanel', () => {
   beforeEach(() => {
     mockUseSessionAgentRoster.mockReturnValue({
       agents: mockAgents,
+      isLoading: false,
+      error: null
+    })
+    mockUseCoordinatorSidebarData.mockReturnValue({
+      agentItems: [
+        {
+          id: 'agent-coordinator',
+          name: 'Coordinator',
+          role: 'Coordinates the session',
+          kind: 'coordinator',
+          status: 'idle',
+          avatarColor: '#0f766e',
+          sortOrder: 0,
+          createdAt: '2026-03-06T00:00:00.000Z',
+          updatedAt: '2026-03-06T00:01:00.000Z'
+        }
+      ],
+      contextItems: [
+        {
+          id: 'resource-spec',
+          kind: 'spec',
+          label: 'Spec',
+          sortOrder: 0,
+          createdAt: '2026-03-06T00:00:00.000Z',
+          updatedAt: '2026-03-06T00:00:00.000Z'
+        }
+      ],
+      promptPreview: 'I would like to build the following product...',
       isLoading: false,
       error: null
     })
@@ -33,18 +120,17 @@ describe('LeftPanel', () => {
     cleanup()
   })
 
-  it('shows the agents tab by default with agent summaries', () => {
-    render(<LeftPanel />)
+  it('hides the left status section and renders the coordinator agents surface in coordinator mode', () => {
+    render(<LeftPanel activeSpaceId="space-1" activeSessionId="session-1" taskActivitySnapshot={undefined} />)
 
     expect(screen.getByRole('tablist', { name: 'Left panel modules' })).toBeTruthy()
-    expect(screen.getByLabelText('Left panel status')).toBeTruthy()
-    expect(screen.getByText('Tasks ready to go.')).toBeTruthy()
+    expect(screen.queryByLabelText('Left panel status')).toBeNull()
     expect(screen.getByText('Agents write code, maintain notes, and coordinate tasks.')).toBeTruthy()
-    expect(screen.getByText('MVP Planning Coordinator')).toBeTruthy()
+    expect(screen.getByText('Coordinator')).toBeTruthy()
+    expect(screen.getByText('I would like to build the following product...')).toBeTruthy()
     expect(screen.getByRole('button', { name: 'Collapse sidebar navigation' })).toBeTruthy()
     expect(screen.getByRole('heading', { name: 'Agents' })).toBeTruthy()
-    expect(screen.queryByText('Model: gpt-5')).toBeNull()
-    expect(screen.queryByText('Tokens: 5,356')).toBeNull()
+    expect(screen.getByRole('button', { name: 'Create new agent' }).textContent).toBe('+ Create new agent')
   })
 
   it('uses session roster hook with activeSpaceId and derives the Agents tab count from loaded roster length', () => {
@@ -55,14 +141,14 @@ describe('LeftPanel', () => {
       error: null
     })
 
-    render(<LeftPanel activeSpaceId="space-42" />)
+    renderBuildLeftPanel({ activeSpaceId: 'space-42' })
 
     expect(mockUseSessionAgentRoster).toHaveBeenCalledWith('space-42', null)
     expect(screen.getByRole('tab', { name: 'Agents' }).getAttribute('title')).toBe(`Agents (${roster.length})`)
   })
 
   it('renders status section above tab content', () => {
-    render(<LeftPanel />)
+    renderBuildLeftPanel()
 
     const statusSection = screen.getByLabelText('Left panel status')
     const agentsHeading = screen.getByRole('heading', { name: 'Agents' })
@@ -74,14 +160,14 @@ describe('LeftPanel', () => {
 
   it('supports overflow state scenario with rollup chips', () => {
     window.localStorage.setItem(LEFT_STATUS_SCENARIO_KEY, 'overflow')
-    render(<LeftPanel />)
+    renderBuildLeftPanel()
 
     expect(screen.getAllByText('25 done')).toHaveLength(2)
     expect(screen.getByText('50 of 60 complete.')).toBeTruthy()
   })
 
   it('toggles to busy preview when clicking the status section', () => {
-    render(<LeftPanel />)
+    renderBuildLeftPanel()
 
     const cyclePreviewStateButton = screen.getByRole('button', { name: 'Cycle status preview state' })
     const statusSection = screen.getByLabelText('Left panel status')
@@ -100,7 +186,7 @@ describe('LeftPanel', () => {
   })
 
   it('supports direct preview selection using the 0-1-2-3 controls', () => {
-    render(<LeftPanel />)
+    renderBuildLeftPanel()
 
     fireEvent.click(screen.getByRole('button', { name: 'Show preview state 2' }))
 
@@ -110,7 +196,7 @@ describe('LeftPanel', () => {
   })
 
   it('keeps the context tab count aligned to the context tab content when preview is active', () => {
-    render(<LeftPanel />)
+    renderBuildLeftPanel()
 
     fireEvent.click(screen.getByRole('button', { name: 'Cycle status preview state' }))
     const contextTab = screen.getByRole('tab', { name: 'Context' })
@@ -119,7 +205,7 @@ describe('LeftPanel', () => {
   })
 
   it('switches to the context tab and renders the baseline context hierarchy', () => {
-    render(<LeftPanel />)
+    renderBuildLeftPanel()
 
     fireEvent.mouseDown(screen.getByRole('tab', { name: 'Context' }), { button: 0 })
 
@@ -136,7 +222,7 @@ describe('LeftPanel', () => {
   })
 
   it('feeds the preview cycle into the context tab states', () => {
-    render(<LeftPanel />)
+    renderBuildLeftPanel()
     fireEvent.click(screen.getByRole('button', { name: 'Cycle status preview state' }))
 
     fireEvent.mouseDown(screen.getByRole('tab', { name: 'Context' }), { button: 0 })
@@ -150,7 +236,7 @@ describe('LeftPanel', () => {
   })
 
   it('switches to changes and files tabs', () => {
-    render(<LeftPanel />)
+    renderBuildLeftPanel()
 
     fireEvent.mouseDown(screen.getByRole('tab', { name: 'Changes' }), { button: 0 })
     expect(screen.getByRole('heading', { name: 'Changes' })).toBeTruthy()
@@ -165,7 +251,7 @@ describe('LeftPanel', () => {
   })
 
   it('feeds the preview cycle into the changes tab click-through states', () => {
-    render(<LeftPanel />)
+    renderBuildLeftPanel()
 
     fireEvent.mouseDown(screen.getByRole('tab', { name: 'Changes' }), { button: 0 })
     expect(screen.getByText('No changes yet')).toBeTruthy()
@@ -288,20 +374,18 @@ describe('LeftPanel', () => {
 
   it('renders conversation entry index in agents tab and forwards jump events', () => {
     const onJumpToMessage = vi.fn()
-    render(
-      <LeftPanel
-        conversationEntries={[
-          {
-            id: 'entry-m-1',
-            messageId: 'm-1',
-            label: 'Spec Updated',
-            timestamp: '10:00 AM',
-            role: 'agent'
-          }
-        ]}
-        onJumpToMessage={onJumpToMessage}
-      />
-    )
+    renderBuildLeftPanel({
+      conversationEntries: [
+        {
+          id: 'entry-m-1',
+          messageId: 'm-1',
+          label: 'Spec Updated',
+          timestamp: '10:00 AM',
+          role: 'agent'
+        }
+      ],
+      onJumpToMessage
+    })
 
     expect(screen.getByRole('heading', { name: 'Conversation Entries' })).toBeTruthy()
     fireEvent.click(screen.getByRole('button', { name: 'Jump to message: Spec Updated at 10:00 AM' }))
@@ -341,19 +425,17 @@ describe('LeftPanel', () => {
   })
 
   it('does not render conversation entry index when jump callback is not provided', () => {
-    render(
-      <LeftPanel
-        conversationEntries={[
-          {
-            id: 'entry-m-1',
-            messageId: 'm-1',
-            label: 'Spec Updated',
-            timestamp: '10:00 AM',
-            role: 'agent'
-          }
-        ]}
-      />
-    )
+    renderBuildLeftPanel({
+      conversationEntries: [
+        {
+          id: 'entry-m-1',
+          messageId: 'm-1',
+          label: 'Spec Updated',
+          timestamp: '10:00 AM',
+          role: 'agent'
+        }
+      ]
+    })
 
     expect(screen.queryByRole('heading', { name: 'Conversation Entries' })).toBeNull()
   })

--- a/app/tests/unit/renderer/left/LeftSection.test.tsx
+++ b/app/tests/unit/renderer/left/LeftSection.test.tsx
@@ -8,7 +8,7 @@ describe('LeftSection', () => {
     cleanup()
   })
 
-  it('renders section title, subtitle, and disabled add action by default', () => {
+  it('renders section title, subtitle, and a disabled icon add action by default', () => {
     render(
       <LeftSection
         title="Agents"
@@ -21,7 +21,10 @@ describe('LeftSection', () => {
 
     expect(screen.getByRole('heading', { name: 'Agents' })).toBeTruthy()
     expect(screen.getByText('Agents write code, maintain notes, and coordinate tasks.')).toBeTruthy()
-    expect(screen.getByRole('button', { name: 'Add agent' }).hasAttribute('disabled')).toBe(true)
+    const addActionButton = screen.getByRole('button', { name: 'Add agent' })
+    expect(addActionButton.hasAttribute('disabled')).toBe(true)
+    expect(addActionButton.textContent).toBe('')
+    expect(screen.queryByText('Add agent')).toBeNull()
     expect(screen.getByText('Body content')).toBeTruthy()
   })
 
@@ -45,6 +48,52 @@ describe('LeftSection', () => {
     fireEvent.click(addActionButton)
 
     expect(onAddAction).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders an inline text action when actionVariant is inline', () => {
+    const onAddAction = vi.fn()
+
+    render(
+      <LeftSection
+        title="Agents"
+        description="Agents write code, maintain notes, and coordinate tasks."
+        addActionLabel="Create new agent"
+        actionVariant="inline"
+        onAddAction={onAddAction}
+      >
+        <div>Body content</div>
+      </LeftSection>
+    )
+
+    const inlineActionButton = screen.getByRole('button', { name: 'Create new agent' })
+
+    expect(inlineActionButton.textContent).toBe('+ Create new agent')
+    expect(inlineActionButton.className).toContain('focus-visible:border-ring')
+    expect(inlineActionButton.className).toContain('focus-visible:ring-ring/50')
+    expect(inlineActionButton.className).toContain('focus-visible:ring-3')
+    expect(screen.queryByRole('button', { name: 'Add agent' })).toBeNull()
+
+    fireEvent.click(inlineActionButton)
+
+    expect(onAddAction).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders a disabled inline text action when no add callback is provided', () => {
+    render(
+      <LeftSection
+        title="Agents"
+        description="Agents write code, maintain notes, and coordinate tasks."
+        addActionLabel="Create new agent"
+        actionVariant="inline"
+      >
+        <div>Body content</div>
+      </LeftSection>
+    )
+
+    const inlineActionButton = screen.getByRole('button', { name: 'Create new agent' })
+
+    expect(inlineActionButton.textContent).toBe('+ Create new agent')
+    expect(inlineActionButton.hasAttribute('disabled')).toBe(true)
   })
 
   it('does not render an empty description paragraph when description is omitted', () => {

--- a/app/tests/unit/renderer/left/left-panel-mode.test.ts
+++ b/app/tests/unit/renderer/left/left-panel-mode.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveLeftPanelMode } from '../../../../src/renderer/components/left/left-panel-mode'
+
+describe('resolveLeftPanelMode', () => {
+  it('resolves coordinator mode when no task activity snapshot is present', () => {
+    expect(resolveLeftPanelMode({ taskActivitySnapshot: undefined })).toBe('coordinator')
+  })
+
+  it('resolves build mode when a task activity snapshot is present', () => {
+    expect(
+      resolveLeftPanelMode({
+        taskActivitySnapshot: {
+          sessionId: 'session-1',
+          runId: 'run-1',
+          items: [],
+          counts: {
+            not_started: 0,
+            in_progress: 0,
+            blocked: 0,
+            complete: 0
+          }
+        }
+      })
+    ).toBe('build')
+  })
+})


### PR DESCRIPTION
## Summary
- add coordinator-specific left sidebar mode resolution based on task-tracking availability
- load coordinator sidebar agents and context from IPC-backed selectors and render dedicated coordinator sections
- cover the new sidebar mode with unit tests, coordinator E2E coverage, and follow-up E2E isolation fixes for shared worker state

## Test Plan
- npm run -w app test:ci:local
- npx playwright test tests/e2e/kat-170-sidebar-sectionsnav.spec.ts --headed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added coordinator mode to the left sidebar with dedicated Agents and Context sections, displaying agent rosters and context resources with status indicators.
  * Introduced inline text action variant for section headers alongside existing icon-only actions.
  * Added panel mode detection to switch between coordinator and build layouts.

* **Tests**
  * Added end-to-end tests for coordinator sidebar behavior and agent roster interactions.
  * Added unit tests for coordinator sidebar data fetching and UI components.
  * Updated navigation tests to reflect coordinator mode rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a coordinator-specific left sidebar mode for the `LeftPanel`. When no `TaskActivitySnapshot` is present the panel resolves to `'coordinator'` mode via the new `resolveLeftPanelMode` helper, loading agent roster and context data from IPC-backed selectors instead of the build-mode roster hook. New components (`CoordinatorAgentsSection`, `CoordinatorContextSection`, `CoordinatorAgentListItem`, `LeftSection`) are wired into `LeftPanel` behind the mode gate, and `AppShell` gains mode-aware width constants. Test coverage is thorough — unit tests cover the hook lifecycle, mode resolution, and each new component, and E2E specs validate coordinator sidebar rendering end-to-end.

**Key findings:**
- `useCoordinatorSidebarData` is called unconditionally with the active session ID even when `panelMode === 'build'`, triggering three redundant IPC calls per session that are never consumed in build mode (see `LeftPanel.tsx` line 94).
- The four new width constants (`LEFT_MIN_BUILD`, `LEFT_MIN_COORDINATOR`, `LEFT_DEFAULT_BUILD`, `LEFT_DEFAULT_COORDINATOR`) all share identical numeric values (320/320/390/390), making the `useLayoutEffect` snap condition in `AppShell` equivalent to `current === 390` in both modes. The logic will need revisiting when the constants are actually differentiated.
- Context items in `CoordinatorContextSection` are rendered as enabled `<button>` elements without `onClick` handlers, exposing non-functional interactive controls to keyboard and assistive-technology users.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor follow-up; no data loss or security risk, but the unconditional IPC calls in build mode should be addressed soon.
- The core mode-resolution logic, IPC hook, and new components are all well-implemented and thoroughly tested. The unconditional IPC calls in build mode are a performance issue rather than a correctness bug, and the non-functional context item buttons are an incremental UX gap. Neither blocks the feature from working correctly.
- Pay close attention to `app/src/renderer/components/layout/LeftPanel.tsx` (unconditional IPC calls) and `app/src/renderer/components/left/CoordinatorContextSection.tsx` (non-functional button elements).

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/src/renderer/components/layout/LeftPanel.tsx | Wires up coordinator sidebar mode and data; calls `useCoordinatorSidebarData` unconditionally, causing unnecessary IPC calls in build mode. |
| app/src/renderer/components/layout/AppShell.tsx | Introduces mode-aware panel width constants; all four new constants share identical values, making the useLayoutEffect snap logic a no-op until they diverge. |
| app/src/renderer/components/left/left-panel-mode.ts | Clean, well-tested utility that resolves coordinator vs build panel mode from task activity snapshot presence. |
| app/src/renderer/hooks/useCoordinatorSidebarData.ts | Well-structured hook with proper disposed guard, IPC bridge validation, and comprehensive test coverage for all lifecycle scenarios. |
| app/src/renderer/components/left/CoordinatorAgentsSection.tsx | Clean coordinator agents section with loading, error, and empty states; delegates subtitle logic to a clear helper function. |
| app/src/renderer/components/left/CoordinatorContextSection.tsx | Renders context items as clickable `<button>` elements without `onClick` handlers, creating non-functional interactive controls for keyboard users. |
| app/tests/unit/renderer/hooks/useCoordinatorSidebarData.test.ts | Thorough test suite covering IPC bridge validation, session switching with late-resolve isolation, error handling, and unmount cleanup. |
| app/tests/e2e/kat-170-sidebar-sectionsnav.spec.ts | New E2E spec for coordinator sidebar; creates a fresh session to guarantee coordinator mode, covering agent display, tab switching, and collapse/restore. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([AppShell renders]) --> B{taskActivitySnapshot\npresent?}
    B -- Yes --> C[panelMode = 'build']
    B -- No --> D[panelMode = 'coordinator']

    C --> E[leftMin = LEFT_MIN_BUILD\nleftDefault = LEFT_DEFAULT_BUILD]
    D --> F[leftMin = LEFT_MIN_COORDINATOR\nleftDefault = LEFT_DEFAULT_COORDINATOR]

    E --> G[LeftPanel — build mode]
    F --> H[LeftPanel — coordinator mode]

    G --> I[useSessionAgentRoster IPC]
    H --> J[useCoordinatorSidebarData IPC\n← also called in build mode ⚠️]
    I --> J

    H --> K{activeTab}
    G --> K

    K -- agents + coordinator --> L[CoordinatorAgentsSection\nagentItems + promptPreview]
    K -- agents + build --> M[AgentsTab\n+ ConversationEntryIndexSection]
    K -- context + coordinator --> N[CoordinatorContextSection\ncontextItems]
    K -- context + build --> O[ContextTab]
    K -- changes --> P[ChangesTab]
    K -- files --> Q[FilesTab]

    L --> R[CoordinatorAgentListItem\nper agent]
```

<sub>Last reviewed commit: 953dd98</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->