### PR TITLE
KAT-173: wire session model selector to provider models

### DIFF
--- a/app/docs/plans/2026-03-06-kat-173-model-selector-ux-wired-to-provider-model-list-design.md
+++ b/app/docs/plans/2026-03-06-kat-173-model-selector-ux-wired-to-provider-model-list-design.md
@@ -1,0 +1,393 @@
+# KAT-173 [02.5] Model selector UX wired to provider model list Design
+
+**Issue:** KAT-173  
+**Linear URL:** https://linear.app/kata-sh/issue/KAT-173/025-model-selector-ux-wired-to-provider-model-list  
+**Branch target:** `feature/kat-173-025-model-selector-ux-wired-to-provider-model-list`  
+**Parent epic:** KAT-163 Post-Slice A - Coordinator Session Parity (Spec 02)  
+**Specs:** `_plans/design/specs/02-coordinator-session.md`  
+**Relevant mocks:** `04-coordinator-session-initial-state.png`, `05-coordinator-session-pasted-context.png`, `06-coordinator-session-spec-context-reading.png`, `07-coordinator-session-spec-analyzing.png`
+
+## Scope and Outcome
+
+Wire the center-panel model selector to the real provider model list and give the session input a deterministic, persisted active-model policy.
+
+Required outcome:
+
+- mount the existing renderer `ModelSelector` into the session input surface
+- load the auth-aware curated model list from `model:list`
+- resolve one effective selected model per session from persisted state plus live availability
+- submit and retry runs with the resolved provider/model pair instead of hardcoded defaults
+- persist the session's chosen model through `SessionRecord.activeModelId`
+- keep fallback behavior deterministic when the persisted model is missing, unauthenticated, or model loading fails
+
+This ticket is an **Enabler**.
+
+It does not own final mock-polish of the selector row, settings affordance parity, or full screenshot evidence. Those remain with `KAT-176` and the Spec 02 parent umbrella `KAT-163`.
+
+## Context Loaded
+
+Sources reviewed for this design:
+
+- Linear issues:
+  - `KAT-173`
+  - parent epic `KAT-163`
+- Linear comments on `KAT-173`:
+  - fidelity role = `Enabler`
+  - UI surface = model selector wiring/integration in center input
+  - acceptance bar = correct provider-model wiring and fallback behavior
+- Linear project documents:
+  - `Execution Model: UI Baseline then Parallel Functional Vertical Slices`
+  - `Desktop App Linear Workflow Contract`
+  - `UI Ticket Fidelity Contract (Desktop App)`
+- Local specs and mock indexes:
+  - `AGENTS.md`
+  - `_plans/design/specs/README.md`
+  - `_plans/design/specs/02-coordinator-session.md`
+  - `_plans/design/mocks/README.md`
+- Relevant prior local design docs:
+  - `docs/plans/2026-03-01-kat-159-orchestrator-run-lifecycle-design.md`
+  - `docs/plans/2026-03-05-kat-214-shared-conversation-ui-primitives-design.md`
+  - `docs/plans/2026-03-06-kat-169-agentcontext-sidebar-domain-model-state-contracts-design.md`
+  - `docs/plans/2026-03-06-kat-171-conversation-message-primitives-coordinator-status-design.md`
+- Current implementation:
+  - `src/renderer/components/center/ModelSelector.tsx`
+  - `src/renderer/components/center/ChatInput.tsx`
+  - `src/renderer/components/center/ChatPanel.tsx`
+  - `src/renderer/hooks/useIpcSessionConversation.ts`
+  - `src/preload/index.ts`
+  - `src/main/ipc-handlers.ts`
+  - `src/main/orchestrator.ts`
+  - `src/main/agent-runner.ts`
+  - `src/main/state-store.ts`
+  - `src/shared/types/space.ts`
+  - `src/shared/types/run.ts`
+
+## Current State Summary
+
+The repo already has almost all of the raw pieces this ticket needs, but they are disconnected:
+
+- `src/renderer/components/center/ModelSelector.tsx` exists and already renders an auth-aware dropdown.
+- `src/renderer/components/center/ChatInput.tsx` already exposes a `modelSlot`, so the input shell can host the selector without a layout rewrite.
+- `src/main/ipc-handlers.ts` already exposes `model:list` and returns the curated `SUPPORTED_MODELS` array with `authStatus`.
+- `run:submit` already accepts `{ sessionId, prompt, model, provider }`, and `RunRecord` already persists the chosen provider/model for each run.
+- `SessionRecord.activeModelId` already exists in `src/shared/types/space.ts`, so session-level persistence was planned earlier.
+
+What is still missing:
+
+- `ChatPanel` never mounts `ModelSelector`.
+- `useIpcSessionConversation` still hardcodes `openai-codex` + `gpt-5.3-codex` for both submit and retry.
+- there is no renderer hook that loads and resolves the model list for the active session.
+- there is no IPC path to persist a changed `activeModelId`.
+- there is no explicit fallback policy for stale or unavailable selections.
+
+## Clarifications and Assumptions
+
+- As of **March 6, 2026**, Linear shows `KAT-173` with no blockers and classified as an `Enabler`.
+- The curated model list in `src/main/ipc-handlers.ts` is the canonical ordering for fallback resolution in this ticket.
+- `activeModelId` remains the persisted session preference for this ticket because the current curated `SUPPORTED_MODELS` set uses unique `modelId` values. If implementation finds duplicate `modelId` values in the shipped registry, this ticket should widen persistence before merging.
+- A model with `authStatus === 'none'` is visible in the selector but should not win the "best available" fallback when an authenticated model exists.
+- Final auth UX polish such as a settings icon or explicit login CTA in the footer is out of scope here; the acceptance bar is correct wiring and deterministic selection behavior.
+
+## Approaches Considered
+
+### Approach 1 (Recommended): Session model-selection hook + explicit `session:setActiveModel` IPC
+
+Introduce a focused renderer hook that loads `model:list`, resolves the effective selection for the current session, and persists user changes through a dedicated session IPC update.
+
+Pros:
+
+- finishes the half-implemented `activeModelId` contract instead of bypassing it
+- keeps selection logic deterministic and centralized
+- lets submit and retry both use the same resolved model source
+- preserves clean ownership boundaries: main owns persistence, renderer owns presentation and resolution
+
+Cons:
+
+- adds one small IPC seam
+- requires a little more cross-layer wiring than a pure renderer patch
+
+### Approach 2: Renderer-local selection state only, persisted indirectly on `run:submit`
+
+Keep model state inside the center panel, and update `activeModelId` only when a run is submitted.
+
+Pros:
+
+- smallest code change
+- no new IPC channel
+
+Cons:
+
+- selected model is lost on reload if the user changes it before submitting
+- `activeModelId` stays underutilized
+- retry semantics become harder to keep correct after a failed run plus selector change
+
+### Approach 3: Expand session persistence to store a full `{ provider, modelId, name }` object
+
+Treat model selection as a richer persisted structure and avoid lookups against the canonical model list.
+
+Pros:
+
+- reduces renderer lookup work
+- can preserve display metadata even if the model list is temporarily unavailable
+
+Cons:
+
+- unnecessary schema churn for an enabler ticket
+- duplicates canonical data already owned by `model:list`
+- raises migration and compatibility cost before it is justified
+
+## Recommendation
+
+Proceed with **Approach 1**.
+
+This is the smallest design that actually completes the intended architecture. It uses the existing selector UI, the existing `activeModelId` field, and the existing `model:list` + `run:submit` contracts, while adding only the missing session persistence seam and a deterministic resolver.
+
+## Proposed Design
+
+## 1) Ownership Boundary
+
+This ticket should own:
+
+- active-model resolution for the current session
+- selector mounting in the center input
+- persistence of `SessionRecord.activeModelId`
+- submit/retry using the resolved selection
+- deterministic fallback rules
+
+This ticket should not own:
+
+- redesigning the selector visuals beyond what the existing component already provides
+- auth dialog or provider-login UX changes
+- right-panel workflow/sidebar behavior
+- final parity evidence screenshots
+
+## 2) Canonical Model Descriptor and Resolver
+
+Use the existing renderer-facing descriptor shape from `ModelSelector.tsx`:
+
+```ts
+type ModelInfo = {
+  provider: string
+  modelId: string
+  name: string
+  authStatus: 'oauth' | 'api_key' | 'none'
+}
+```
+
+Add a pure resolver helper in the renderer:
+
+```ts
+type ResolveSelectedModelInput = {
+  models: ModelInfo[]
+  persistedModelId?: string
+}
+```
+
+Resolution rules, in order:
+
+1. If `persistedModelId` matches a model whose `authStatus !== 'none'`, use it.
+2. Otherwise use the first authenticated model in canonical `model:list` order.
+3. Otherwise use the first model in canonical `model:list` order.
+4. If `model:list` fails or returns empty, fall back to the existing hardcoded default:
+   - provider: `openai-codex`
+   - modelId: `gpt-5.3-codex`
+   - name: `GPT-5.3 Codex`
+
+This makes the effective selection deterministic across reloads, missing credentials, and cold-start failures.
+
+## 3) Persistence Contract
+
+Keep `SessionRecord.activeModelId?: string` as the persisted field for this ticket.
+
+Constraint:
+
+- this is valid only while the curated model inventory keeps `modelId` unique across providers
+- if that invariant changes during implementation, the persistence contract must be widened before ship
+
+Add a new IPC contract:
+
+```ts
+// preload/main
+sessionSetActiveModel(input: {
+  sessionId: string
+  activeModelId: string
+}): Promise<SessionRecord>
+```
+
+Main-process rules:
+
+- validate that the target session exists
+- validate that `activeModelId` is a string
+- update only `SessionRecord.activeModelId`
+- return the updated session record
+
+Renderer rules:
+
+- persist immediately when the user selects a model from the dropdown
+- after the first successful `model:list` load, if the resolver must fall back away from an invalid persisted id, persist the resolved id once so subsequent loads are stable
+
+This preserves session continuity without introducing a broader session-update API.
+
+## 4) Renderer Integration Shape
+
+Add a focused hook, for example:
+
+```ts
+useSessionModelSelection(sessionId: string | null, spaceId: string | null)
+```
+
+Responsibilities:
+
+- load the current session record
+- load `model:list`
+- expose:
+  - `models`
+  - `currentModel`
+  - `isLoading`
+  - `loadError`
+  - `setCurrentModel(model: ModelInfo)`
+
+Data source options:
+
+- preferred: add a `session:get` preload/main method for direct session lookup
+- acceptable minimal fallback: derive the current session from `sessionListBySpace({ spaceId })`
+
+Recommendation:
+
+- add `session:get` if no existing parent component already has the active `SessionRecord`
+- avoid forcing `ChatPanel` to scan all sessions in a space just to resolve one field
+
+## 5) Center-Panel Wiring
+
+`ChatPanel` should:
+
+- call `useSessionModelSelection(sessionId, spaceId)`
+- pass a `ModelSelector` into `ChatInput.modelSlot`
+- submit prompts with the hook's current resolved model
+
+`ChatInput` should remain mostly unchanged. Its existing `modelSlot` seam is already the right integration point.
+
+`ModelSelector` should be reused, not replaced. Any visual parity gaps remain follow-up work for fidelity/evidence tickets.
+
+## 6) Submit and Retry Semantics
+
+Change `useIpcSessionConversation` so submit/retry consume a model selection input instead of internal constants.
+
+Recommended API evolution:
+
+```ts
+submitPrompt(prompt: string, model: ModelInfo): void
+retry(model: ModelInfo): void
+```
+
+Alternative implementation:
+
+- keep the public methods simple and hold the current model in a ref supplied by the selection hook
+
+Behavioral rule:
+
+- `submitPrompt` always uses the currently resolved model
+- `retry` uses the currently resolved model at the moment the user retries, not a stale hardcoded default
+
+This lets a user recover from a failed or unauthenticated model choice by picking a new model and hitting Retry.
+
+## 7) Deterministic Fallback Behavior
+
+The fallback policy should be explicit and test-backed:
+
+- persisted valid + authenticated model -> preserve it
+- persisted valid but unauthenticated model -> fall back to first authenticated model
+- persisted unknown model id -> fall back to first authenticated model
+- no authenticated models available -> fall back to first canonical model so the selector still shows a stable choice
+- `model:list` unavailable -> fall back to the current hardcoded Codex default and disable selector interaction until the list loads again
+
+Important product rule:
+
+- fallback is silent but deterministic for this ticket
+- final explicit auth/error affordances are deferred to fidelity follow-ups
+
+## 8) Main/Preload Changes
+
+Main process:
+
+- extend `src/main/ipc-handlers.ts`
+  - add `SESSION_SET_ACTIVE_MODEL_CHANNEL`
+  - optionally add `SESSION_GET_CHANNEL`
+  - keep `SUPPORTED_MODELS` as the canonical list source
+
+Preload:
+
+- expose matching bridge methods in `src/preload/index.ts`
+
+Shared types:
+
+- keep `SessionRecord.activeModelId` as-is
+- no new shared persisted model type is required for this ticket
+
+## 9) Testing Strategy (TDD)
+
+Required tests:
+
+### Unit
+
+- resolver tests for:
+  - valid persisted selection
+  - persisted missing from model list
+  - persisted unauthenticated
+  - no authenticated models
+  - empty/failed model list fallback
+- `ModelSelector` integration test proving the selected resolved model is rendered through `ChatInput.modelSlot`
+- `useIpcSessionConversation` tests proving submit and retry use the provided model instead of hardcoded defaults
+
+### Main / Preload
+
+- `ipc-handlers.test.ts`
+  - `session:setActiveModel` validates input
+  - persists `activeModelId`
+  - optionally `session:get` returns the targeted session
+- `preload/index.test.ts`
+  - new bridge methods invoke the correct channels
+
+### Integration
+
+- `ChatPanel` tests proving:
+  - selector appears when session data is available
+  - changing the selector persists the session model
+  - send/retry use the current resolved model
+  - fallback selection is stable when the persisted id is invalid
+
+E2E note:
+
+- full parity screenshots remain owned by `KAT-176`
+- this ticket only needs targeted behavioral proof, not the full fidelity package
+
+## Non-Goals
+
+- adding settings-icon behavior to the selector row
+- changing the curated model inventory
+- redesigning the auth/login flow
+- expanding persistence to a provider+model compound session schema
+- final screenshot/video evidence for Spec 02 states 04-07
+
+## Risks and Mitigations
+
+- Risk: the renderer duplicates canonical fallback knowledge.
+  - Mitigation: keep one renderer fallback constant for the emergency-empty-list path only; all normal selection comes from `model:list`.
+
+- Risk: `activeModelId` becomes ambiguous if two providers ever ship the same model id.
+  - Mitigation: assert uniqueness against the curated list in tests for this ticket, and widen persistence if the invariant no longer holds.
+
+- Risk: silently falling off an unauthenticated persisted model may surprise users.
+  - Mitigation: keep the behavior deterministic now and defer explicit UX copy/status affordances to final fidelity work.
+
+- Risk: adding a larger session update API broadens surface area unnecessarily.
+  - Mitigation: use a narrowly scoped `session:setActiveModel` channel.
+
+## Approval Gate
+
+If this design is approved, the next step is an implementation plan with a test-first sequence for:
+
+1. session model persistence IPC
+2. renderer selection resolver hook
+3. `ChatPanel` and `useIpcSessionConversation` wiring
+4. regression coverage for fallback behavior

--- a/app/docs/plans/2026-03-06-kat-173-model-selector-ux-wired-to-provider-model-list-implementation-plan.md
+++ b/app/docs/plans/2026-03-06-kat-173-model-selector-ux-wired-to-provider-model-list-implementation-plan.md
@@ -1,0 +1,865 @@
+# KAT-173 Model Selector UX Wired to Provider Model List Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Wire the center-session model selector to the real provider model list, persist the session's selected model, and make submit/retry use a deterministic resolved provider/model instead of hardcoded Codex defaults.
+
+**Architecture:** Add a narrow session persistence seam in main/preload for reading and writing `SessionRecord.activeModelId`, then build a renderer-side model-selection resolver that consumes `model:list` and produces one effective `ModelInfo` for the active session. Mount the existing `ModelSelector` into `ChatInput` through `ChatPanel`, and rework `useIpcSessionConversation` so prompt submission and retry use the resolved selection rather than internal constants.
+
+**Tech Stack:** Electron IPC, React 19, TypeScript, existing renderer center components, shared app state in `src/shared/types/space.ts`, Vitest, Testing Library.
+
+---
+
+**Execution Rules:**
+- Apply `@test-driven-development` on every task: red, then green, then refactor.
+- Apply `@verification-before-completion` before claiming ticket completion.
+- Keep scope focused on model-selector wiring, persistence, and deterministic fallback behavior.
+- Do not expand auth UX, selector polish, or final fidelity evidence in this ticket.
+- Keep commits small: one commit per task.
+
+### Task 1: Add session model persistence IPC
+
+**Files:**
+- Modify: `src/main/ipc-handlers.ts`
+- Modify: `src/preload/index.ts`
+- Test: `tests/unit/main/ipc-handlers.test.ts`
+- Test: `tests/unit/preload/index.test.ts`
+
+**Step 1: Write the failing tests**
+
+```ts
+// tests/unit/main/ipc-handlers.test.ts
+it('session:get returns the requested session record', async () => {
+  const store = createMockStore({
+    ...createDefaultAppState(),
+    sessions: {
+      'session-1': {
+        id: 'session-1',
+        spaceId: 'space-1',
+        label: 'Chat',
+        createdAt: '2026-03-06T00:00:00.000Z',
+        activeModelId: 'gpt-5.3-codex'
+      }
+    }
+  })
+
+  registerIpcHandlers(store)
+  const handler = getHandlersByChannel().get('session:get')!
+
+  await expect(handler({}, { sessionId: 'session-1' })).resolves.toMatchObject({
+    id: 'session-1',
+    activeModelId: 'gpt-5.3-codex'
+  })
+})
+
+it('session:setActiveModel persists activeModelId for an existing session', async () => {
+  const state = {
+    ...createDefaultAppState(),
+    sessions: {
+      'session-1': {
+        id: 'session-1',
+        spaceId: 'space-1',
+        label: 'Chat',
+        createdAt: '2026-03-06T00:00:00.000Z'
+      }
+    }
+  }
+  const store = createMockStore(state)
+
+  registerIpcHandlers(store)
+  const handler = getHandlersByChannel().get('session:setActiveModel')!
+
+  await handler({}, { sessionId: 'session-1', activeModelId: 'claude-sonnet-4-6-20250514' })
+
+  expect(store.save).toHaveBeenCalledWith({
+    ...state,
+    sessions: {
+      ...state.sessions,
+      'session-1': {
+        ...state.sessions['session-1'],
+        activeModelId: 'claude-sonnet-4-6-20250514'
+      }
+    }
+  })
+})
+```
+
+```ts
+// tests/unit/preload/index.test.ts
+it('exposes sessionGet and sessionSetActiveModel bridge methods', async () => {
+  await import('../../../src/preload/index')
+
+  const [, api] = exposeInMainWorld.mock.calls[0] as [
+    string,
+    {
+      sessionGet: (sessionId: string) => Promise<unknown>
+      sessionSetActiveModel: (input: { sessionId: string; activeModelId: string }) => Promise<unknown>
+    }
+  ]
+
+  invoke.mockResolvedValueOnce({ id: 'session-1', activeModelId: 'gpt-5.3-codex' })
+  await expect(api.sessionGet('session-1')).resolves.toMatchObject({ id: 'session-1' })
+  expect(invoke).toHaveBeenCalledWith('session:get', { sessionId: 'session-1' })
+
+  invoke.mockResolvedValueOnce({ id: 'session-1', activeModelId: 'claude-sonnet-4-6-20250514' })
+  await expect(
+    api.sessionSetActiveModel({
+      sessionId: 'session-1',
+      activeModelId: 'claude-sonnet-4-6-20250514'
+    })
+  ).resolves.toMatchObject({ activeModelId: 'claude-sonnet-4-6-20250514' })
+  expect(invoke).toHaveBeenCalledWith('session:setActiveModel', {
+    sessionId: 'session-1',
+    activeModelId: 'claude-sonnet-4-6-20250514'
+  })
+})
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run tests/unit/main/ipc-handlers.test.ts tests/unit/preload/index.test.ts`
+
+Expected: FAIL because `session:get` and `session:setActiveModel` are not registered or exposed yet.
+
+**Step 3: Write the minimal implementation**
+
+```ts
+// src/main/ipc-handlers.ts
+const SESSION_GET_CHANNEL = 'session:get'
+const SESSION_SET_ACTIVE_MODEL_CHANNEL = 'session:setActiveModel'
+
+function parseSessionGetInput(input: unknown): { sessionId: string } {
+  if (!isObjectRecord(input) || typeof input.sessionId !== 'string') {
+    throw new Error('session:get input must be an object with string sessionId')
+  }
+  return { sessionId: input.sessionId }
+}
+
+function parseSessionSetActiveModelInput(input: unknown): {
+  sessionId: string
+  activeModelId: string
+} {
+  if (
+    !isObjectRecord(input) ||
+    typeof input.sessionId !== 'string' ||
+    typeof input.activeModelId !== 'string'
+  ) {
+    throw new Error('session:setActiveModel input must include string sessionId and activeModelId')
+  }
+  return { sessionId: input.sessionId, activeModelId: input.activeModelId }
+}
+
+ipcMain.handle(SESSION_GET_CHANNEL, async (_event, input: unknown) => {
+  const { sessionId } = parseSessionGetInput(input)
+  return stateStore.load().sessions[sessionId] ?? null
+})
+
+ipcMain.handle(SESSION_SET_ACTIVE_MODEL_CHANNEL, async (_event, input: unknown) => {
+  const { sessionId, activeModelId } = parseSessionSetActiveModelInput(input)
+  const state = stateStore.load()
+  const session = state.sessions[sessionId]
+  if (!session) {
+    throw new Error(`Cannot set active model for unknown session: ${sessionId}`)
+  }
+
+  const updatedSession = { ...session, activeModelId }
+  stateStore.save({
+    ...state,
+    sessions: {
+      ...state.sessions,
+      [sessionId]: updatedSession
+    }
+  })
+
+  return updatedSession
+})
+```
+
+```ts
+// src/preload/index.ts
+const SESSION_GET_CHANNEL = 'session:get'
+const SESSION_SET_ACTIVE_MODEL_CHANNEL = 'session:setActiveModel'
+
+sessionGet: (sessionId: string): Promise<SessionRecord | null> =>
+  invokeTyped<SessionRecord | null>(SESSION_GET_CHANNEL, { sessionId }),
+sessionSetActiveModel: (input: { sessionId: string; activeModelId: string }): Promise<SessionRecord> =>
+  invokeTyped<SessionRecord>(SESSION_SET_ACTIVE_MODEL_CHANNEL, input),
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run tests/unit/main/ipc-handlers.test.ts tests/unit/preload/index.test.ts`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/main/ipc-handlers.ts src/preload/index.ts tests/unit/main/ipc-handlers.test.ts tests/unit/preload/index.test.ts
+git commit -m "feat(ipc): persist session active model selection"
+```
+
+### Task 2: Add a deterministic session-model resolver and hook
+
+**Files:**
+- Create: `src/renderer/hooks/useSessionModelSelection.ts`
+- Create: `src/renderer/components/center/model-selection.ts`
+- Test: `tests/unit/renderer/hooks/useSessionModelSelection.test.ts`
+- Test: `tests/unit/renderer/center/model-selection.test.ts`
+
+**Step 1: Write the failing tests**
+
+```ts
+// tests/unit/renderer/center/model-selection.test.ts
+import { describe, expect, it } from 'vitest'
+
+import {
+  FALLBACK_MODEL,
+  resolveSelectedModel
+} from '../../../../src/renderer/components/center/model-selection'
+
+const models = [
+  {
+    provider: 'openai-codex',
+    modelId: 'gpt-5.3-codex',
+    name: 'GPT-5.3 Codex',
+    authStatus: 'oauth' as const
+  },
+  {
+    provider: 'anthropic',
+    modelId: 'claude-sonnet-4-6-20250514',
+    name: 'Claude Sonnet 4.6',
+    authStatus: 'api_key' as const
+  }
+]
+
+describe('resolveSelectedModel', () => {
+  it('keeps a valid authenticated persisted model', () => {
+    expect(resolveSelectedModel(models, 'claude-sonnet-4-6-20250514')).toMatchObject({
+      modelId: 'claude-sonnet-4-6-20250514'
+    })
+  })
+
+  it('falls back to the first authenticated model when persisted id is unknown', () => {
+    expect(resolveSelectedModel(models, 'unknown')).toMatchObject({
+      modelId: 'gpt-5.3-codex'
+    })
+  })
+
+  it('falls back to the constant emergency model when list is empty', () => {
+    expect(resolveSelectedModel([], undefined)).toEqual(FALLBACK_MODEL)
+  })
+})
+```
+
+```ts
+// tests/unit/renderer/hooks/useSessionModelSelection.test.ts
+it('loads model list plus session activeModelId and exposes the resolved model', async () => {
+  ;(window as any).kata = {
+    sessionGet: vi.fn().mockResolvedValue({
+      id: 'session-1',
+      spaceId: 'space-1',
+      label: 'Chat',
+      createdAt: '2026-03-06T00:00:00.000Z',
+      activeModelId: 'claude-sonnet-4-6-20250514'
+    }),
+    modelList: vi.fn().mockResolvedValue([
+      {
+        provider: 'openai-codex',
+        modelId: 'gpt-5.3-codex',
+        name: 'GPT-5.3 Codex',
+        authStatus: 'oauth'
+      },
+      {
+        provider: 'anthropic',
+        modelId: 'claude-sonnet-4-6-20250514',
+        name: 'Claude Sonnet 4.6',
+        authStatus: 'api_key'
+      }
+    ]),
+    sessionSetActiveModel: vi.fn().mockResolvedValue({})
+  }
+
+  const { useSessionModelSelection } = await import(
+    '../../../../src/renderer/hooks/useSessionModelSelection'
+  )
+  const { result } = renderHook(() => useSessionModelSelection('session-1'))
+
+  await waitFor(() => {
+    expect(result.current.currentModel?.modelId).toBe('claude-sonnet-4-6-20250514')
+  })
+})
+
+it('persists reconciled fallback when persisted model is unavailable', async () => {
+  const sessionSetActiveModel = vi.fn().mockResolvedValue({})
+  ;(window as any).kata = {
+    sessionGet: vi.fn().mockResolvedValue({
+      id: 'session-1',
+      spaceId: 'space-1',
+      label: 'Chat',
+      createdAt: '2026-03-06T00:00:00.000Z',
+      activeModelId: 'missing-model'
+    }),
+    modelList: vi.fn().mockResolvedValue([
+      {
+        provider: 'openai-codex',
+        modelId: 'gpt-5.3-codex',
+        name: 'GPT-5.3 Codex',
+        authStatus: 'oauth'
+      }
+    ]),
+    sessionSetActiveModel
+  }
+
+  const { useSessionModelSelection } = await import(
+    '../../../../src/renderer/hooks/useSessionModelSelection'
+  )
+  renderHook(() => useSessionModelSelection('session-1'))
+
+  await waitFor(() => {
+    expect(sessionSetActiveModel).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      activeModelId: 'gpt-5.3-codex'
+    })
+  })
+})
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run tests/unit/renderer/center/model-selection.test.ts tests/unit/renderer/hooks/useSessionModelSelection.test.ts`
+
+Expected: FAIL because the resolver module and hook do not exist yet.
+
+**Step 3: Write the minimal implementation**
+
+```ts
+// src/renderer/components/center/model-selection.ts
+import type { ModelInfo } from './ModelSelector'
+
+export const FALLBACK_MODEL: ModelInfo = {
+  provider: 'openai-codex',
+  modelId: 'gpt-5.3-codex',
+  name: 'GPT-5.3 Codex',
+  authStatus: 'none'
+}
+
+export function resolveSelectedModel(
+  models: ModelInfo[],
+  activeModelId?: string
+): ModelInfo {
+  const persisted = activeModelId
+    ? models.find((model) => model.modelId === activeModelId && model.authStatus !== 'none')
+    : undefined
+
+  if (persisted) {
+    return persisted
+  }
+
+  const firstAuthenticated = models.find((model) => model.authStatus !== 'none')
+  if (firstAuthenticated) {
+    return firstAuthenticated
+  }
+
+  return models[0] ?? FALLBACK_MODEL
+}
+```
+
+```ts
+// src/renderer/hooks/useSessionModelSelection.ts
+import { useEffect, useState } from 'react'
+
+import type { SessionRecord } from '../../shared/types/space'
+import type { ModelInfo } from '../components/center/ModelSelector'
+import { resolveSelectedModel } from '../components/center/model-selection'
+
+export function useSessionModelSelection(sessionId: string | null) {
+  const [models, setModels] = useState<ModelInfo[]>([])
+  const [session, setSession] = useState<SessionRecord | null>(null)
+  const [currentModel, setCurrentModelState] = useState<ModelInfo | null>(null)
+
+  useEffect(() => {
+    if (!sessionId) {
+      setModels([])
+      setSession(null)
+      setCurrentModelState(null)
+      return
+    }
+
+    let cancelled = false
+
+    Promise.all([
+      window.kata?.sessionGet?.(sessionId) ?? Promise.resolve(null),
+      window.kata?.modelList?.() ?? Promise.resolve([])
+    ]).then(async ([nextSession, nextModels]) => {
+      if (cancelled) return
+
+      setSession(nextSession)
+      setModels(nextModels)
+      const resolved = resolveSelectedModel(nextModels, nextSession?.activeModelId)
+      setCurrentModelState(resolved)
+
+      if (
+        nextSession?.id &&
+        resolved.modelId &&
+        nextSession.activeModelId !== resolved.modelId &&
+        typeof window.kata?.sessionSetActiveModel === 'function'
+      ) {
+        await window.kata.sessionSetActiveModel({
+          sessionId: nextSession.id,
+          activeModelId: resolved.modelId
+        })
+      }
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [sessionId])
+
+  const setCurrentModel = async (model: ModelInfo) => {
+    setCurrentModelState(model)
+    if (sessionId && typeof window.kata?.sessionSetActiveModel === 'function') {
+      await window.kata.sessionSetActiveModel({
+        sessionId,
+        activeModelId: model.modelId
+      })
+    }
+  }
+
+  return {
+    models,
+    session,
+    currentModel,
+    setCurrentModel
+  }
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run tests/unit/renderer/center/model-selection.test.ts tests/unit/renderer/hooks/useSessionModelSelection.test.ts`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/renderer/hooks/useSessionModelSelection.ts src/renderer/components/center/model-selection.ts tests/unit/renderer/hooks/useSessionModelSelection.test.ts tests/unit/renderer/center/model-selection.test.ts
+git commit -m "feat(renderer): add session model selection resolver"
+```
+
+### Task 3: Wire the selector into `ChatPanel` and route submit/retry through the resolved model
+
+**Files:**
+- Modify: `src/renderer/components/center/ChatPanel.tsx`
+- Modify: `src/renderer/components/center/ChatInput.tsx`
+- Modify: `src/renderer/hooks/useIpcSessionConversation.ts`
+- Test: `tests/unit/renderer/center/ChatPanel.test.tsx`
+- Test: `tests/unit/renderer/center/ChatInput.test.tsx`
+- Test: `tests/unit/renderer/hooks/useIpcSessionConversation.test.ts`
+
+**Step 1: Write the failing tests**
+
+```ts
+// tests/unit/renderer/hooks/useIpcSessionConversation.test.ts
+it('submitPrompt uses the provided model and provider', async () => {
+  const { useIpcSessionConversation } = await import(
+    '../../../../src/renderer/hooks/useIpcSessionConversation'
+  )
+  const { result } = renderHook(() => useIpcSessionConversation('s-1'))
+
+  act(() => {
+    result.current.submitPrompt('Plan phase 2', {
+      provider: 'anthropic',
+      modelId: 'claude-sonnet-4-6-20250514',
+      name: 'Claude Sonnet 4.6',
+      authStatus: 'api_key'
+    })
+  })
+
+  expect(mockRunSubmit).toHaveBeenCalledWith({
+    sessionId: 's-1',
+    prompt: 'Plan phase 2',
+    model: 'claude-sonnet-4-6-20250514',
+    provider: 'anthropic'
+  })
+})
+
+it('retry uses the currently selected model and provider', async () => {
+  const { useIpcSessionConversation } = await import(
+    '../../../../src/renderer/hooks/useIpcSessionConversation'
+  )
+  const { result } = renderHook(() => useIpcSessionConversation('s-1'))
+
+  act(() => {
+    result.current.submitPrompt('Plan phase 2', {
+      provider: 'openai-codex',
+      modelId: 'gpt-5.3-codex',
+      name: 'GPT-5.3 Codex',
+      authStatus: 'oauth'
+    })
+  })
+
+  act(() => {
+    onRunEventCallback?.({
+      type: 'run_state_changed',
+      runState: 'error',
+      errorMessage: 'No credentials'
+    })
+  })
+
+  act(() => {
+    result.current.retry({
+      provider: 'anthropic',
+      modelId: 'claude-sonnet-4-6-20250514',
+      name: 'Claude Sonnet 4.6',
+      authStatus: 'api_key'
+    })
+  })
+
+  expect(mockRunSubmit).toHaveBeenLastCalledWith({
+    sessionId: 's-1',
+    prompt: 'Plan phase 2',
+    model: 'claude-sonnet-4-6-20250514',
+    provider: 'anthropic'
+  })
+})
+```
+
+```tsx
+// tests/unit/renderer/center/ChatPanel.test.tsx
+it('renders the selector model label from the session model hook', () => {
+  mockModelHook.mockReturnValue({
+    models: [
+      {
+        provider: 'anthropic',
+        modelId: 'claude-sonnet-4-6-20250514',
+        name: 'Claude Sonnet 4.6',
+        authStatus: 'api_key'
+      }
+    ],
+    currentModel: {
+      provider: 'anthropic',
+      modelId: 'claude-sonnet-4-6-20250514',
+      name: 'Claude Sonnet 4.6',
+      authStatus: 'api_key'
+    },
+    setCurrentModel: vi.fn()
+  })
+
+  render(<ChatPanel sessionId="session-1" />)
+
+  expect(screen.getByText('Claude Sonnet 4.6')).toBeTruthy()
+})
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run tests/unit/renderer/hooks/useIpcSessionConversation.test.ts tests/unit/renderer/center/ChatPanel.test.tsx tests/unit/renderer/center/ChatInput.test.tsx`
+
+Expected: FAIL because `submitPrompt`/`retry` do not accept a selected model and `ChatPanel` does not mount `ModelSelector`.
+
+**Step 3: Write the minimal implementation**
+
+```ts
+// src/renderer/hooks/useIpcSessionConversation.ts
+import type { ModelInfo } from '../components/center/ModelSelector'
+
+const DEFAULT_RUN_MODEL = 'gpt-5.3-codex'
+const DEFAULT_RUN_PROVIDER = 'openai-codex'
+
+function toRunSelection(model?: ModelInfo) {
+  return {
+    model: model?.modelId ?? DEFAULT_RUN_MODEL,
+    provider: model?.provider ?? DEFAULT_RUN_PROVIDER
+  }
+}
+
+const submitPrompt = useCallback(
+  (prompt: string, selectedModel?: ModelInfo) => {
+    const kata = window.kata
+    if (!kata?.runSubmit || !sessionId) return
+
+    const selection = toRunSelection(selectedModel)
+    lastPromptRef.current = prompt
+    setLatestDraft(undefined)
+    dispatch({ type: 'SUBMIT_PROMPT', prompt })
+
+    kata
+      .runSubmit({
+        sessionId,
+        prompt,
+        model: selection.model,
+        provider: selection.provider
+      })
+      .catch((error: Error) => {
+        dispatch({ type: 'RUN_FAILED', error: error.message })
+      })
+  },
+  [sessionId]
+)
+
+const retry = useCallback(
+  (selectedModel?: ModelInfo) => {
+    if (state.runState !== 'error' || !lastPromptRef.current) return
+    const kata = window.kata
+    if (!kata?.runSubmit || !sessionId) return
+
+    const selection = toRunSelection(selectedModel)
+    kata.runSubmit({
+      sessionId,
+      prompt: lastPromptRef.current,
+      model: selection.model,
+      provider: selection.provider
+    })
+  },
+  [sessionId, state.runState]
+)
+```
+
+```tsx
+// src/renderer/components/center/ChatPanel.tsx
+import { ModelSelector } from './ModelSelector'
+import { useSessionModelSelection } from '../../hooks/useSessionModelSelection'
+
+const { currentModel, models, setCurrentModel } = useSessionModelSelection(sessionId)
+
+<ChatInput
+  onSend={(prompt) => submitPrompt(prompt, currentModel ?? undefined)}
+  onRetry={() => retry(currentModel ?? undefined)}
+  runState={state.runState}
+  disabled={!sessionId}
+  modelSlot={
+    currentModel ? (
+      <ModelSelector
+        currentModel={currentModel}
+        models={models}
+        onModelChange={setCurrentModel}
+        disabled={!sessionId}
+      />
+    ) : null
+  }
+/>
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run tests/unit/renderer/hooks/useIpcSessionConversation.test.ts tests/unit/renderer/center/ChatPanel.test.tsx tests/unit/renderer/center/ChatInput.test.tsx`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/renderer/components/center/ChatPanel.tsx src/renderer/components/center/ChatInput.tsx src/renderer/hooks/useIpcSessionConversation.ts tests/unit/renderer/center/ChatPanel.test.tsx tests/unit/renderer/center/ChatInput.test.tsx tests/unit/renderer/hooks/useIpcSessionConversation.test.ts
+git commit -m "feat(renderer): wire session model selector into chat submission"
+```
+
+### Task 4: Lock deterministic fallback behavior and model-id invariants
+
+**Files:**
+- Modify: `tests/unit/renderer/center/model-selection.test.ts`
+- Modify: `tests/unit/renderer/hooks/useSessionModelSelection.test.ts`
+- Modify: `tests/unit/main/ipc-handlers.test.ts`
+
+**Step 1: Write the failing tests**
+
+```ts
+// tests/unit/renderer/center/model-selection.test.ts
+it('prefers the first authenticated model when the persisted model is unauthenticated', () => {
+  const models = [
+    {
+      provider: 'openai-codex',
+      modelId: 'gpt-5.3-codex',
+      name: 'GPT-5.3 Codex',
+      authStatus: 'none' as const
+    },
+    {
+      provider: 'anthropic',
+      modelId: 'claude-sonnet-4-6-20250514',
+      name: 'Claude Sonnet 4.6',
+      authStatus: 'api_key' as const
+    }
+  ]
+
+  expect(resolveSelectedModel(models, 'gpt-5.3-codex')).toMatchObject({
+    modelId: 'claude-sonnet-4-6-20250514'
+  })
+})
+
+it('asserts the curated model list has unique model ids', () => {
+  const modelIds = SUPPORTED_MODELS.map((model) => model.modelId)
+  expect(new Set(modelIds).size).toBe(modelIds.length)
+})
+```
+
+```ts
+// tests/unit/renderer/hooks/useSessionModelSelection.test.ts
+it('does not repersist the activeModelId when persisted selection is already valid', async () => {
+  const sessionSetActiveModel = vi.fn().mockResolvedValue({})
+  ;(window as any).kata = {
+    sessionGet: vi.fn().mockResolvedValue({
+      id: 'session-1',
+      spaceId: 'space-1',
+      label: 'Chat',
+      createdAt: '2026-03-06T00:00:00.000Z',
+      activeModelId: 'gpt-5.3-codex'
+    }),
+    modelList: vi.fn().mockResolvedValue([
+      {
+        provider: 'openai-codex',
+        modelId: 'gpt-5.3-codex',
+        name: 'GPT-5.3 Codex',
+        authStatus: 'oauth'
+      }
+    ]),
+    sessionSetActiveModel
+  }
+
+  const { useSessionModelSelection } = await import(
+    '../../../../src/renderer/hooks/useSessionModelSelection'
+  )
+  renderHook(() => useSessionModelSelection('session-1'))
+
+  await waitFor(() => {
+    expect((window as any).kata.sessionGet).toHaveBeenCalled()
+  })
+
+  expect(sessionSetActiveModel).not.toHaveBeenCalled()
+})
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run tests/unit/renderer/center/model-selection.test.ts tests/unit/renderer/hooks/useSessionModelSelection.test.ts tests/unit/main/ipc-handlers.test.ts`
+
+Expected: FAIL until the resolver explicitly handles unauthenticated persisted selections and the curated model invariant is asserted.
+
+**Step 3: Write the minimal implementation**
+
+```ts
+// src/renderer/components/center/model-selection.ts
+export function resolveSelectedModel(
+  models: ModelInfo[],
+  activeModelId?: string
+): ModelInfo {
+  const persisted = activeModelId
+    ? models.find((model) => model.modelId === activeModelId)
+    : undefined
+
+  if (persisted && persisted.authStatus !== 'none') {
+    return persisted
+  }
+
+  const firstAuthenticated = models.find((model) => model.authStatus !== 'none')
+  if (firstAuthenticated) {
+    return firstAuthenticated
+  }
+
+  return models[0] ?? FALLBACK_MODEL
+}
+```
+
+```ts
+// tests/unit/main/ipc-handlers.test.ts
+describe('SUPPORTED_MODELS invariants', () => {
+  it('uses unique model ids across the curated list', async () => {
+    const { SUPPORTED_MODELS } = await import('../../../src/main/ipc-handlers')
+    const modelIds = SUPPORTED_MODELS.map((model) => model.modelId)
+    expect(new Set(modelIds).size).toBe(modelIds.length)
+  })
+})
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run tests/unit/renderer/center/model-selection.test.ts tests/unit/renderer/hooks/useSessionModelSelection.test.ts tests/unit/main/ipc-handlers.test.ts`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tests/unit/renderer/center/model-selection.test.ts tests/unit/renderer/hooks/useSessionModelSelection.test.ts tests/unit/main/ipc-handlers.test.ts
+git commit -m "test(renderer): lock deterministic model selection fallback"
+```
+
+### Task 5: Verify the full ticket surface
+
+**Files:**
+- Modify: `tests/unit/renderer/center/ChatPanel.test.tsx`
+- Modify: `tests/unit/renderer/hooks/useIpcSessionConversation.test.ts`
+- Optional evidence notes: `docs/plans/2026-03-06-kat-173-model-selector-ux-wired-to-provider-model-list-design.md`
+
+**Step 1: Add the final behavioral assertions**
+
+```tsx
+// tests/unit/renderer/center/ChatPanel.test.tsx
+it('passes the newly selected model to the next send action', async () => {
+  const setCurrentModel = vi.fn()
+  mockModelHook.mockReturnValue({
+    models: [
+      {
+        provider: 'anthropic',
+        modelId: 'claude-sonnet-4-6-20250514',
+        name: 'Claude Sonnet 4.6',
+        authStatus: 'api_key'
+      }
+    ],
+    currentModel: {
+      provider: 'anthropic',
+      modelId: 'claude-sonnet-4-6-20250514',
+      name: 'Claude Sonnet 4.6',
+      authStatus: 'api_key'
+    },
+    setCurrentModel
+  })
+
+  render(<ChatPanel sessionId="session-1" />)
+
+  expect(screen.getByText('Claude Sonnet 4.6')).toBeTruthy()
+})
+```
+
+**Step 2: Run focused tests**
+
+Run: `npx vitest run tests/unit/renderer/center/ChatPanel.test.tsx tests/unit/renderer/hooks/useIpcSessionConversation.test.ts tests/unit/renderer/hooks/useSessionModelSelection.test.ts tests/unit/renderer/center/model-selection.test.ts tests/unit/main/ipc-handlers.test.ts tests/unit/preload/index.test.ts`
+
+Expected: PASS.
+
+**Step 3: Run the broader app unit suite for regression safety**
+
+Run: `npm run test -- --runInBand`
+
+Expected: PASS, or if the workspace uses Vitest directly for app tests, run the repo-standard equivalent and confirm no regressions in center-panel or preload/main tests.
+
+**Step 4: Check the working tree**
+
+Run: `git status --short`
+
+Expected: only the files for KAT-173 plan/implementation are modified.
+
+**Step 5: Commit verification-only adjustments if needed**
+
+```bash
+git add tests/unit/renderer/center/ChatPanel.test.tsx tests/unit/renderer/hooks/useIpcSessionConversation.test.ts tests/unit/renderer/hooks/useSessionModelSelection.test.ts tests/unit/renderer/center/model-selection.test.ts tests/unit/main/ipc-handlers.test.ts tests/unit/preload/index.test.ts
+git commit -m "test(renderer): verify model selector session wiring"
+```
+
+## Completion Checklist
+
+- `ModelSelector` is mounted in the active chat input.
+- `model:list` is used as the source of truth for selectable models.
+- `SessionRecord.activeModelId` is read and written through IPC.
+- submit and retry use the resolved model/provider, not hardcoded constants.
+- fallback behavior is deterministic and covered by tests.
+- curated model ids are asserted unique while `activeModelId` remains the persistence key.
+
+Plan complete and saved to `docs/plans/2026-03-06-kat-173-model-selector-ux-wired-to-provider-model-list-implementation-plan.md`. Two execution options:
+
+1. Subagent-Driven (this session) - I dispatch fresh subagent per task, review between tasks, fast iteration
+
+2. Parallel Session (separate) - Open new session with executing-plans, batch execution with checkpoints
+
+Which approach?

--- a/app/src/main/ipc-handlers.ts
+++ b/app/src/main/ipc-handlers.ts
@@ -72,7 +72,9 @@ const SESSION_CREATE_CHANNEL = 'session:create'
 const SESSION_AGENT_ROSTER_LIST_CHANNEL = 'session-agent-roster:list'
 const SESSION_CONTEXT_RESOURCES_LIST_CHANNEL = 'session-context-resources:list'
 const SESSION_LIST_BY_SPACE_CHANNEL = 'session:listBySpace'
+const SESSION_GET_CHANNEL = 'session:get'
 const SESSION_SET_ACTIVE_CHANNEL = 'session:setActive'
+const SESSION_SET_ACTIVE_MODEL_CHANNEL = 'session:setActiveModel'
 const SPEC_GET_CHANNEL = 'spec:get'
 const SPEC_SAVE_CHANNEL = 'spec:save'
 const DIALOG_OPEN_DIR_CHANNEL = 'dialog:openDirectory'
@@ -88,7 +90,7 @@ const AUTH_LOGIN_CHANNEL = 'auth:login'
 const AUTH_LOGOUT_CHANNEL = 'auth:logout'
 const MODEL_LIST_CHANNEL = 'model:list'
 
-const SUPPORTED_MODELS = [
+export const SUPPORTED_MODELS = [
   { provider: 'openai-codex', modelId: 'gpt-5.3-codex', name: 'GPT-5.3 Codex' },
   { provider: 'anthropic', modelId: 'claude-sonnet-4-6-20250514', name: 'Claude Sonnet 4.6' },
   { provider: 'anthropic', modelId: 'claude-haiku-4-5-20251001', name: 'Claude Haiku 4.5' },
@@ -314,6 +316,14 @@ function parseSessionListBySpaceInput(input: unknown): { spaceId: string } {
   return { spaceId: input.spaceId }
 }
 
+function parseSessionGetInput(input: unknown): { sessionId: string } {
+  if (!isObjectRecord(input) || typeof input.sessionId !== 'string') {
+    throw new Error('session:get input must be an object with string sessionId')
+  }
+
+  return { sessionId: input.sessionId }
+}
+
 function parseSpaceSetActiveInput(input: unknown): { spaceId: string } {
   if (!isObjectRecord(input) || typeof input.spaceId !== 'string') {
     throw new Error('space:setActive input must be an object with string spaceId')
@@ -328,6 +338,24 @@ function parseSessionSetActiveInput(input: unknown): { sessionId: string } {
   }
 
   return { sessionId: input.sessionId }
+}
+
+function parseSessionSetActiveModelInput(input: unknown): {
+  sessionId: string
+  activeModelId: string
+} {
+  if (
+    !isObjectRecord(input) ||
+    typeof input.sessionId !== 'string' ||
+    typeof input.activeModelId !== 'string'
+  ) {
+    throw new Error('session:setActiveModel input must include string sessionId and activeModelId')
+  }
+
+  return {
+    sessionId: input.sessionId,
+    activeModelId: input.activeModelId
+  }
 }
 
 function parseSpecGetInput(input: unknown): { spaceId: string; sessionId: string } {
@@ -603,7 +631,9 @@ export function registerIpcHandlers(store: StateStore, options?: RegisterIpcOpti
   ipcMain.removeHandler(SESSION_AGENT_ROSTER_LIST_CHANNEL)
   ipcMain.removeHandler(SESSION_CONTEXT_RESOURCES_LIST_CHANNEL)
   ipcMain.removeHandler(SESSION_LIST_BY_SPACE_CHANNEL)
+  ipcMain.removeHandler(SESSION_GET_CHANNEL)
   ipcMain.removeHandler(SESSION_SET_ACTIVE_CHANNEL)
+  ipcMain.removeHandler(SESSION_SET_ACTIVE_MODEL_CHANNEL)
   ipcMain.removeHandler(SPEC_GET_CHANNEL)
   ipcMain.removeHandler(SPEC_SAVE_CHANNEL)
 
@@ -821,6 +851,11 @@ export function registerIpcHandlers(store: StateStore, options?: RegisterIpcOpti
       .sort((left, right) => right.createdAt.localeCompare(left.createdAt))
   })
 
+  ipcMain.handle(SESSION_GET_CHANNEL, async (_event, input: unknown) => {
+    const { sessionId } = parseSessionGetInput(input)
+    return stateStore.load().sessions[sessionId] ?? null
+  })
+
   ipcMain.handle(SESSION_SET_ACTIVE_CHANNEL, async (_event, input: unknown) => {
     const { sessionId } = parseSessionSetActiveInput(input)
     const state = stateStore.load()
@@ -839,6 +874,30 @@ export function registerIpcHandlers(store: StateStore, options?: RegisterIpcOpti
       activeSpaceId: session.spaceId,
       activeSessionId: sessionId
     }
+  })
+
+  ipcMain.handle(SESSION_SET_ACTIVE_MODEL_CHANNEL, async (_event, input: unknown) => {
+    const { sessionId, activeModelId } = parseSessionSetActiveModelInput(input)
+    const state = stateStore.load()
+    const session = state.sessions[sessionId]
+    if (!session) {
+      throw new Error(`Cannot set active model for unknown session: ${sessionId}`)
+    }
+
+    const updatedSession: SessionRecord = {
+      ...session,
+      activeModelId
+    }
+
+    stateStore.save({
+      ...state,
+      sessions: {
+        ...state.sessions,
+        [sessionId]: updatedSession
+      }
+    })
+
+    return updatedSession
   })
 
   ipcMain.handle(SPEC_GET_CHANNEL, async (_event, input: unknown) => {
@@ -1244,12 +1303,11 @@ export function registerIpcHandlers(store: StateStore, options?: RegisterIpcOpti
       return SUPPORTED_MODELS.map((m) => ({ ...m, authStatus: 'none' as const }))
     }
 
-    const results = await Promise.all(
-      SUPPORTED_MODELS.map(async (m) => ({
-        ...m,
-        authStatus: await credResolver.getAuthStatus(m.provider)
-      }))
+    const uniqueProviders = [...new Set(SUPPORTED_MODELS.map((m) => m.provider))]
+    const statusEntries = await Promise.all(
+      uniqueProviders.map(async (p) => [p, await credResolver.getAuthStatus(p)] as const)
     )
-    return results
+    const statusByProvider = Object.fromEntries(statusEntries)
+    return SUPPORTED_MODELS.map((m) => ({ ...m, authStatus: statusByProvider[m.provider] }))
   })
 }

--- a/app/src/preload/index.ts
+++ b/app/src/preload/index.ts
@@ -22,7 +22,9 @@ const SESSION_CREATE_CHANNEL = 'session:create'
 const SESSION_AGENT_ROSTER_LIST_CHANNEL = 'session-agent-roster:list'
 const SESSION_CONTEXT_RESOURCES_LIST_CHANNEL = 'session-context-resources:list'
 const SESSION_LIST_BY_SPACE_CHANNEL = 'session:listBySpace'
+const SESSION_GET_CHANNEL = 'session:get'
 const SESSION_SET_ACTIVE_CHANNEL = 'session:setActive'
+const SESSION_SET_ACTIVE_MODEL_CHANNEL = 'session:setActiveModel'
 const SPEC_GET_CHANNEL = 'spec:get'
 const SPEC_SAVE_CHANNEL = 'spec:save'
 const DIALOG_OPEN_DIR_CHANNEL = 'dialog:openDirectory'
@@ -80,10 +82,14 @@ const kataApi = {
     invokeTyped<SessionContextResourceRecord[]>(SESSION_CONTEXT_RESOURCES_LIST_CHANNEL, input),
   sessionListBySpace: (input: { spaceId: string }): Promise<SessionRecord[]> =>
     invokeTyped<SessionRecord[]>(SESSION_LIST_BY_SPACE_CHANNEL, input),
+  sessionGet: (sessionId: string): Promise<SessionRecord | null> =>
+    invokeTyped<SessionRecord | null>(SESSION_GET_CHANNEL, { sessionId }),
   sessionSetActive: (sessionId: string): Promise<{ activeSpaceId: string; activeSessionId: string }> =>
     invokeTyped<{ activeSpaceId: string; activeSessionId: string }>(SESSION_SET_ACTIVE_CHANNEL, {
       sessionId
     }),
+  sessionSetActiveModel: (input: { sessionId: string; activeModelId: string }): Promise<SessionRecord> =>
+    invokeTyped<SessionRecord>(SESSION_SET_ACTIVE_MODEL_CHANNEL, input),
   specGet: (input: { spaceId: string; sessionId: string }): Promise<PersistedSpecDocument | null> =>
     invokeTyped<PersistedSpecDocument | null>(SPEC_GET_CHANNEL, input),
   specSave: (input: {

--- a/app/src/renderer/components/center/ChatPanel.tsx
+++ b/app/src/renderer/components/center/ChatPanel.tsx
@@ -1,11 +1,13 @@
 import { useEffect, useMemo, useState } from 'react'
 
 import { useIpcSessionConversation } from '../../hooks/useIpcSessionConversation'
+import { useSessionModelSelection } from '../../hooks/useSessionModelSelection'
 import type { LatestRunDraft } from '../../types/spec-document'
 import type { ConversationEntry } from '../left/conversation-entry-index'
 import { buildConversationEntries } from '../left/conversation-entry-index'
 import { ChatInput } from './ChatInput'
 import { MessageBubble } from './MessageBubble'
+import { ModelSelector } from './ModelSelector'
 import { type DecisionState, extractInlineDecisionCard, type InlineDecisionCard, isDecisionResolved } from './message-decision-parser'
 import { type ScrollToMessage, MessageList } from './MessageList'
 import { toCoordinatorStatusBadgeState, toPrimitiveRunState } from './primitives/adapters'
@@ -30,8 +32,10 @@ export function ChatPanel({
   onRegisterScrollToMessage
 }: ChatPanelProps) {
   const { state, submitPrompt, retry } = useIpcSessionConversation(sessionId, spaceId ?? null)
+  const { currentModel, models, setCurrentModel, isHydrated } = useSessionModelSelection(sessionId)
   const [dismissedMessageIds, setDismissedMessageIds] = useState<Set<string>>(() => new Set())
   const primitiveRunState = toPrimitiveRunState(state.runState)
+  const isModelSelectionReady = !sessionId || (isHydrated && currentModel !== null)
   const coordinatorStatusBadgeState = toCoordinatorStatusBadgeState({
     conversationRunState: state.runState,
     activityPhase: state.activityPhase
@@ -91,7 +95,7 @@ export function ChatPanel({
           const { card: decisionCard, resolved } = decisionCardMap.get(message.id)!
           const decisionState: DecisionState = resolved
             ? 'resolved'
-            : primitiveRunState === 'pending'
+            : primitiveRunState === 'pending' || !isModelSelectionReady
               ? 'pending'
               : 'available'
 
@@ -109,9 +113,14 @@ export function ChatPanel({
                 decisionCard={decisionCard}
                 decisionState={decisionState}
                 onDecisionAction={(actionId) => {
-                  submitPrompt(
-                    decisionCard!.actions.find((action) => action.id === actionId)!.followUpPrompt
-                  )
+                  const selectedAction =
+                    decisionState === 'available'
+                      ? decisionCard?.actions.find((action) => action.id === actionId)
+                      : undefined
+
+                  if (selectedAction) {
+                    submitPrompt(selectedAction.followUpPrompt, currentModel ?? undefined)
+                  }
                 }}
                 onDismiss={(messageId) => {
                   setDismissedMessageIds((current) => {
@@ -129,10 +138,24 @@ export function ChatPanel({
         <ConversationStatusBadge state={coordinatorStatusBadgeState} />
       </div>
       <ChatInput
-        onSend={submitPrompt}
-        onRetry={retry}
+        onSend={(prompt) => {
+          submitPrompt(prompt, currentModel ?? undefined)
+        }}
+        onRetry={() => {
+          retry(currentModel ?? undefined)
+        }}
         runState={state.runState}
-        disabled={!sessionId}
+        disabled={!sessionId || !isModelSelectionReady}
+        modelSlot={
+          currentModel && isModelSelectionReady ? (
+            <ModelSelector
+              currentModel={currentModel}
+              models={models}
+              onModelChange={setCurrentModel}
+              disabled={!sessionId}
+            />
+          ) : null
+        }
       />
     </div>
   )

--- a/app/src/renderer/components/center/ChatPanel.tsx
+++ b/app/src/renderer/components/center/ChatPanel.tsx
@@ -151,7 +151,11 @@ export function ChatPanel({
             <ModelSelector
               currentModel={currentModel}
               models={models}
-              onModelChange={setCurrentModel}
+              onModelChange={(model) => {
+                void setCurrentModel(model).catch((error) => {
+                  console.error('[ChatPanel] Failed to persist session model selection:', error)
+                })
+              }}
               disabled={!sessionId}
             />
           ) : null

--- a/app/src/renderer/components/center/model-selection.ts
+++ b/app/src/renderer/components/center/model-selection.ts
@@ -1,0 +1,30 @@
+import type { ModelInfo } from './ModelSelector'
+
+export const FALLBACK_MODEL: ModelInfo = {
+  provider: 'openai-codex',
+  modelId: 'gpt-5.3-codex',
+  name: 'GPT-5.3 Codex',
+  authStatus: 'none'
+}
+
+export function resolveSelectedModel(
+  models: ModelInfo[],
+  activeModelId?: string
+): ModelInfo {
+  const persisted = activeModelId
+    ? models.find(
+        (model) => model.modelId === activeModelId && model.authStatus !== 'none'
+      )
+    : undefined
+
+  if (persisted) {
+    return persisted
+  }
+
+  const firstAuthenticated = models.find((model) => model.authStatus !== 'none')
+  if (firstAuthenticated) {
+    return firstAuthenticated
+  }
+
+  return models[0] ?? FALLBACK_MODEL
+}

--- a/app/src/renderer/hooks/useIpcSessionConversation.ts
+++ b/app/src/renderer/hooks/useIpcSessionConversation.ts
@@ -27,6 +27,7 @@ function toConversationActivityPhase(content: string): 'thinking' | 'drafting' |
   return undefined
 }
 
+
 function toRunSelection(model?: ModelInfo): { model: string; provider: string } {
   return {
     model: model?.modelId ?? FALLBACK_MODEL.modelId,

--- a/app/src/renderer/hooks/useIpcSessionConversation.ts
+++ b/app/src/renderer/hooks/useIpcSessionConversation.ts
@@ -4,14 +4,14 @@ import {
   createInitialSessionConversationState,
   sessionConversationReducer
 } from '../components/center/sessionConversationState'
+import type { ModelInfo } from '../components/center/ModelSelector'
+import { FALLBACK_MODEL } from '../components/center/model-selection'
 import type { SessionRuntimeEvent } from '../types/session-runtime-adapter'
 import { INTERRUPTED_RUN_ERROR_MESSAGE } from '../../shared/types/run'
 import { isPersistedSpecDocument } from '../../shared/types/spec-document'
 import { toStableTaskId } from '@shared/task-id'
 import { buildTaskCounts, type TaskActivitySnapshot, type TaskTrackingItem } from '@shared/types/task-tracking'
 
-const DEFAULT_RUN_MODEL = 'gpt-5.3-codex'
-const DEFAULT_RUN_PROVIDER = 'openai-codex'
 const SPEC_AUTHORING_COMPLETION_MESSAGE = "I've created an initial draft of the project spec."
 
 function toConversationActivityPhase(content: string): 'thinking' | 'drafting' | undefined {
@@ -25,6 +25,13 @@ function toConversationActivityPhase(content: string): 'thinking' | 'drafting' |
   }
 
   return undefined
+}
+
+function toRunSelection(model?: ModelInfo): { model: string; provider: string } {
+  return {
+    model: model?.modelId ?? FALLBACK_MODEL.modelId,
+    provider: model?.provider ?? FALLBACK_MODEL.provider
+  }
 }
 
 export function useIpcSessionConversation(sessionId: string | null, spaceId: string | null = null) {
@@ -161,10 +168,11 @@ export function useIpcSessionConversation(sessionId: string | null, spaceId: str
   }, [sessionId, spaceId])
 
   const submitPrompt = useCallback(
-    (prompt: string) => {
+    (prompt: string, selectedModel?: ModelInfo) => {
       const kata = window.kata
       if (!kata?.runSubmit || !sessionId) return
 
+      const selection = toRunSelection(selectedModel)
       lastPromptRef.current = prompt
       dispatch({ type: 'SUBMIT_PROMPT', prompt })
 
@@ -172,8 +180,8 @@ export function useIpcSessionConversation(sessionId: string | null, spaceId: str
         .runSubmit({
           sessionId,
           prompt,
-          model: DEFAULT_RUN_MODEL,
-          provider: DEFAULT_RUN_PROVIDER
+          model: selection.model,
+          provider: selection.provider
         })
         .catch((error: Error) => {
           dispatch({ type: 'RUN_FAILED', error: error.message })
@@ -182,21 +190,22 @@ export function useIpcSessionConversation(sessionId: string | null, spaceId: str
     [sessionId]
   )
 
-  const retry = useCallback(() => {
+  const retry = useCallback((selectedModel?: ModelInfo) => {
     if (state.runState !== 'error' || !lastPromptRef.current) return
 
     const kata = window.kata
     if (!kata?.runSubmit || !sessionId) return
 
     const prompt = lastPromptRef.current
+    const selection = toRunSelection(selectedModel)
     dispatch({ type: 'RETRY_FROM_ERROR' })
 
     kata
       .runSubmit({
         sessionId,
         prompt,
-        model: DEFAULT_RUN_MODEL,
-        provider: DEFAULT_RUN_PROVIDER
+        model: selection.model,
+        provider: selection.provider
       })
       .catch((error: Error) => {
         dispatch({ type: 'RUN_FAILED', error: error.message })

--- a/app/src/renderer/hooks/useSessionModelSelection.ts
+++ b/app/src/renderer/hooks/useSessionModelSelection.ts
@@ -1,12 +1,10 @@
 import { useEffect, useState } from 'react'
 
-import type { SessionRecord } from '../../shared/types/space'
 import type { ModelInfo } from '../components/center/ModelSelector'
 import { FALLBACK_MODEL, resolveSelectedModel } from '../components/center/model-selection'
 
 type SessionModelSelectionState = {
   models: ModelInfo[]
-  session: SessionRecord | null
   currentModel: ModelInfo | null
   isHydrated: boolean
   setCurrentModel: (model: ModelInfo) => Promise<void>
@@ -16,14 +14,12 @@ export function useSessionModelSelection(
   sessionId: string | null
 ): SessionModelSelectionState {
   const [models, setModels] = useState<ModelInfo[]>([])
-  const [session, setSession] = useState<SessionRecord | null>(null)
   const [currentModel, setCurrentModelState] = useState<ModelInfo | null>(null)
   const [isHydrated, setIsHydrated] = useState(false)
 
   useEffect(() => {
     if (!sessionId) {
       setModels([])
-      setSession(null)
       setCurrentModelState(null)
       setIsHydrated(true)
       return
@@ -41,7 +37,6 @@ export function useSessionModelSelection(
           return
         }
 
-        setSession(nextSession)
         setModels(nextModels)
 
         const resolved = resolveSelectedModel(nextModels, nextSession?.activeModelId)
@@ -50,6 +45,7 @@ export function useSessionModelSelection(
 
         if (
           nextSession?.id &&
+          nextSession.activeModelId !== undefined &&
           nextSession.activeModelId !== resolved.modelId &&
           typeof window.kata?.sessionSetActiveModel === 'function'
         ) {
@@ -73,7 +69,6 @@ export function useSessionModelSelection(
         }
 
         setModels([])
-        setSession(null)
         setCurrentModelState(FALLBACK_MODEL)
         setIsHydrated(true)
       })
@@ -102,7 +97,6 @@ export function useSessionModelSelection(
 
   return {
     models,
-    session,
     currentModel,
     isHydrated,
     setCurrentModel

--- a/app/src/renderer/hooks/useSessionModelSelection.ts
+++ b/app/src/renderer/hooks/useSessionModelSelection.ts
@@ -53,10 +53,17 @@ export function useSessionModelSelection(
           nextSession.activeModelId !== resolved.modelId &&
           typeof window.kata?.sessionSetActiveModel === 'function'
         ) {
-          await window.kata.sessionSetActiveModel({
-            sessionId: nextSession.id,
-            activeModelId: resolved.modelId
-          })
+          try {
+            await window.kata.sessionSetActiveModel({
+              sessionId: nextSession.id,
+              activeModelId: resolved.modelId
+            })
+          } catch (reconcileError) {
+            console.error(
+              '[useSessionModelSelection] Failed to persist reconciled model selection:',
+              reconcileError
+            )
+          }
         }
       })
       .catch((error: unknown) => {
@@ -77,13 +84,19 @@ export function useSessionModelSelection(
   }, [sessionId])
 
   const setCurrentModel = async (model: ModelInfo) => {
+    const previousModel = currentModel
     setCurrentModelState(model)
 
     if (sessionId && typeof window.kata?.sessionSetActiveModel === 'function') {
-      await window.kata.sessionSetActiveModel({
-        sessionId,
-        activeModelId: model.modelId
-      })
+      try {
+        await window.kata.sessionSetActiveModel({
+          sessionId,
+          activeModelId: model.modelId
+        })
+      } catch (error) {
+        setCurrentModelState(previousModel)
+        throw error
+      }
     }
   }
 

--- a/app/src/renderer/hooks/useSessionModelSelection.ts
+++ b/app/src/renderer/hooks/useSessionModelSelection.ts
@@ -1,0 +1,97 @@
+import { useEffect, useState } from 'react'
+
+import type { SessionRecord } from '../../shared/types/space'
+import type { ModelInfo } from '../components/center/ModelSelector'
+import { FALLBACK_MODEL, resolveSelectedModel } from '../components/center/model-selection'
+
+type SessionModelSelectionState = {
+  models: ModelInfo[]
+  session: SessionRecord | null
+  currentModel: ModelInfo | null
+  isHydrated: boolean
+  setCurrentModel: (model: ModelInfo) => Promise<void>
+}
+
+export function useSessionModelSelection(
+  sessionId: string | null
+): SessionModelSelectionState {
+  const [models, setModels] = useState<ModelInfo[]>([])
+  const [session, setSession] = useState<SessionRecord | null>(null)
+  const [currentModel, setCurrentModelState] = useState<ModelInfo | null>(null)
+  const [isHydrated, setIsHydrated] = useState(false)
+
+  useEffect(() => {
+    if (!sessionId) {
+      setModels([])
+      setSession(null)
+      setCurrentModelState(null)
+      setIsHydrated(true)
+      return
+    }
+
+    let cancelled = false
+    setIsHydrated(false)
+
+    void Promise.all([
+      window.kata?.sessionGet?.(sessionId) ?? Promise.resolve(null),
+      window.kata?.modelList?.() ?? Promise.resolve([])
+    ])
+      .then(async ([nextSession, nextModels]) => {
+        if (cancelled) {
+          return
+        }
+
+        setSession(nextSession)
+        setModels(nextModels)
+
+        const resolved = resolveSelectedModel(nextModels, nextSession?.activeModelId)
+        setCurrentModelState(resolved)
+        setIsHydrated(true)
+
+        if (
+          nextSession?.id &&
+          nextSession.activeModelId !== resolved.modelId &&
+          typeof window.kata?.sessionSetActiveModel === 'function'
+        ) {
+          await window.kata.sessionSetActiveModel({
+            sessionId: nextSession.id,
+            activeModelId: resolved.modelId
+          })
+        }
+      })
+      .catch((error: unknown) => {
+        console.error('[useSessionModelSelection] Failed to load model selection:', error)
+        if (cancelled) {
+          return
+        }
+
+        setModels([])
+        setSession(null)
+        setCurrentModelState(FALLBACK_MODEL)
+        setIsHydrated(true)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [sessionId])
+
+  const setCurrentModel = async (model: ModelInfo) => {
+    setCurrentModelState(model)
+
+    if (sessionId && typeof window.kata?.sessionSetActiveModel === 'function') {
+      await window.kata.sessionSetActiveModel({
+        sessionId,
+        activeModelId: model.modelId
+      })
+    }
+  }
+
+  return {
+    models,
+    session,
+    currentModel,
+    isHydrated,
+    setCurrentModel
+  }
+}

--- a/app/tests/e2e/kat-158-session-shell-states.spec.ts
+++ b/app/tests/e2e/kat-158-session-shell-states.spec.ts
@@ -10,6 +10,12 @@ const pendingStatePath = path.join(evidenceDir, 'state-pending.png')
 const errorStatePath = path.join(evidenceDir, 'state-error.png')
 const idleStatePath = path.join(evidenceDir, 'state-idle.png')
 
+type ModelStatus = {
+  currentModelName: string | null
+  preferredModelName: string | null
+  hasCredentials: boolean
+}
+
 async function expectRunStatus(appWindow: Page, label: 'Ready' | 'Thinking' | 'Error' | 'Stopped', timeout: number): Promise<void> {
   await expect(appWindow.getByRole('status', { name: label })).toBeVisible({ timeout })
 }
@@ -33,12 +39,50 @@ async function waitForTerminalRunStatus(
   throw new Error(`Run did not reach terminal state (Stopped/Error) within ${timeoutMs}ms`)
 }
 
-async function hasRunCredentials(appWindow: Page): Promise<boolean> {
-  const authStatus = await appWindow.evaluate(async () => {
-    return (await window.kata?.authStatus?.('openai-codex')) ?? 'none'
-  })
+async function readModelStatus(appWindow: Page): Promise<ModelStatus> {
+  return appWindow.evaluate(async () => {
+    const bootstrap = await window.kata?.appBootstrap?.()
+    const sessionId = bootstrap?.activeSessionId ?? null
+    const [models, session] = await Promise.all([
+      window.kata?.modelList?.() ?? Promise.resolve([]),
+      sessionId ? window.kata?.sessionGet?.(sessionId) ?? Promise.resolve(null) : Promise.resolve(null)
+    ])
 
-  return authStatus === 'oauth' || authStatus === 'api_key'
+    const currentModel =
+      models.find((model) => model.modelId === session?.activeModelId) ?? null
+    const preferredModel =
+      models.find((model) => model.authStatus === 'oauth' || model.authStatus === 'api_key') ??
+      null
+
+    return {
+      currentModelName: currentModel?.name ?? null,
+      preferredModelName: preferredModel?.name ?? null,
+      hasCredentials: preferredModel !== null
+    }
+  })
+}
+
+async function ensureRunnableModelSelected(appWindow: Page): Promise<boolean> {
+  const modelStatus = await readModelStatus(appWindow)
+  if (
+    !modelStatus.hasCredentials ||
+    !modelStatus.preferredModelName ||
+    modelStatus.currentModelName === modelStatus.preferredModelName
+  ) {
+    return modelStatus.hasCredentials
+  }
+
+  await appWindow
+    .getByRole('button', { name: modelStatus.currentModelName ?? '' })
+    .click()
+  await appWindow
+    .getByRole('button', { name: modelStatus.preferredModelName, exact: true })
+    .click()
+  await expect(
+    appWindow.getByRole('button', { name: modelStatus.preferredModelName, exact: true })
+  ).toBeVisible({ timeout: 5_000 })
+
+  return true
 }
 
 test.describe('KAT-158 session shell run-state evidence @uat', () => {
@@ -47,7 +91,7 @@ test.describe('KAT-158 session shell run-state evidence @uat', () => {
   }) => {
     await ensureWorkspaceShell(appWindow)
     await fs.mkdir(evidenceDir, { recursive: true })
-    const runCredentialsAvailable = await hasRunCredentials(appWindow)
+    const runCredentialsAvailable = await ensureRunnableModelSelected(appWindow)
 
     const messageInput = appWindow.getByLabel('Message input')
     const sendButton = appWindow.getByRole('button', { name: 'Send' })

--- a/app/tests/unit/main/ipc-handlers.test.ts
+++ b/app/tests/unit/main/ipc-handlers.test.ts
@@ -320,6 +320,15 @@ describe('registerIpcHandlers', () => {
     await expect(handler?.({}, { sessionId: 'missing-session' })).resolves.toBeNull()
   })
 
+  it('session:get rejects invalid input payloads', async () => {
+    registerIpcHandlers(createMockStore())
+    const handler = getHandlersByChannel().get('session:get')
+
+    await expect(handler?.({}, null)).rejects.toThrow(
+      'session:get input must be an object with string sessionId'
+    )
+  })
+
   it('session:setActiveModel persists activeModelId for an existing session', async () => {
     const state = {
       ...createDefaultAppState(),
@@ -352,6 +361,27 @@ describe('registerIpcHandlers', () => {
         }
       }
     })
+  })
+
+  it('session:setActiveModel rejects invalid input payloads', async () => {
+    registerIpcHandlers(createMockStore())
+    const handler = getHandlersByChannel().get('session:setActiveModel')
+
+    await expect(handler?.({}, { sessionId: 'session-1' })).rejects.toThrow(
+      'session:setActiveModel input must include string sessionId and activeModelId'
+    )
+  })
+
+  it('session:setActiveModel rejects unknown session ids', async () => {
+    registerIpcHandlers(createMockStore())
+    const handler = getHandlersByChannel().get('session:setActiveModel')
+
+    await expect(
+      handler?.({}, {
+        sessionId: 'missing-session',
+        activeModelId: 'gpt-4.1-2025-04-14'
+      })
+    ).rejects.toThrow('Cannot set active model for unknown session: missing-session')
   })
 
   it('space:create delegates managed provisioning and persists rootPath/branch/name', async () => {

--- a/app/tests/unit/main/ipc-handlers.test.ts
+++ b/app/tests/unit/main/ipc-handlers.test.ts
@@ -120,7 +120,7 @@ vi.mock('../../../src/main/agent-runner', () => ({
 }))
 
 import { WorkspaceProvisioningError } from '../../../src/main/workspace-provisioning'
-import { registerIpcHandlers } from '../../../src/main/ipc-handlers'
+import { registerIpcHandlers, SUPPORTED_MODELS } from '../../../src/main/ipc-handlers'
 
 type IpcHandler = (event: unknown, ...args: unknown[]) => Promise<unknown>
 type MockStore = {
@@ -229,7 +229,9 @@ describe('registerIpcHandlers', () => {
     expect(mockRemoveHandler).toHaveBeenCalledWith('session:create')
     expect(mockRemoveHandler).toHaveBeenCalledWith('session-agent-roster:list')
     expect(mockRemoveHandler).toHaveBeenCalledWith('session:listBySpace')
+    expect(mockRemoveHandler).toHaveBeenCalledWith('session:get')
     expect(mockRemoveHandler).toHaveBeenCalledWith('session:setActive')
+    expect(mockRemoveHandler).toHaveBeenCalledWith('session:setActiveModel')
     expect(mockRemoveHandler).toHaveBeenCalledWith('spec:get')
     expect(mockRemoveHandler).toHaveBeenCalledWith('spec:save')
     expect(mockHandle).toHaveBeenCalledWith('app:bootstrap', expect.any(Function))
@@ -237,7 +239,9 @@ describe('registerIpcHandlers', () => {
     expect(mockHandle).toHaveBeenCalledWith('space:setActive', expect.any(Function))
     expect(mockHandle).toHaveBeenCalledWith('session-agent-roster:list', expect.any(Function))
     expect(mockHandle).toHaveBeenCalledWith('session:listBySpace', expect.any(Function))
+    expect(mockHandle).toHaveBeenCalledWith('session:get', expect.any(Function))
     expect(mockHandle).toHaveBeenCalledWith('session:setActive', expect.any(Function))
+    expect(mockHandle).toHaveBeenCalledWith('session:setActiveModel', expect.any(Function))
     expect(mockHandle).toHaveBeenCalledWith('spec:get', expect.any(Function))
     expect(mockHandle).toHaveBeenCalledWith('spec:save', expect.any(Function))
   })
@@ -284,6 +288,70 @@ describe('registerIpcHandlers', () => {
       status: 'active'
     })
     expect(store.save).toHaveBeenCalledTimes(1)
+  })
+
+  it('session:get returns the requested session record', async () => {
+    const store = createMockStore({
+      ...createDefaultAppState(),
+      sessions: {
+        'session-1': {
+          id: 'session-1',
+          spaceId: 'space-1',
+          label: 'Chat',
+          createdAt: '2026-03-06T00:00:00.000Z',
+          activeModelId: 'gpt-5.3-codex'
+        }
+      }
+    })
+
+    registerIpcHandlers(store)
+    const handler = getHandlersByChannel().get('session:get')
+
+    await expect(handler?.({}, { sessionId: 'session-1' })).resolves.toMatchObject({
+      id: 'session-1',
+      activeModelId: 'gpt-5.3-codex'
+    })
+  })
+
+  it('session:get returns null for an unknown session id', async () => {
+    registerIpcHandlers(createMockStore())
+    const handler = getHandlersByChannel().get('session:get')
+
+    await expect(handler?.({}, { sessionId: 'missing-session' })).resolves.toBeNull()
+  })
+
+  it('session:setActiveModel persists activeModelId for an existing session', async () => {
+    const state = {
+      ...createDefaultAppState(),
+      sessions: {
+        'session-1': {
+          id: 'session-1',
+          spaceId: 'space-1',
+          label: 'Chat',
+          createdAt: '2026-03-06T00:00:00.000Z'
+        }
+      }
+    }
+    const store = createMockStore(state)
+
+    registerIpcHandlers(store)
+    const handler = getHandlersByChannel().get('session:setActiveModel')
+
+    await handler?.({}, {
+      sessionId: 'session-1',
+      activeModelId: 'claude-sonnet-4-6-20250514'
+    })
+
+    expect(store.save).toHaveBeenCalledWith({
+      ...state,
+      sessions: {
+        ...state.sessions,
+        'session-1': {
+          ...state.sessions['session-1'],
+          activeModelId: 'claude-sonnet-4-6-20250514'
+        }
+      }
+    })
   })
 
   it('space:create delegates managed provisioning and persists rootPath/branch/name', async () => {
@@ -2554,10 +2622,8 @@ describe('registerIpcHandlers', () => {
     it('returns supported models with auth status', async () => {
       mockCredentialResolver.getAuthStatus
         .mockResolvedValueOnce('none')     // openai-codex
-        .mockResolvedValueOnce('api_key')  // anthropic (first model)
-        .mockResolvedValueOnce('api_key')  // anthropic (second model)
-        .mockResolvedValueOnce('none')     // openai (first model)
-        .mockResolvedValueOnce('none')     // openai (second model)
+        .mockResolvedValueOnce('api_key')  // anthropic
+        .mockResolvedValueOnce('none')     // openai
 
       registerIpcHandlers(createMockStore(), { credentialResolver: mockCredentialResolver })
       const handler = getHandlersByChannel().get('model:list')!
@@ -2576,6 +2642,11 @@ describe('registerIpcHandlers', () => {
 
       expect(result.length).toBeGreaterThan(0)
       expect(result.every(m => m.authStatus === 'none')).toBe(true)
+    })
+
+    it('uses unique model ids across the curated list', () => {
+      const modelIds = SUPPORTED_MODELS.map((model) => model.modelId)
+      expect(new Set(modelIds).size).toBe(modelIds.length)
     })
   })
 })

--- a/app/tests/unit/preload/index.test.ts
+++ b/app/tests/unit/preload/index.test.ts
@@ -187,6 +187,37 @@ describe('preload bridge', () => {
     expect(invoke).toHaveBeenCalledWith('session:listBySpace', { spaceId: 'space-1' })
   })
 
+  it('exposes sessionGet and sessionSetActiveModel bridge methods', async () => {
+    await import('../../../src/preload/index')
+
+    const [, api] = exposeInMainWorld.mock.calls[0] as [
+      string,
+      {
+        sessionGet: (sessionId: string) => Promise<unknown>
+        sessionSetActiveModel: (input: { sessionId: string; activeModelId: string }) => Promise<unknown>
+      }
+    ]
+
+    invoke.mockResolvedValueOnce({ id: 'session-1', activeModelId: 'gpt-5.3-codex' })
+    await expect(api.sessionGet('session-1')).resolves.toMatchObject({ id: 'session-1' })
+    expect(invoke).toHaveBeenCalledWith('session:get', { sessionId: 'session-1' })
+
+    invoke.mockResolvedValueOnce({
+      id: 'session-1',
+      activeModelId: 'claude-sonnet-4-6-20250514'
+    })
+    await expect(
+      api.sessionSetActiveModel({
+        sessionId: 'session-1',
+        activeModelId: 'claude-sonnet-4-6-20250514'
+      })
+    ).resolves.toMatchObject({ activeModelId: 'claude-sonnet-4-6-20250514' })
+    expect(invoke).toHaveBeenCalledWith('session:setActiveModel', {
+      sessionId: 'session-1',
+      activeModelId: 'claude-sonnet-4-6-20250514'
+    })
+  })
+
   it('returns false when external open invoke throws', async () => {
     invoke.mockRejectedValue(new Error('ipc unavailable'))
 

--- a/app/tests/unit/renderer/center/ChatPanel.test.tsx
+++ b/app/tests/unit/renderer/center/ChatPanel.test.tsx
@@ -698,4 +698,48 @@ describe('ChatPanel', () => {
 
     expect(onRegisterScrollToMessage).toHaveBeenCalledWith(expect.any(Function))
   })
+
+  it('catches and logs model change persistence failures without crashing', async () => {
+    const persistenceError = new Error('IPC write failed')
+    const setCurrentModel = vi.fn().mockRejectedValue(persistenceError)
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const currentModel = {
+      provider: 'anthropic',
+      modelId: 'claude-sonnet-4-6-20250514',
+      name: 'Claude Sonnet 4.6',
+      authStatus: 'api_key'
+    }
+    const alternateModel = {
+      provider: 'openai',
+      modelId: 'gpt-5.3',
+      name: 'GPT 5.3',
+      authStatus: 'api_key'
+    }
+    mockModelHook.mockReturnValue({
+      models: [currentModel, alternateModel],
+      session: null,
+      currentModel,
+      isHydrated: true,
+      setCurrentModel
+    })
+    mockHook.mockReturnValue({
+      state: idleState({ runState: 'empty' }),
+      submitPrompt: vi.fn(),
+      retry: vi.fn()
+    })
+
+    render(<ChatPanel sessionId="sess-1" />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Claude Sonnet 4.6' }))
+    fireEvent.click(screen.getByText('GPT 5.3'))
+
+    await vi.waitFor(() => {
+      expect(consoleSpy).toHaveBeenCalledWith(
+        '[ChatPanel] Failed to persist session model selection:',
+        persistenceError
+      )
+    })
+
+    consoleSpy.mockRestore()
+  })
 })

--- a/app/tests/unit/renderer/center/ChatPanel.test.tsx
+++ b/app/tests/unit/renderer/center/ChatPanel.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { SessionConversationState } from '../../../../src/renderer/types/session-conversation'
 import { ChatPanel } from '../../../../src/renderer/components/center/ChatPanel'
@@ -12,10 +12,12 @@ const mockHook = vi.fn<
   [string | null, (string | null)?],
   {
     state: SessionConversationState
-    submitPrompt: (prompt: string) => void
-    retry: () => void
+    submitPrompt: (...args: any[]) => void
+    retry: (...args: any[]) => void
   }
 >()
+
+const mockModelHook = vi.fn()
 
 vi.mock('../../../../src/renderer/hooks/useIpcSessionConversation', () => ({
   useIpcSessionConversation: (...args: [string | null, (string | null)?]) => mockHook(...args),
@@ -41,6 +43,10 @@ vi.mock('../../../../src/renderer/components/center/MessageBubble', async (impor
   }
 })
 
+vi.mock('../../../../src/renderer/hooks/useSessionModelSelection', () => ({
+  useSessionModelSelection: (...args: unknown[]) => mockModelHook(...args)
+}))
+
 const decisionProposal = [
   '## Why',
   '- Electron + TypeScript keeps desktop iteration stable',
@@ -64,6 +70,16 @@ function idleState(
 }
 
 describe('ChatPanel', () => {
+  beforeEach(() => {
+    mockModelHook.mockReturnValue({
+      models: [],
+
+      currentModel: null,
+      isHydrated: true,
+      setCurrentModel: vi.fn()
+    })
+  })
+
   afterEach(() => {
     cleanup()
     vi.clearAllMocks()
@@ -364,6 +380,19 @@ describe('ChatPanel', () => {
 
   it('submitting a message calls submitPrompt from the hook', () => {
     const submitPrompt = vi.fn()
+    const currentModel = {
+      provider: 'anthropic',
+      modelId: 'claude-sonnet-4-6-20250514',
+      name: 'Claude Sonnet 4.6',
+      authStatus: 'api_key'
+    }
+    mockModelHook.mockReturnValue({
+      models: [currentModel],
+
+      currentModel,
+      isHydrated: true,
+      setCurrentModel: vi.fn()
+    })
     mockHook.mockReturnValue({
       state: idleState({ runState: 'empty' }),
       submitPrompt,
@@ -377,7 +406,7 @@ describe('ChatPanel', () => {
     })
     fireEvent.click(screen.getByRole('button', { name: 'Send' }))
 
-    expect(submitPrompt).toHaveBeenCalledWith('Build feature X')
+    expect(submitPrompt).toHaveBeenCalledWith('Build feature X', currentModel)
   })
 
   it('disables the chat composer when no sessionId is available yet', () => {
@@ -397,8 +426,45 @@ describe('ChatPanel', () => {
     expect(sendButton.disabled).toBe(true)
   })
 
+  it('disables the chat composer while model selection is still hydrating', () => {
+    const submitPrompt = vi.fn()
+    mockModelHook.mockReturnValue({
+      models: [],
+
+      currentModel: null,
+      isHydrated: false,
+      setCurrentModel: vi.fn()
+    })
+    mockHook.mockReturnValue({
+      state: idleState({ runState: 'empty' }),
+      submitPrompt,
+      retry: vi.fn()
+    })
+
+    render(<ChatPanel sessionId="sess-1" />)
+
+    const input = screen.getByLabelText('Message input') as HTMLTextAreaElement
+    const sendButton = screen.getByRole('button', { name: 'Send' }) as HTMLButtonElement
+
+    expect(input.disabled).toBe(true)
+    expect(sendButton.disabled).toBe(true)
+  })
+
   it('error state shows retry button that calls retry from the hook', () => {
     const retry = vi.fn()
+    const currentModel = {
+      provider: 'anthropic',
+      modelId: 'claude-sonnet-4-6-20250514',
+      name: 'Claude Sonnet 4.6',
+      authStatus: 'api_key'
+    }
+    mockModelHook.mockReturnValue({
+      models: [currentModel],
+
+      currentModel,
+      isHydrated: true,
+      setCurrentModel: vi.fn()
+    })
     mockHook.mockReturnValue({
       state: idleState({ runState: 'error', errorMessage: 'Something broke' }),
       submitPrompt: vi.fn(),
@@ -410,7 +476,7 @@ describe('ChatPanel', () => {
     expect(screen.getByText('Error')).toBeTruthy()
     fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
 
-    expect(retry).toHaveBeenCalled()
+    expect(retry).toHaveBeenCalledWith(currentModel)
   })
 
   it('does not render hardcoded model badge', () => {
@@ -423,6 +489,37 @@ describe('ChatPanel', () => {
     render(<ChatPanel sessionId={null} />)
 
     expect(screen.queryByText('GPT-5.3 Codex')).toBeNull()
+  })
+
+  it('renders the selector model label from the session model hook', () => {
+    mockModelHook.mockReturnValue({
+      models: [
+        {
+          provider: 'anthropic',
+          modelId: 'claude-sonnet-4-6-20250514',
+          name: 'Claude Sonnet 4.6',
+          authStatus: 'api_key'
+        }
+      ],
+
+      currentModel: {
+        provider: 'anthropic',
+        modelId: 'claude-sonnet-4-6-20250514',
+        name: 'Claude Sonnet 4.6',
+        authStatus: 'api_key'
+      },
+      isHydrated: true,
+      setCurrentModel: vi.fn()
+    })
+    mockHook.mockReturnValue({
+      state: idleState({ runState: 'empty' }),
+      submitPrompt: vi.fn(),
+      retry: vi.fn()
+    })
+
+    render(<ChatPanel sessionId="session-1" />)
+
+    expect(screen.getByText('Claude Sonnet 4.6')).toBeTruthy()
   })
 
   it('renders inline decision actions for an eligible agent message', () => {
@@ -445,6 +542,19 @@ describe('ChatPanel', () => {
 
   it('clicking a decision action submits the canonical follow-up prompt', () => {
     const submitPrompt = vi.fn()
+    const currentModel = {
+      provider: 'anthropic',
+      modelId: 'claude-sonnet-4-6-20250514',
+      name: 'Claude Sonnet 4.6',
+      authStatus: 'api_key'
+    }
+    mockModelHook.mockReturnValue({
+      models: [currentModel],
+
+      currentModel,
+      isHydrated: true,
+      setCurrentModel: vi.fn()
+    })
     mockHook.mockReturnValue({
       state: idleState({
         messages: [
@@ -459,7 +569,10 @@ describe('ChatPanel', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Approve the plan...' }))
 
-    expect(submitPrompt).toHaveBeenCalledWith('Approve the plan and continue with this tech stack.')
+    expect(submitPrompt).toHaveBeenCalledWith(
+      'Approve the plan and continue with this tech stack.',
+      currentModel
+    )
   })
 
   it('disables inline decision actions while runState is pending', () => {
@@ -476,6 +589,33 @@ describe('ChatPanel', () => {
     })
 
     render(<ChatPanel sessionId={null} />)
+
+    const approveButton = screen.getByRole('button', { name: 'Approve the plan...' }) as HTMLButtonElement
+    expect(approveButton.disabled).toBe(true)
+    fireEvent.click(approveButton)
+    expect(submitPrompt).not.toHaveBeenCalled()
+  })
+
+  it('disables inline decision actions while model selection is still hydrating', () => {
+    const submitPrompt = vi.fn()
+    mockModelHook.mockReturnValue({
+      models: [],
+
+      currentModel: null,
+      isHydrated: false,
+      setCurrentModel: vi.fn()
+    })
+    mockHook.mockReturnValue({
+      state: idleState({
+        messages: [
+          { id: 'm1', role: 'agent', content: decisionProposal, createdAt: '2026-03-01T00:00:01Z' }
+        ]
+      }),
+      submitPrompt,
+      retry: vi.fn()
+    })
+
+    render(<ChatPanel sessionId="sess-1" />)
 
     const approveButton = screen.getByRole('button', { name: 'Approve the plan...' }) as HTMLButtonElement
     expect(approveButton.disabled).toBe(true)

--- a/app/tests/unit/renderer/center/model-selection.test.ts
+++ b/app/tests/unit/renderer/center/model-selection.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  FALLBACK_MODEL,
+  resolveSelectedModel
+} from '../../../../src/renderer/components/center/model-selection'
+import type { ModelInfo } from '../../../../src/renderer/components/center/ModelSelector'
+
+const models: ModelInfo[] = [
+  {
+    provider: 'openai-codex',
+    modelId: 'gpt-5.3-codex',
+    name: 'GPT-5.3 Codex',
+    authStatus: 'oauth'
+  },
+  {
+    provider: 'anthropic',
+    modelId: 'claude-sonnet-4-6-20250514',
+    name: 'Claude Sonnet 4.6',
+    authStatus: 'api_key'
+  }
+]
+
+describe('resolveSelectedModel', () => {
+  it('keeps a valid authenticated persisted model', () => {
+    expect(resolveSelectedModel(models, 'claude-sonnet-4-6-20250514')).toMatchObject({
+      modelId: 'claude-sonnet-4-6-20250514'
+    })
+  })
+
+  it('falls back to the first authenticated model when persisted id is unknown', () => {
+    expect(resolveSelectedModel(models, 'unknown')).toMatchObject({
+      modelId: 'gpt-5.3-codex'
+    })
+  })
+
+  it('prefers the first authenticated model when the persisted model is unauthenticated', () => {
+    expect(
+      resolveSelectedModel(
+        [
+          {
+            provider: 'openai-codex',
+            modelId: 'gpt-5.3-codex',
+            name: 'GPT-5.3 Codex',
+            authStatus: 'none'
+          },
+          {
+            provider: 'anthropic',
+            modelId: 'claude-sonnet-4-6-20250514',
+            name: 'Claude Sonnet 4.6',
+            authStatus: 'api_key'
+          }
+        ],
+        'gpt-5.3-codex'
+      )
+    ).toMatchObject({
+      modelId: 'claude-sonnet-4-6-20250514'
+    })
+  })
+
+  it('falls back to the constant emergency model when list is empty', () => {
+    expect(resolveSelectedModel([], undefined)).toEqual(FALLBACK_MODEL)
+  })
+})

--- a/app/tests/unit/renderer/hooks/useIpcSessionConversation.test.ts
+++ b/app/tests/unit/renderer/hooks/useIpcSessionConversation.test.ts
@@ -104,6 +104,29 @@ describe('useIpcSessionConversation', () => {
     })
   })
 
+  it('submitPrompt uses the provided model and provider', async () => {
+    const { useIpcSessionConversation } = await import(
+      '../../../../src/renderer/hooks/useIpcSessionConversation'
+    )
+    const { result } = renderHook(() => useIpcSessionConversation('s-1'))
+
+    act(() => {
+      result.current.submitPrompt('Plan phase 2', {
+        provider: 'anthropic',
+        modelId: 'claude-sonnet-4-6-20250514',
+        name: 'Claude Sonnet 4.6',
+        authStatus: 'api_key'
+      })
+    })
+
+    expect(mockRunSubmit).toHaveBeenCalledWith({
+      sessionId: 's-1',
+      prompt: 'Plan phase 2',
+      model: 'claude-sonnet-4-6-20250514',
+      provider: 'anthropic'
+    })
+  })
+
   it('clears draft state when the active session changes', async () => {
     const { useIpcSessionConversation } = await import(
       '../../../../src/renderer/hooks/useIpcSessionConversation'
@@ -578,6 +601,46 @@ describe('useIpcSessionConversation', () => {
 
     expect(result.current.state.runState).toBe('pending')
     expect(mockRunSubmit).toHaveBeenCalledTimes(2)
+  })
+
+  it('retry uses the currently selected model and provider', async () => {
+    const { useIpcSessionConversation } = await import(
+      '../../../../src/renderer/hooks/useIpcSessionConversation'
+    )
+    const { result } = renderHook(() => useIpcSessionConversation('s-1'))
+
+    act(() => {
+      result.current.submitPrompt('Plan phase 2', {
+        provider: 'openai-codex',
+        modelId: 'gpt-5.3-codex',
+        name: 'GPT-5.3 Codex',
+        authStatus: 'oauth'
+      })
+    })
+
+    act(() => {
+      onRunEventCallback?.({
+        type: 'run_state_changed',
+        runState: 'error',
+        errorMessage: 'No credentials'
+      })
+    })
+
+    act(() => {
+      result.current.retry({
+        provider: 'anthropic',
+        modelId: 'claude-sonnet-4-6-20250514',
+        name: 'Claude Sonnet 4.6',
+        authStatus: 'api_key'
+      })
+    })
+
+    expect(mockRunSubmit).toHaveBeenLastCalledWith({
+      sessionId: 's-1',
+      prompt: 'Plan phase 2',
+      model: 'claude-sonnet-4-6-20250514',
+      provider: 'anthropic'
+    })
   })
 
   it('unsubscribes from run events on unmount', async () => {

--- a/app/tests/unit/renderer/hooks/useSessionModelSelection.test.ts
+++ b/app/tests/unit/renderer/hooks/useSessionModelSelection.test.ts
@@ -196,7 +196,6 @@ describe('useSessionModelSelection', () => {
 
     expect(result.current.currentModel?.modelId).toBe('gpt-5.3-codex')
     expect(result.current.models).toEqual([])
-    expect(result.current.session).toBeNull()
     expect(consoleError).toHaveBeenCalledWith(
       '[useSessionModelSelection] Failed to load model selection:',
       expect.any(Error)

--- a/app/tests/unit/renderer/hooks/useSessionModelSelection.test.ts
+++ b/app/tests/unit/renderer/hooks/useSessionModelSelection.test.ts
@@ -1,0 +1,116 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+describe('useSessionModelSelection', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    delete (window as typeof window & { kata?: unknown }).kata
+  })
+
+  it('loads model list plus session activeModelId and exposes the resolved model', async () => {
+    ;(window as typeof window & { kata?: unknown }).kata = {
+      sessionGet: vi.fn().mockResolvedValue({
+        id: 'session-1',
+        spaceId: 'space-1',
+        label: 'Chat',
+        createdAt: '2026-03-06T00:00:00.000Z',
+        activeModelId: 'claude-sonnet-4-6-20250514'
+      }),
+      modelList: vi.fn().mockResolvedValue([
+        {
+          provider: 'openai-codex',
+          modelId: 'gpt-5.3-codex',
+          name: 'GPT-5.3 Codex',
+          authStatus: 'oauth'
+        },
+        {
+          provider: 'anthropic',
+          modelId: 'claude-sonnet-4-6-20250514',
+          name: 'Claude Sonnet 4.6',
+          authStatus: 'api_key'
+        }
+      ]),
+      sessionSetActiveModel: vi.fn().mockResolvedValue({})
+    }
+
+    const { useSessionModelSelection } = await import(
+      '../../../../src/renderer/hooks/useSessionModelSelection'
+    )
+    const { result } = renderHook(() => useSessionModelSelection('session-1'))
+
+    await waitFor(() => {
+      expect(result.current.currentModel?.modelId).toBe('claude-sonnet-4-6-20250514')
+    })
+  })
+
+  it('persists reconciled fallback when persisted model is unavailable', async () => {
+    const sessionSetActiveModel = vi.fn().mockResolvedValue({})
+    ;(window as typeof window & { kata?: unknown }).kata = {
+      sessionGet: vi.fn().mockResolvedValue({
+        id: 'session-1',
+        spaceId: 'space-1',
+        label: 'Chat',
+        createdAt: '2026-03-06T00:00:00.000Z',
+        activeModelId: 'missing-model'
+      }),
+      modelList: vi.fn().mockResolvedValue([
+        {
+          provider: 'openai-codex',
+          modelId: 'gpt-5.3-codex',
+          name: 'GPT-5.3 Codex',
+          authStatus: 'oauth'
+        }
+      ]),
+      sessionSetActiveModel
+    }
+
+    const { useSessionModelSelection } = await import(
+      '../../../../src/renderer/hooks/useSessionModelSelection'
+    )
+    renderHook(() => useSessionModelSelection('session-1'))
+
+    await waitFor(() => {
+      expect(sessionSetActiveModel).toHaveBeenCalledWith({
+        sessionId: 'session-1',
+        activeModelId: 'gpt-5.3-codex'
+      })
+    })
+  })
+
+  it('does not repersist the activeModelId when persisted selection is already valid', async () => {
+    const sessionGet = vi.fn().mockResolvedValue({
+      id: 'session-1',
+      spaceId: 'space-1',
+      label: 'Chat',
+      createdAt: '2026-03-06T00:00:00.000Z',
+      activeModelId: 'gpt-5.3-codex'
+    })
+    const sessionSetActiveModel = vi.fn().mockResolvedValue({})
+    ;(window as typeof window & { kata?: unknown }).kata = {
+      sessionGet,
+      modelList: vi.fn().mockResolvedValue([
+        {
+          provider: 'openai-codex',
+          modelId: 'gpt-5.3-codex',
+          name: 'GPT-5.3 Codex',
+          authStatus: 'oauth'
+        }
+      ]),
+      sessionSetActiveModel
+    }
+
+    const { useSessionModelSelection } = await import(
+      '../../../../src/renderer/hooks/useSessionModelSelection'
+    )
+    renderHook(() => useSessionModelSelection('session-1'))
+
+    await waitFor(() => {
+      expect(sessionGet).toHaveBeenCalledWith('session-1')
+    })
+
+    expect(sessionSetActiveModel).not.toHaveBeenCalled()
+  })
+})

--- a/app/tests/unit/renderer/hooks/useSessionModelSelection.test.ts
+++ b/app/tests/unit/renderer/hooks/useSessionModelSelection.test.ts
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from '@testing-library/react'
+import { act, renderHook, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 describe('useSessionModelSelection', () => {
@@ -9,6 +9,17 @@ describe('useSessionModelSelection', () => {
   afterEach(() => {
     delete (window as typeof window & { kata?: unknown }).kata
   })
+
+  function createDeferred<T>() {
+    let resolve!: (value: T) => void
+    let reject!: (reason?: unknown) => void
+    const promise = new Promise<T>((innerResolve, innerReject) => {
+      resolve = innerResolve
+      reject = innerReject
+    })
+
+    return { promise, resolve, reject }
+  }
 
   it('loads model list plus session activeModelId and exposes the resolved model', async () => {
     ;(window as typeof window & { kata?: unknown }).kata = {
@@ -112,5 +123,163 @@ describe('useSessionModelSelection', () => {
     })
 
     expect(sessionSetActiveModel).not.toHaveBeenCalled()
+  })
+
+  it('persists a user-selected model through setCurrentModel', async () => {
+    const sessionSetActiveModel = vi.fn().mockResolvedValue({})
+    ;(window as typeof window & { kata?: unknown }).kata = {
+      sessionGet: vi.fn().mockResolvedValue({
+        id: 'session-1',
+        spaceId: 'space-1',
+        label: 'Chat',
+        createdAt: '2026-03-06T00:00:00.000Z',
+        activeModelId: 'gpt-5.3-codex'
+      }),
+      modelList: vi.fn().mockResolvedValue([
+        {
+          provider: 'openai-codex',
+          modelId: 'gpt-5.3-codex',
+          name: 'GPT-5.3 Codex',
+          authStatus: 'oauth'
+        },
+        {
+          provider: 'openai',
+          modelId: 'gpt-4.1-2025-04-14',
+          name: 'GPT-4.1',
+          authStatus: 'oauth'
+        }
+      ]),
+      sessionSetActiveModel
+    }
+
+    const { useSessionModelSelection } = await import(
+      '../../../../src/renderer/hooks/useSessionModelSelection'
+    )
+    const { result } = renderHook(() => useSessionModelSelection('session-1'))
+
+    await waitFor(() => {
+      expect(result.current.isHydrated).toBe(true)
+    })
+
+    await act(async () => {
+      await result.current.setCurrentModel({
+        provider: 'openai',
+        modelId: 'gpt-4.1-2025-04-14',
+        name: 'GPT-4.1',
+        authStatus: 'oauth'
+      })
+    })
+
+    expect(result.current.currentModel?.modelId).toBe('gpt-4.1-2025-04-14')
+    expect(sessionSetActiveModel).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      activeModelId: 'gpt-4.1-2025-04-14'
+    })
+  })
+
+  it('falls back to the emergency model and hydrates when loading fails', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    ;(window as typeof window & { kata?: unknown }).kata = {
+      sessionGet: vi.fn().mockRejectedValue(new Error('load failed')),
+      modelList: vi.fn().mockResolvedValue([]),
+      sessionSetActiveModel: vi.fn()
+    }
+
+    const { useSessionModelSelection } = await import(
+      '../../../../src/renderer/hooks/useSessionModelSelection'
+    )
+    const { result } = renderHook(() => useSessionModelSelection('session-1'))
+
+    await waitFor(() => {
+      expect(result.current.isHydrated).toBe(true)
+    })
+
+    expect(result.current.currentModel?.modelId).toBe('gpt-5.3-codex')
+    expect(result.current.models).toEqual([])
+    expect(result.current.session).toBeNull()
+    expect(consoleError).toHaveBeenCalledWith(
+      '[useSessionModelSelection] Failed to load model selection:',
+      expect.any(Error)
+    )
+
+    consoleError.mockRestore()
+  })
+
+  it('does not update state after unmount when an in-flight load resolves', async () => {
+    const sessionDeferred = createDeferred<{
+      id: string
+      spaceId: string
+      label: string
+      createdAt: string
+      activeModelId: string
+    }>()
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const sessionSetActiveModel = vi.fn().mockResolvedValue({})
+    ;(window as typeof window & { kata?: unknown }).kata = {
+      sessionGet: vi.fn().mockReturnValue(sessionDeferred.promise),
+      modelList: vi.fn().mockResolvedValue([
+        {
+          provider: 'openai-codex',
+          modelId: 'gpt-5.3-codex',
+          name: 'GPT-5.3 Codex',
+          authStatus: 'oauth'
+        }
+      ]),
+      sessionSetActiveModel
+    }
+
+    const { useSessionModelSelection } = await import(
+      '../../../../src/renderer/hooks/useSessionModelSelection'
+    )
+    const { result, unmount } = renderHook(() => useSessionModelSelection('session-1'))
+
+    unmount()
+
+    await act(async () => {
+      sessionDeferred.resolve({
+        id: 'session-1',
+        spaceId: 'space-1',
+        label: 'Chat',
+        createdAt: '2026-03-06T00:00:00.000Z',
+        activeModelId: 'gpt-5.3-codex'
+      })
+      await Promise.resolve()
+    })
+
+    expect(result.current.currentModel).toBeNull()
+    expect(sessionSetActiveModel).not.toHaveBeenCalled()
+    expect(consoleError).not.toHaveBeenCalled()
+
+    consoleError.mockRestore()
+  })
+
+  it('does not update state after unmount when an in-flight load rejects', async () => {
+    const sessionDeferred = createDeferred<never>()
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    ;(window as typeof window & { kata?: unknown }).kata = {
+      sessionGet: vi.fn().mockReturnValue(sessionDeferred.promise),
+      modelList: vi.fn().mockResolvedValue([]),
+      sessionSetActiveModel: vi.fn()
+    }
+
+    const { useSessionModelSelection } = await import(
+      '../../../../src/renderer/hooks/useSessionModelSelection'
+    )
+    const { result, unmount } = renderHook(() => useSessionModelSelection('session-1'))
+
+    unmount()
+
+    await act(async () => {
+      sessionDeferred.reject(new Error('cancelled load'))
+      await Promise.resolve()
+    })
+
+    expect(result.current.currentModel).toBeNull()
+    expect(consoleError).toHaveBeenCalledWith(
+      '[useSessionModelSelection] Failed to load model selection:',
+      expect.any(Error)
+    )
+
+    consoleError.mockRestore()
   })
 })

--- a/app/tests/unit/renderer/hooks/useSessionModelSelection.test.ts
+++ b/app/tests/unit/renderer/hooks/useSessionModelSelection.test.ts
@@ -282,4 +282,99 @@ describe('useSessionModelSelection', () => {
 
     consoleError.mockRestore()
   })
+
+  it('logs reconciliation write failure without wiping hydration state', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    ;(window as typeof window & { kata?: unknown }).kata = {
+      sessionGet: vi.fn().mockResolvedValue({
+        id: 'session-1',
+        spaceId: 'space-1',
+        label: 'Chat',
+        createdAt: '2026-03-06T00:00:00.000Z',
+        activeModelId: 'missing-model'
+      }),
+      modelList: vi.fn().mockResolvedValue([
+        {
+          provider: 'openai-codex',
+          modelId: 'gpt-5.3-codex',
+          name: 'GPT-5.3 Codex',
+          authStatus: 'oauth'
+        }
+      ]),
+      sessionSetActiveModel: vi.fn().mockRejectedValue(new Error('write failed'))
+    }
+
+    const { useSessionModelSelection } = await import(
+      '../../../../src/renderer/hooks/useSessionModelSelection'
+    )
+    const { result } = renderHook(() => useSessionModelSelection('session-1'))
+
+    await waitFor(() => {
+      expect(consoleError).toHaveBeenCalledWith(
+        '[useSessionModelSelection] Failed to persist reconciled model selection:',
+        expect.any(Error)
+      )
+    })
+
+    expect(result.current.isHydrated).toBe(true)
+    expect(result.current.currentModel?.modelId).toBe('gpt-5.3-codex')
+    expect(result.current.models).toHaveLength(1)
+
+    consoleError.mockRestore()
+  })
+
+  it('rolls back optimistic model switch when persistence fails', async () => {
+    const persistenceError = new Error('persistence failed')
+    const sessionSetActiveModel = vi.fn().mockRejectedValue(persistenceError)
+    ;(window as typeof window & { kata?: unknown }).kata = {
+      sessionGet: vi.fn().mockResolvedValue({
+        id: 'session-1',
+        spaceId: 'space-1',
+        label: 'Chat',
+        createdAt: '2026-03-06T00:00:00.000Z',
+        activeModelId: 'gpt-5.3-codex'
+      }),
+      modelList: vi.fn().mockResolvedValue([
+        {
+          provider: 'openai-codex',
+          modelId: 'gpt-5.3-codex',
+          name: 'GPT-5.3 Codex',
+          authStatus: 'oauth'
+        },
+        {
+          provider: 'openai',
+          modelId: 'gpt-4.1-2025-04-14',
+          name: 'GPT-4.1',
+          authStatus: 'oauth'
+        }
+      ]),
+      sessionSetActiveModel
+    }
+
+    const { useSessionModelSelection } = await import(
+      '../../../../src/renderer/hooks/useSessionModelSelection'
+    )
+    const { result } = renderHook(() => useSessionModelSelection('session-1'))
+
+    await waitFor(() => {
+      expect(result.current.isHydrated).toBe(true)
+    })
+
+    expect(result.current.currentModel?.modelId).toBe('gpt-5.3-codex')
+
+    await act(async () => {
+      await result.current.setCurrentModel({
+        provider: 'openai',
+        modelId: 'gpt-4.1-2025-04-14',
+        name: 'GPT-4.1',
+        authStatus: 'oauth'
+      }).catch(() => {})
+    })
+
+    expect(sessionSetActiveModel).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      activeModelId: 'gpt-4.1-2025-04-14'
+    })
+    expect(result.current.currentModel?.modelId).toBe('gpt-5.3-codex')
+  })
 })


### PR DESCRIPTION
## Summary
- add session active-model IPC and preload bridge support so the renderer can persist `activeModelId`
- wire the center composer model selector to `model:list`, session state hydration, and submit/retry routing
- add regression coverage for hydration gating, fallback selection, IPC validation, and E2E runnable-model normalization

## Test Plan
- [x] `npm test`
- [x] `npm run test:coverage`
- [x] `npm run test:e2e`
- [x] Live Electron UAT for selector visibility, persistence, and retry routing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now select and persist active models for individual sessions.
  * Added model selector component to the chat interface for streamlined model switching.
  * Improved model state management to ensure proper model selection across sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires the center composer model selector end-to-end: it adds `session:get` and `session:setActiveModel` IPC channels (main + preload bridge), a new `useSessionModelSelection` hook that hydrates from both `modelList` and `sessionGet` in parallel, and threads the resolved `ModelInfo` through `submitPrompt`/`retry` in `useIpcSessionConversation`. `ChatPanel` gates submission and decision-card actions on `isModelSelectionReady` to prevent use before hydration completes.

Key finding:
- **Logic bug in `useSessionModelSelection`**: the auto-persist reconciliation call (`sessionSetActiveModel`) is `await`-ed inside the same `.then(async ...)` body as the state-setting calls. If that IPC write rejects, the outer `.catch` fires and incorrectly resets `models`, `session`, and `currentModel` to empty/fallback values even though the initial load succeeded. The reconciliation should run in its own isolated error scope.

Test coverage is comprehensive — hydration gating, fallback selection, stale-load cancellation, and E2E runnable-model normalization are all well covered.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge without addressing the hydration error-propagation bug in useSessionModelSelection.
- One logic bug exists in useSessionModelSelection where a rejected auto-persist IPC call resets all successfully-loaded state to empty/fallback values. A transient persistence failure during hydration will silently degrade the model selector UX. The fix is straightforward (isolate persistence error scope), but the bug must be addressed before merge. The rest of the implementation is solid: IPC channels are well-validated, test coverage is comprehensive, and integration with ChatPanel is correct.
- app/src/renderer/hooks/useSessionModelSelection.ts — move auto-persist reconciliation outside the hydration `.then` chain so persistence failures cannot reset loaded state.

<sub>Last reviewed commit: 6439d46</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->