### PR TITLE
KAT-219: add coordinator markdown parity and streaming-safe rendering

### DIFF
--- a/app/docs/plans/2026-03-06-kat-219-coordinator-chat-markdown-parity-streaming-design.md
+++ b/app/docs/plans/2026-03-06-kat-219-coordinator-chat-markdown-parity-streaming-design.md
@@ -1,0 +1,331 @@
+# KAT-219 Coordinator Chat Markdown Parity + Streaming-Safe Output Design
+
+**Issue:** KAT-219  
+**Linear URL:** https://linear.app/kata-sh/issue/KAT-219/027-coordinator-chat-markdown-rendering-parity-streaming-safe-output  
+**Parent epic:** KAT-163 Post-Slice A - Coordinator Session Parity (Spec 02)  
+**Branch target:** `feature/kat-219-027-coordinator-chat-markdown-rendering-parity-streaming`  
+**Specs:** `_plans/design/specs/02-coordinator-session.md`  
+**Relevant mocks:** `04-coordinator-session-initial-state.png`, `05-coordinator-session-pasted-context.png`, `06-coordinator-session-spec-context-reading.png`, `07-coordinator-session-spec-analyzing.png`
+
+## Scope and Outcome
+
+Deliver the final-fidelity markdown rendering layer for the center coordinator conversation so supported markdown elements render predictably during both settled and streaming states.
+
+Required outcome:
+
+- Assistant output in the center panel renders supported markdown instead of degrading to plain text.
+- Supported parity-critical markdown matches Spec 02 expectations: headings, ordered lists, unordered lists, inline code, fenced code blocks, blockquotes, and GFM task/checklist text.
+- Streaming updates remain readable while `message_updated` events are arriving and stabilize cleanly when the final `message_appended` event lands.
+- Unit/component coverage proves renderer behavior for both completed and partial markdown.
+
+Out of scope:
+
+- Rich markdown authoring for user prompts.
+- Runtime-loaded markdown plugins or network-dependent renderers.
+- Ownership of pasted-content badge behavior, agent/context chips, or right-panel workflow content.
+
+## Context Loaded
+
+Sources reviewed for this design:
+
+- Linear issue `KAT-219`, parent epic `KAT-163`, and the fidelity-classification comments attached to the ticket.
+- Linear documents:
+  - `Execution Model: UI Baseline then Parallel Functional Vertical Slices`
+  - `Desktop App Linear Workflow Contract`
+- Local design references:
+  - `AGENTS.md`
+  - `_plans/design/specs/README.md`
+  - `_plans/design/specs/02-coordinator-session.md`
+  - `_plans/design/mocks/README.md`
+- Existing related design docs:
+  - `docs/plans/2026-03-05-kat-214-shared-conversation-ui-primitives-design.md`
+  - `docs/plans/2026-03-06-kat-171-conversation-message-primitives-coordinator-status-design.md`
+  - `docs/plans/2026-03-02-ui-ticket-fidelity-contract-ui-center-mapping.md`
+- Current implementation:
+  - `src/renderer/components/shared/MarkdownRenderer.tsx`
+  - `src/renderer/components/center/primitives/ConversationMessage.tsx`
+  - `src/renderer/components/center/primitives/ConversationMessageCard.tsx`
+  - `src/renderer/components/center/MessageBubble.tsx`
+  - `src/renderer/components/center/ChatPanel.tsx`
+  - `src/renderer/hooks/useIpcSessionConversation.ts`
+  - `src/main/agent-runner.ts`
+- Existing tests:
+  - `tests/unit/renderer/shared/MarkdownRenderer.test.tsx`
+  - `tests/unit/renderer/center/MessageBubble.test.tsx`
+  - `tests/unit/renderer/center/primitives/ConversationMessage.test.tsx`
+  - `tests/unit/renderer/center/sessionConversationState.test.ts`
+  - `tests/unit/main/agent-runner.test.ts`
+
+## Clarifications and Assumptions
+
+- User-authored messages remain in the existing plain/card treatment from mocks 04-07. Markdown parity in this ticket applies to assistant/coordinator output, not prompt authoring UX.
+- Existing shared conversation primitives from KAT-214 and KAT-171 remain the contract seam. KAT-219 should extend the renderer behavior, not replace the center-panel composition model.
+- The live streaming path in the current code uses `message_updated` events from `src/main/agent-runner.ts`, not the older `RUN_STREAM_UPDATED` reducer event as the primary runtime path.
+- Final evidence for this ticket will require screenshots against markdown-heavy coordinator states; this design only defines how to achieve that parity.
+
+## Problem Statement
+
+The current renderer stack is close but not yet Spec-02-safe:
+
+- `MarkdownRenderer` already handles headings, basic lists, fenced code, and inline code through `react-markdown` + `remark-gfm`, but it does not define explicit rendering for blockquotes or GFM checklists and does not tune spacing/semantics for streaming partial documents.
+- `ConversationMessage` renders user rows as plain text and assistant rows through `MarkdownRenderer`, which is the right composition boundary, but the markdown contract is too minimal for the fidelity bar KAT-219 owns.
+- `useIpcSessionConversation` replaces the active assistant message on each `message_updated` event. That keeps message identity stable, but the renderer currently has no stream-aware normalization layer to preserve readable line breaks and incomplete fenced blocks while chunks are still arriving.
+- Existing tests prove base markdown rendering and stream event delivery, but they do not yet lock the specific failure modes this ticket cares about: partial fences, partial blockquotes, progressive checklist rendering, and stability between stream and final append.
+
+## Approaches Considered
+
+### Approach 1 (Recommended): Extend the shared markdown renderer and add a stream-normalization seam before render
+
+Keep `ConversationMessage` and `MessageBubble` unchanged as the composition boundary. Improve `MarkdownRenderer` to cover the missing Spec 02 elements and introduce a tiny stream-safe preprocessor for assistant content before passing it to `react-markdown`.
+
+Pros:
+
+- Smallest surface area and lowest merge risk.
+- Preserves the enabler work already landed in KAT-214 and KAT-171.
+- Centralizes markdown behavior so right-panel and future conversation surfaces can reuse it later if desired.
+- Makes streaming and settled rendering share one rendering path.
+
+Cons:
+
+- Requires careful normalization rules so stream-safe fixes do not change completed markdown semantics.
+
+### Approach 2: Add a separate streaming markdown component for center-panel assistant messages
+
+Create a `StreamingMarkdownRenderer` used only while the run is pending and switch back to the existing renderer once the final message arrives.
+
+Pros:
+
+- Allows aggressive streaming-specific formatting without touching settled rendering.
+
+Cons:
+
+- Two render paths for the same content invites parity drift.
+- Higher maintenance and higher risk of visual jumps when swapping renderers.
+
+### Approach 3: Keep the current renderer and patch line breaks in the reducer/runtime path only
+
+Leave markdown rendering mostly unchanged and normalize content strings in `agent-runner` or `useIpcSessionConversation`.
+
+Pros:
+
+- Fastest localized patch.
+
+Cons:
+
+- Couples presentation fixes to transport/runtime code.
+- Still leaves missing markdown element styling unresolved.
+- Harder to reuse and harder to test as a rendering contract.
+
+## Recommendation
+
+Proceed with **Approach 1**.
+
+KAT-219 is a final-fidelity UI ticket, so the cleanest solution is one canonical markdown rendering contract for assistant messages with a narrow pre-render normalization step for streaming safety. That keeps runtime delivery simple and makes the fidelity bar testable at the renderer layer.
+
+## Proposed Design
+
+## 1) Ownership Boundary
+
+KAT-219 should own:
+
+- assistant/coordinator markdown rendering in the center conversation panel
+- stream-safe normalization for partial assistant markdown
+- center-panel tests that prove the rendering contract
+- screenshot/evidence targets for markdown-heavy coordinator output
+
+KAT-219 should not own:
+
+- user prompt markdown authoring or rich-text editing
+- pasted-content badge interaction
+- context chip population rules
+- right-panel markdown/spec parsing
+- model selector or input bar behavior
+
+## 2) Rendering Contract
+
+Assistant/coordinator messages continue to flow through:
+
+`MessageBubble` -> `ConversationMessageCard` -> `ConversationMessage` -> `MarkdownRenderer`
+
+User messages continue to render as:
+
+- plain text
+- `whitespace-pre-wrap`
+- existing card shell and dismiss/footer affordances
+
+Assistant/coordinator messages must support these rendered elements:
+
+- `h1` through `h6`
+- unordered lists
+- ordered lists
+- inline code
+- fenced code blocks, including language-tagged fences
+- blockquotes
+- GFM task/checklist items rendered as readable checklist rows
+
+The renderer must remain deterministic:
+
+- no role-specific fallback to raw `<pre>` or plain text for supported elements
+- stable DOM structure for the same markdown input
+- no alternate streaming-only component tree
+
+## 3) Stream-Safe Markdown Normalization
+
+Introduce a pure helper in the shared markdown layer, for example:
+
+```ts
+type MarkdownRenderMode = 'settled' | 'streaming'
+
+function normalizeMarkdownForRender(content: string, mode: MarkdownRenderMode): string
+```
+
+Rules for `streaming` mode:
+
+- Preserve incoming newlines exactly; never collapse line breaks into a single paragraph.
+- If a fenced code block is opened but not yet closed, synthetically close it for render only so the remainder of the stream stays in a code block instead of corrupting all following layout.
+- If a blockquote line is mid-stream, preserve its prefix and paragraph boundaries rather than flattening it into surrounding text.
+- Leave incomplete emphasis/code markers untouched unless normalization is required to avoid catastrophic layout corruption.
+
+Rules for `settled` mode:
+
+- Return the content unchanged.
+- The final `message_appended` event becomes the canonical persisted/rendered string.
+
+This normalization must be presentation-only. It must not mutate stored run content or alter the message payload in the runtime adapter.
+
+## 4) Markdown Component Coverage
+
+`MarkdownRenderer` should explicitly define components for the currently missing fidelity-critical nodes:
+
+- `blockquote`
+  - muted left border
+  - inset padding
+  - readable foreground contrast
+- task/checklist list items
+  - render GFM checkboxes as disabled visual checkboxes or equivalent static markers
+  - preserve checked vs unchecked state
+- list item spacing
+  - nested paragraph/list spacing should not collapse awkwardly during streaming updates
+- fenced code blocks
+  - keep overflow containment and monospace styling
+  - ensure unterminated fences still render as one code block in streaming mode
+
+The goal is not syntax highlighting or rich plugins. The goal is stable structural rendering with the tokens already used by the app shell.
+
+## 5) Center-Panel Integration
+
+Add the mode seam at the assistant message render boundary, not in the reducer:
+
+- `ConversationMessage` detects assistant/coordinator role.
+- When the conversation run is pending and the message is the currently streaming assistant message, render the normalized `streaming` form.
+- All other assistant messages render in `settled` mode.
+
+This can be passed as a small prop from `ChatPanel` or `MessageBubble`, for example `renderMode="streaming" | "settled"`.
+
+Why here:
+
+- `ChatPanel` already knows the current run state.
+- `MessageBubble` already encapsulates user vs assistant composition.
+- The runtime adapter and reducer should stay focused on event/state correctness, not visual repair.
+
+## 6) Streaming Stability Rules
+
+The center panel must satisfy these UX invariants during a live run:
+
+- streamed assistant content keeps a stable message id throughout `message_updated` events
+- prior rendered content is replaced in place, not duplicated
+- line breaks remain readable across updates
+- partial markdown may be visually incomplete, but it must not cause surrounding layout corruption
+- when the final `message_appended` event arrives, the visual result converges to the exact settled markdown output with no extra wrapper swap or jarring structural reset
+
+This design intentionally accepts that partially streamed markdown may not be semantically perfect at every intermediate character. The bar is readability and convergence, not speculative completion of every incomplete token type.
+
+## 7) Testing Strategy (TDD)
+
+### Renderer unit tests
+
+Add/extend tests in `tests/unit/renderer/shared/MarkdownRenderer.test.tsx` for:
+
+- blockquote rendering
+- GFM task/checklist rendering
+- ordered + unordered list spacing around paragraphs
+- streaming normalization for unterminated fenced code blocks
+- streaming normalization preserving multi-line blockquotes
+
+### Center primitive tests
+
+Add/extend tests in:
+
+- `tests/unit/renderer/center/primitives/ConversationMessage.test.tsx`
+- `tests/unit/renderer/center/MessageBubble.test.tsx`
+- `tests/unit/renderer/center/ChatPanel.test.tsx`
+
+Cover:
+
+- assistant messages render supported markdown elements through the real center-panel path
+- user messages remain plain text even when they contain markdown markers
+- pending/streaming assistant message uses streaming-safe render mode
+- settled assistant message uses canonical render mode
+- final append matches the expected final markdown after prior stream updates
+
+### State/runtime tests
+
+Keep the existing reducer/runtime guarantees and extend only where needed:
+
+- `tests/unit/main/agent-runner.test.ts` already proves `message_updated` + `message_appended`
+- `tests/unit/renderer/center/sessionConversationState.test.ts` should keep proving in-place replacement and no duplicate assistant messages
+
+## 8) Evidence Plan
+
+To satisfy the workflow contract for a final-fidelity ticket, completion evidence must include:
+
+- passing unit/component tests for the renderer and stream transition cases
+- screenshot evidence against coordinator-session mock states using markdown-heavy assistant output
+- explicit confirmation that supported markdown elements no longer fall back to plain text
+
+Suggested screenshot targets:
+
+- a markdown-heavy coordinator response while idle/stopped
+- the same response during an active stream with a partial fenced block or checklist
+
+## 9) Risks and Mitigations
+
+- Risk: stream normalization changes final markdown semantics.
+  - Mitigation: normalization is mode-gated and a no-op in `settled` mode.
+
+- Risk: checklist rendering depends on `remark-gfm` output details.
+  - Mitigation: test the actual rendered DOM for checked/unchecked states rather than assuming a specific internal AST shape.
+
+- Risk: adding render-mode props causes primitive API churn.
+  - Mitigation: keep the new prop optional and default to `settled`.
+
+- Risk: blockquote/code styles drift from the rest of the shell.
+  - Mitigation: reuse existing `border`, `bg-card`, `text-muted-foreground`, and mono token patterns already present in `MarkdownRenderer` and `ConversationMessageCard`.
+
+## Approval Summary
+
+Approved scope decision recorded during brainstorming:
+
+- user messages stay plain/card-like
+- assistant/coordinator output gets markdown parity
+- streaming safety is handled at render time, not by mutating runtime payloads
+
+## Next Step
+
+Create the implementation plan for KAT-219 with a test-first sequence centered on:
+
+1. markdown renderer contract tests
+2. stream normalization helper tests
+3. center-panel integration tests
+4. implementation updates in shared renderer and center message composition
+
+## Verification Commands
+
+- `npx vitest run tests/unit/renderer/shared/normalize-markdown-for-render.test.ts tests/unit/renderer/shared/MarkdownRenderer.test.tsx tests/unit/renderer/center/primitives/ConversationMessage.test.tsx tests/unit/renderer/center/MessageBubble.test.tsx tests/unit/renderer/center/ChatPanel.test.tsx`
+- `npm test`
+- `npm run dev -- --remote-debugging-port=9222`
+
+## Screenshot Evidence Targets
+
+- Pending coordinator response with markdown blockquote + checklist
+- Final/stopped coordinator response with heading + fenced code block

--- a/app/docs/plans/2026-03-06-kat-219-coordinator-chat-markdown-parity-streaming-implementation-plan.md
+++ b/app/docs/plans/2026-03-06-kat-219-coordinator-chat-markdown-parity-streaming-implementation-plan.md
@@ -1,0 +1,584 @@
+# KAT-219 Coordinator Chat Markdown Parity + Streaming-Safe Output Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make the center coordinator conversation render assistant markdown with Spec 02 parity while keeping streaming updates readable and stable until the final assistant message lands.
+
+**Architecture:** Keep the existing center-panel composition boundary (`ChatPanel` -> `MessageBubble` -> `ConversationMessage` -> `MarkdownRenderer`) and improve the shared markdown renderer instead of adding a second streaming-specific renderer. Add a tiny render-time normalization helper for partial assistant markdown, thread an explicit render mode only through assistant message paths, and lock behavior with targeted renderer and panel tests.
+
+**Tech Stack:** React 19, TypeScript, `react-markdown`, `remark-gfm`, Vitest, Testing Library, Electron renderer center-panel primitives.
+
+---
+
+**Execution Rules:**
+- Apply `@test-driven-development` on every task: red, then green, then refactor.
+- Apply `@verification-before-completion` before claiming ticket completion.
+- Keep user-authored messages plain/card-like. This ticket does not add markdown authoring to user rows.
+- Keep the runtime event pipeline (`src/main/agent-runner.ts`, `src/renderer/hooks/useIpcSessionConversation.ts`) focused on event delivery, not markdown repair.
+- Keep commits small: one commit per task.
+
+### Task 1: Add a render-time markdown normalization helper for streaming assistant content
+
+**Files:**
+- Create: `src/renderer/components/shared/normalize-markdown-for-render.ts`
+- Test: `tests/unit/renderer/shared/normalize-markdown-for-render.test.ts`
+
+**Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it } from 'vitest'
+
+import {
+  normalizeMarkdownForRender
+} from '../../../../src/renderer/components/shared/normalize-markdown-for-render'
+
+describe('normalizeMarkdownForRender', () => {
+  it('returns settled markdown unchanged', () => {
+    const content = ['## Summary', '', '> stable quote', '', '```ts', 'const ready = true', '```'].join('\n')
+
+    expect(normalizeMarkdownForRender(content, 'settled')).toBe(content)
+  })
+
+  it('closes an unterminated fenced block only for streaming mode', () => {
+    const content = ['## Summary', '', '```ts', 'const ready = true'].join('\n')
+
+    expect(normalizeMarkdownForRender(content, 'streaming')).toBe(
+      ['## Summary', '', '```ts', 'const ready = true', '```'].join('\n')
+    )
+  })
+
+  it('preserves blockquote line breaks while streaming', () => {
+    const content = ['> first line', '> second line'].join('\n')
+
+    expect(normalizeMarkdownForRender(content, 'streaming')).toBe(content)
+  })
+
+  it('does not append a closing fence when the markdown is already balanced', () => {
+    const content = ['```md', '- item', '```'].join('\n')
+
+    expect(normalizeMarkdownForRender(content, 'streaming')).toBe(content)
+  })
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/renderer/shared/normalize-markdown-for-render.test.ts`
+
+Expected: FAIL because `normalize-markdown-for-render.ts` does not exist yet.
+
+**Step 3: Write the minimal implementation**
+
+```ts
+export type MarkdownRenderMode = 'settled' | 'streaming'
+
+const FENCE_PATTERN = /^```/gm
+
+export function normalizeMarkdownForRender(
+  content: string,
+  mode: MarkdownRenderMode
+): string {
+  if (mode === 'settled') {
+    return content
+  }
+
+  const fenceCount = content.match(FENCE_PATTERN)?.length ?? 0
+  if (fenceCount % 2 === 1) {
+    return `${content}\n\`\`\``
+  }
+
+  return content
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/renderer/shared/normalize-markdown-for-render.test.ts`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/renderer/components/shared/normalize-markdown-for-render.ts tests/unit/renderer/shared/normalize-markdown-for-render.test.ts
+git commit -m "test(renderer): add streaming markdown normalization contract"
+```
+
+### Task 2: Extend the shared markdown renderer for blockquotes, GFM checklist items, and render mode support
+
+**Files:**
+- Modify: `src/renderer/components/shared/MarkdownRenderer.tsx`
+- Modify: `tests/unit/renderer/shared/MarkdownRenderer.test.tsx`
+- Modify: `package.json`
+
+**Step 1: Write the failing test**
+
+Append tests like these to `tests/unit/renderer/shared/MarkdownRenderer.test.tsx`:
+
+```tsx
+it('renders blockquotes with readable structure', () => {
+  render(
+    <MarkdownRenderer
+      content={['> Review the current spec draft.', '>', '> Keep the layout stable.'].join('\n')}
+    />
+  )
+
+  const quote = screen.getByText('Review the current spec draft.').closest('blockquote')
+  expect(quote).toBeTruthy()
+  expect(quote?.className).toContain('border-l')
+})
+
+it('renders GFM checklist items as disabled checkboxes', () => {
+  render(
+    <MarkdownRenderer
+      content={['- [x] Capture screenshot evidence', '- [ ] Verify streaming readability'].join('\n')}
+    />
+  )
+
+  const checkboxes = screen.getAllByRole('checkbox') as HTMLInputElement[]
+  expect(checkboxes).toHaveLength(2)
+  expect(checkboxes[0]?.checked).toBe(true)
+  expect(checkboxes[1]?.checked).toBe(false)
+  expect(checkboxes[0]?.disabled).toBe(true)
+  expect(checkboxes[1]?.disabled).toBe(true)
+})
+
+it('normalizes unterminated fences when renderMode is streaming', () => {
+  render(
+    <MarkdownRenderer
+      renderMode="streaming"
+      content={['```ts', 'const ready = true'].join('\n')}
+    />
+  )
+
+  expect(
+    screen.getByText((_, node) => node?.tagName === 'CODE' && node.textContent?.includes('const ready = true') === true)
+  ).toBeTruthy()
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/renderer/shared/MarkdownRenderer.test.tsx`
+
+Expected: FAIL because `MarkdownRenderer` does not yet accept `renderMode` and does not define explicit blockquote/checkbox rendering.
+
+**Step 3: Write the minimal implementation**
+
+Update `src/renderer/components/shared/MarkdownRenderer.tsx` to:
+
+```tsx
+import type { Components } from 'react-markdown'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+
+import { cn } from '../../lib/cn'
+import {
+  normalizeMarkdownForRender,
+  type MarkdownRenderMode
+} from './normalize-markdown-for-render'
+
+type MarkdownRendererProps = {
+  content: string
+  className?: string
+  renderMode?: MarkdownRenderMode
+}
+
+const MD_COMPONENTS: Components = {
+  blockquote: ({ children }) => (
+    <blockquote className="border-l-2 border-border/80 pl-4 text-foreground/90">
+      {children}
+    </blockquote>
+  ),
+  ul: ({ children }) => <ul className="list-inside list-disc space-y-1">{children}</ul>,
+  ol: ({ children }) => <ol className="list-inside list-decimal space-y-1">{children}</ol>,
+  li: ({ children }) => <li className="leading-6 marker:text-muted-foreground">{children}</li>,
+  input: ({ type, checked }) => {
+    if (type !== 'checkbox') {
+      return <input type={type} checked={checked} readOnly />
+    }
+
+    return (
+      <input
+        type="checkbox"
+        checked={checked}
+        disabled
+        readOnly
+        aria-label={checked ? 'Completed task' : 'Incomplete task'}
+        className="mr-2 translate-y-[1px]"
+      />
+    )
+  }
+}
+
+export function MarkdownRenderer({
+  content,
+  className,
+  renderMode = 'settled'
+}: MarkdownRendererProps) {
+  const normalizedContent = normalizeMarkdownForRender(content, renderMode)
+
+  return (
+    <div className={cn('space-y-3 text-sm text-muted-foreground', className)}>
+      <ReactMarkdown remarkPlugins={[remarkGfm]} components={MD_COMPONENTS}>
+        {normalizedContent}
+      </ReactMarkdown>
+    </div>
+  )
+}
+```
+
+If TypeScript complains about `input` props, add the narrowest local type annotation needed rather than weakening the whole file.
+
+**Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/renderer/shared/MarkdownRenderer.test.tsx`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/renderer/components/shared/MarkdownRenderer.tsx tests/unit/renderer/shared/MarkdownRenderer.test.tsx package.json
+git commit -m "feat(renderer): extend shared markdown renderer for coordinator parity"
+```
+
+### Task 3: Thread render mode through center primitives and keep user rows plain
+
+**Files:**
+- Modify: `src/renderer/components/center/primitives/ConversationMessage.tsx`
+- Modify: `src/renderer/components/center/MessageBubble.tsx`
+- Modify: `tests/unit/renderer/center/primitives/ConversationMessage.test.tsx`
+- Modify: `tests/unit/renderer/center/MessageBubble.test.tsx`
+
+**Step 1: Write the failing test**
+
+Add tests like these:
+
+```tsx
+it('keeps user markdown markers as plain text', () => {
+  render(
+    <MessageBubble
+      message={{
+        id: 'user-markdown',
+        role: 'user',
+        content: '## Do not render this as a heading'
+      }}
+    />
+  )
+
+  expect(screen.getByText('## Do not render this as a heading')).toBeTruthy()
+  expect(screen.queryByRole('heading', { name: 'Do not render this as a heading' })).toBeNull()
+})
+
+it('passes streaming render mode to assistant markdown content', () => {
+  render(
+    <ConversationMessage
+      message={{
+        id: 'agent-stream',
+        role: 'agent',
+        content: ['```ts', 'const ready = true'].join('\n')
+      }}
+      renderMode="streaming"
+    />
+  )
+
+  expect(
+    screen.getByText((_, node) => node?.tagName === 'CODE' && node.textContent?.includes('const ready = true') === true)
+  ).toBeTruthy()
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/renderer/center/primitives/ConversationMessage.test.tsx tests/unit/renderer/center/MessageBubble.test.tsx`
+
+Expected: FAIL because `ConversationMessage` does not yet accept `renderMode`.
+
+**Step 3: Write the minimal implementation**
+
+Update `src/renderer/components/center/primitives/ConversationMessage.tsx`:
+
+```tsx
+import type { MarkdownRenderMode } from '../../shared/normalize-markdown-for-render'
+
+type ConversationMessageProps = {
+  message: PrimitiveMessage
+  variant?: PrimitiveMessageVariant
+  agentLabel?: string
+  renderMode?: MarkdownRenderMode
+}
+
+export function ConversationMessage({
+  message,
+  variant = 'default',
+  agentLabel = 'Kata',
+  renderMode = 'settled'
+}: ConversationMessageProps) {
+  const isUser = message.role === 'user'
+  const content = variant === 'collapsed' && message.summary?.trim() ? message.summary : message.content
+
+  return isUser ? (
+    <p className="m-0 whitespace-pre-wrap text-sm leading-6">{content}</p>
+  ) : (
+    <MarkdownRenderer content={content} renderMode={renderMode} />
+  )
+}
+```
+
+Update `src/renderer/components/center/MessageBubble.tsx`:
+
+```tsx
+import type { MarkdownRenderMode } from '../shared/normalize-markdown-for-render'
+
+type MessageBubbleProps = {
+  message: BubbleMessage
+  variant?: 'default' | 'collapsed'
+  renderMode?: MarkdownRenderMode
+  // existing props...
+}
+
+<ConversationMessageCard
+  message={displayMessage}
+  variant={variant}
+  renderMode={primitiveMessage.role === 'user' ? 'settled' : renderMode}
+  // existing props...
+/>
+```
+
+If `ConversationMessageCard` needs a new optional prop, add it there and forward it to `ConversationMessage`. Keep the default value `settled`.
+
+**Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/renderer/center/primitives/ConversationMessage.test.tsx tests/unit/renderer/center/MessageBubble.test.tsx`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/renderer/components/center/primitives/ConversationMessage.tsx src/renderer/components/center/MessageBubble.tsx tests/unit/renderer/center/primitives/ConversationMessage.test.tsx tests/unit/renderer/center/MessageBubble.test.tsx
+git commit -m "feat(renderer): thread markdown render mode through center messages"
+```
+
+### Task 4: Make `ChatPanel` mark only the active assistant message as streaming and prove stream-to-final convergence
+
+**Files:**
+- Modify: `src/renderer/components/center/ChatPanel.tsx`
+- Modify: `tests/unit/renderer/center/ChatPanel.test.tsx`
+
+**Step 1: Write the failing test**
+
+Add tests like these to `tests/unit/renderer/center/ChatPanel.test.tsx`:
+
+```tsx
+it('renders the latest pending assistant message in streaming mode', () => {
+  mockHook.mockReturnValue({
+    state: idleState({
+      runState: 'pending',
+      messages: [
+        { id: 'm1', role: 'user', content: 'Show me progress', createdAt: '2026-03-01T00:00:00Z' },
+        { id: 'm2', role: 'agent', content: ['```ts', 'const ready = true'].join('\n'), createdAt: '2026-03-01T00:00:01Z' }
+      ]
+    }),
+    submitPrompt: vi.fn(),
+    retry: vi.fn()
+  })
+
+  render(<ChatPanel sessionId="sess-1" />)
+
+  expect(screen.getByRole('status', { name: 'Thinking' })).toBeTruthy()
+  expect(
+    screen.getByText((_, node) => node?.tagName === 'CODE' && node.textContent?.includes('const ready = true') === true)
+  ).toBeTruthy()
+})
+
+it('stabilizes the same assistant message when the final append arrives', () => {
+  let currentState = idleState({
+    runState: 'pending',
+    messages: [
+      { id: 'm1', role: 'user', content: 'Show me progress', createdAt: '2026-03-01T00:00:00Z' },
+      { id: 'm2', role: 'agent', content: ['## Summary', '', '```ts', 'const ready = true'].join('\n'), createdAt: '2026-03-01T00:00:01Z' }
+    ]
+  })
+
+  mockHook.mockImplementation(() => ({
+    state: currentState,
+    submitPrompt: vi.fn(),
+    retry: vi.fn()
+  }))
+
+  const { rerender } = render(<ChatPanel sessionId="sess-1" />)
+  expect(document.querySelector('[data-message-id=\"m2\"]')).toBeTruthy()
+
+  currentState = idleState({
+    runState: 'idle',
+    messages: [
+      { id: 'm1', role: 'user', content: 'Show me progress', createdAt: '2026-03-01T00:00:00Z' },
+      { id: 'm2', role: 'agent', content: ['## Summary', '', '```ts', 'const ready = true', '```'].join('\n'), createdAt: '2026-03-01T00:00:01Z' }
+    ]
+  })
+
+  rerender(<ChatPanel sessionId="sess-1" />)
+
+  expect(screen.getByRole('status', { name: 'Stopped' })).toBeTruthy()
+  expect(document.querySelector('[data-message-id=\"m2\"]')).toBeTruthy()
+  expect(screen.getByRole('heading', { name: 'Summary', level: 2 })).toBeTruthy()
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/renderer/center/ChatPanel.test.tsx`
+
+Expected: FAIL because `ChatPanel` does not yet compute or pass the streaming render mode.
+
+**Step 3: Write the minimal implementation**
+
+Update `src/renderer/components/center/ChatPanel.tsx` to compute the active streaming assistant message:
+
+```tsx
+const streamingMessageId = useMemo(() => {
+  if (state.runState !== 'pending') {
+    return null
+  }
+
+  for (let index = visibleMessages.length - 1; index >= 0; index -= 1) {
+    const message = visibleMessages[index]
+    if (message?.role === 'agent') {
+      return message.id
+    }
+  }
+
+  return null
+}, [state.runState, visibleMessages])
+```
+
+Then pass the mode into `MessageBubble`:
+
+```tsx
+<MessageBubble
+  message={message}
+  renderMode={message.role === 'agent' && message.id === streamingMessageId ? 'streaming' : 'settled'}
+  // existing props...
+/>
+```
+
+Do not special-case user rows here beyond the existing role check.
+
+**Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/renderer/center/ChatPanel.test.tsx`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/renderer/components/center/ChatPanel.tsx tests/unit/renderer/center/ChatPanel.test.tsx
+git commit -m "feat(renderer): make coordinator markdown streaming-safe in chat panel"
+```
+
+### Task 5: Run the focused verification suite and prepare screenshot evidence instructions
+
+**Files:**
+- Modify: `docs/plans/2026-03-06-kat-219-coordinator-chat-markdown-parity-streaming-design.md`
+- Modify: `docs/plans/2026-03-06-kat-219-coordinator-chat-markdown-parity-streaming-implementation-plan.md`
+
+**Step 1: Add the exact verification checklist to the plan/design docs**
+
+Append a short checklist like this:
+
+```md
+## Verification Commands
+
+- `npx vitest run tests/unit/renderer/shared/normalize-markdown-for-render.test.ts tests/unit/renderer/shared/MarkdownRenderer.test.tsx tests/unit/renderer/center/primitives/ConversationMessage.test.tsx tests/unit/renderer/center/MessageBubble.test.tsx tests/unit/renderer/center/ChatPanel.test.tsx`
+- `npm test`
+- `npm run dev -- --remote-debugging-port=9222`
+```
+
+```md
+## Screenshot Evidence Targets
+
+- Pending coordinator response with markdown blockquote + checklist
+- Final/stopped coordinator response with heading + fenced code block
+```
+
+**Step 2: Save docs and verify the markdown renders cleanly**
+
+Run: `npx vitest run tests/unit/renderer/shared/normalize-markdown-for-render.test.ts tests/unit/renderer/shared/MarkdownRenderer.test.tsx tests/unit/renderer/center/primitives/ConversationMessage.test.tsx tests/unit/renderer/center/MessageBubble.test.tsx tests/unit/renderer/center/ChatPanel.test.tsx`
+
+Expected: PASS after Tasks 1-4 are complete.
+
+**Step 3: Capture manual evidence**
+
+Run these from `app/`:
+
+```bash
+npm run dev -- --remote-debugging-port=9222
+```
+
+In a second terminal:
+
+```bash
+npx agent-browser close
+npx agent-browser connect 9222
+npx agent-browser tab
+npx agent-browser tab 0
+npx agent-browser snapshot -i
+```
+
+Use a seeded or manually entered assistant response that includes:
+
+```md
+## Summary
+
+> Review the current plan before implementation.
+
+- [x] Renderer contract locked
+- [ ] Screenshot evidence captured
+
+```ts
+const ready = true
+```
+```
+
+Then capture screenshots:
+
+```bash
+npx agent-browser screenshot /tmp/kat-219-streaming-pending.png
+npx agent-browser screenshot /tmp/kat-219-streaming-final.png
+```
+
+**Step 4: Run the broader renderer suite**
+
+Run: `npm test`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add docs/plans/2026-03-06-kat-219-coordinator-chat-markdown-parity-streaming-design.md docs/plans/2026-03-06-kat-219-coordinator-chat-markdown-parity-streaming-implementation-plan.md
+git commit -m "docs(renderer): add verification checklist for KAT-219"
+```
+
+## Final Verification Before Closing KAT-219
+
+- Run `npx vitest run tests/unit/renderer/shared/normalize-markdown-for-render.test.ts tests/unit/renderer/shared/MarkdownRenderer.test.tsx tests/unit/renderer/center/primitives/ConversationMessage.test.tsx tests/unit/renderer/center/MessageBubble.test.tsx tests/unit/renderer/center/ChatPanel.test.tsx`
+- Run `npm test`
+- Confirm user rows still render raw markdown markers as plain text
+- Confirm assistant rows render headings, lists, inline code, fenced code, blockquotes, and checklists
+- Confirm pending assistant output stays readable while streaming and converges cleanly to final output
+- Capture screenshot evidence for the pending and final markdown-heavy coordinator states
+
+## Verification Commands
+
+- `npx vitest run tests/unit/renderer/shared/normalize-markdown-for-render.test.ts tests/unit/renderer/shared/MarkdownRenderer.test.tsx tests/unit/renderer/center/primitives/ConversationMessage.test.tsx tests/unit/renderer/center/MessageBubble.test.tsx tests/unit/renderer/center/ChatPanel.test.tsx`
+- `npm test`
+- `npm run dev -- --remote-debugging-port=9222`
+
+## Screenshot Evidence Targets
+
+- Pending coordinator response with markdown blockquote + checklist
+- Final/stopped coordinator response with heading + fenced code block

--- a/app/src/renderer/components/center/ChatPanel.tsx
+++ b/app/src/renderer/components/center/ChatPanel.tsx
@@ -40,6 +40,20 @@ export function ChatPanel({
     () => state.messages.filter((message) => !dismissedMessageIds.has(message.id)),
     [dismissedMessageIds, state.messages]
   )
+  const streamingMessageId = useMemo(() => {
+    if (state.runState !== 'pending') {
+      return null
+    }
+
+    for (let index = visibleMessages.length - 1; index >= 0; index -= 1) {
+      const message = visibleMessages[index]
+      if (message?.role === 'agent') {
+        return message.id
+      }
+    }
+
+    return null
+  }, [state.runState, visibleMessages])
   const conversationEntries = useMemo(() => buildConversationEntries(visibleMessages), [visibleMessages])
 
   useEffect(() => {
@@ -92,6 +106,7 @@ export function ChatPanel({
                 message={message}
                 activityPhase={state.activityPhase}
                 conversationRunState={state.runState}
+                renderMode={message.role === 'agent' && message.id === streamingMessageId ? 'streaming' : 'settled'}
                 decisionCard={decisionCard}
                 decisionState={decisionState}
                 onDecisionAction={(actionId) => {

--- a/app/src/renderer/components/center/ChatPanel.tsx
+++ b/app/src/renderer/components/center/ChatPanel.tsx
@@ -45,10 +45,9 @@ export function ChatPanel({
       return null
     }
 
-    for (let index = visibleMessages.length - 1; index >= 0; index -= 1) {
-      const message = visibleMessages[index]
-      if (message?.role === 'agent') {
-        return message.id
+    for (let i = visibleMessages.length - 1; i >= 0; i -= 1) {
+      if (visibleMessages[i]?.role === 'agent') {
+        return visibleMessages[i].id
       }
     }
 

--- a/app/src/renderer/components/center/MessageBubble.tsx
+++ b/app/src/renderer/components/center/MessageBubble.tsx
@@ -164,7 +164,7 @@ export function MessageBubble({
       <ConversationMessageCard
         message={displayMessage}
         variant={variant}
-        renderMode={primitiveMessage.role === 'user' ? 'settled' : renderMode}
+        renderMode={renderMode}
         timestampLabel={timestampLabel}
         footer={footerLabel ? <span>{footerLabel}</span> : undefined}
         onDismiss={footerLabel ? () => onDismiss?.(primitiveMessage.id) : undefined}

--- a/app/src/renderer/components/center/MessageBubble.tsx
+++ b/app/src/renderer/components/center/MessageBubble.tsx
@@ -3,6 +3,7 @@ import { LoaderCircle } from 'lucide-react'
 import { type ChatMessage } from '../../types/chat'
 import { type ConversationActivityPhase, type ConversationMessage, type ConversationRunState } from '../../types/session-conversation'
 import { cn } from '../../lib/cn'
+import type { MarkdownRenderMode } from '../shared/normalize-markdown-for-render'
 import { formatRelativeTime } from './format-relative-time'
 import { MessageActionRow } from './MessageActionRow'
 import { stripDecisionActionLines, type DecisionState, type InlineDecisionActionId, type InlineDecisionCard } from './message-decision-parser'
@@ -14,6 +15,7 @@ type BubbleMessage = ChatMessage | ConversationMessage
 type MessageBubbleProps = {
   message: BubbleMessage
   variant?: 'default' | 'collapsed'
+  renderMode?: MarkdownRenderMode
   summary?: string
   activityPhase?: ConversationActivityPhase
   conversationRunState?: ConversationRunState
@@ -39,6 +41,7 @@ function toAgentActivityPhase(content: string): 'thinking' | 'drafting' | null {
 export function MessageBubble({
   message,
   variant = 'default',
+  renderMode = 'settled',
   summary,
   activityPhase,
   conversationRunState,
@@ -161,6 +164,7 @@ export function MessageBubble({
       <ConversationMessageCard
         message={displayMessage}
         variant={variant}
+        renderMode={primitiveMessage.role === 'user' ? 'settled' : renderMode}
         timestampLabel={timestampLabel}
         footer={footerLabel ? <span>{footerLabel}</span> : undefined}
         onDismiss={footerLabel ? () => onDismiss?.(primitiveMessage.id) : undefined}

--- a/app/src/renderer/components/center/primitives/ConversationMessage.tsx
+++ b/app/src/renderer/components/center/primitives/ConversationMessage.tsx
@@ -1,17 +1,20 @@
 import { cn } from '../../../lib/cn'
 import { MarkdownRenderer } from '../../shared/MarkdownRenderer'
+import type { MarkdownRenderMode } from '../../shared/normalize-markdown-for-render'
 import type { PrimitiveMessage, PrimitiveMessageVariant } from './types'
 
 type ConversationMessageProps = {
   message: PrimitiveMessage
   variant?: PrimitiveMessageVariant
   agentLabel?: string
+  renderMode?: MarkdownRenderMode
 }
 
 export function ConversationMessage({
   message,
   variant = 'default',
-  agentLabel = 'Kata'
+  agentLabel = 'Kata',
+  renderMode = 'settled'
 }: ConversationMessageProps) {
   const isUser = message.role === 'user'
   const isCollapsed = variant === 'collapsed' && Boolean(message.summary?.trim())
@@ -31,7 +34,7 @@ export function ConversationMessage({
         {isUser ? (
           <p className="m-0 whitespace-pre-wrap text-sm leading-6">{content}</p>
         ) : (
-          <MarkdownRenderer content={content} />
+          <MarkdownRenderer content={content} renderMode={renderMode} />
         )}
       </div>
     </div>

--- a/app/src/renderer/components/center/primitives/ConversationMessageCard.tsx
+++ b/app/src/renderer/components/center/primitives/ConversationMessageCard.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react'
 import { X } from 'lucide-react'
 
 import { ConversationMessage } from './ConversationMessage'
+import type { MarkdownRenderMode } from '../../shared/normalize-markdown-for-render'
 import type { PrimitiveMessage, PrimitiveMessageVariant } from './types'
 
 type ConversationMessageCardProps = {
@@ -9,6 +10,7 @@ type ConversationMessageCardProps = {
   variant?: PrimitiveMessageVariant
   timestampLabel?: string
   agentLabel?: string
+  renderMode?: MarkdownRenderMode
   onDismiss?: () => void
   metadata?: ReactNode
   footer?: ReactNode
@@ -19,6 +21,7 @@ export function ConversationMessageCard({
   variant = 'default',
   timestampLabel,
   agentLabel,
+  renderMode = 'settled',
   onDismiss,
   metadata,
   footer
@@ -42,6 +45,7 @@ export function ConversationMessageCard({
             message={message}
             variant={variant}
             agentLabel={agentLabel}
+            renderMode={renderMode}
           />
           {metadata ? (
             <div className="text-xs text-muted-foreground">{metadata}</div>

--- a/app/src/renderer/components/shared/MarkdownRenderer.tsx
+++ b/app/src/renderer/components/shared/MarkdownRenderer.tsx
@@ -3,10 +3,15 @@ import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 
 import { cn } from '../../lib/cn'
+import {
+  normalizeMarkdownForRender,
+  type MarkdownRenderMode
+} from './normalize-markdown-for-render'
 
 type MarkdownRendererProps = {
   content: string
   className?: string
+  renderMode?: MarkdownRenderMode
 }
 
 const HEADING_BASE = 'font-semibold tracking-tight text-foreground'
@@ -20,8 +25,32 @@ const MD_COMPONENTS: Components = {
   h4: ({ children }) => <h4 className={`text-lg ${HEADING_BASE}`}>{children}</h4>,
   h5: ({ children }) => <h5 className={`text-lg ${HEADING_BASE}`}>{children}</h5>,
   h6: ({ children }) => <h6 className={`text-lg ${HEADING_BASE}`}>{children}</h6>,
+  blockquote: ({ children }) => (
+    <blockquote className="border-l-2 border-border/80 pl-4 text-foreground/90">
+      {children}
+    </blockquote>
+  ),
   ul: ({ children }) => <ul className="list-inside list-disc space-y-1">{children}</ul>,
   ol: ({ children }) => <ol className="list-inside list-decimal space-y-1">{children}</ol>,
+  li: ({ children, className }) => (
+    <li className={cn('leading-6 marker:text-muted-foreground', className)}>{children}</li>
+  ),
+  input: ({ checked, className, node: _node, ...props }) => {
+    if (props.type !== 'checkbox') {
+      return <input {...props} checked={checked} className={className} readOnly />
+    }
+
+    return (
+      <input
+        {...props}
+        checked={checked}
+        aria-label={checked ? 'Completed task' : 'Incomplete task'}
+        className={cn('mr-2 translate-y-[1px]', className)}
+        disabled
+        readOnly
+      />
+    )
+  },
   pre: ({ children }) => (
     <pre className="overflow-x-auto rounded-md border bg-card p-3 font-mono text-xs text-foreground">
       {children}
@@ -41,11 +70,17 @@ const MD_COMPONENTS: Components = {
   p: ({ children }) => <p>{children}</p>
 }
 
-export function MarkdownRenderer({ content, className }: MarkdownRendererProps) {
+export function MarkdownRenderer({
+  content,
+  className,
+  renderMode = 'settled'
+}: MarkdownRendererProps) {
+  const normalizedContent = normalizeMarkdownForRender(content, renderMode)
+
   return (
     <div className={cn('space-y-3 text-sm text-muted-foreground', className)}>
       <ReactMarkdown remarkPlugins={REMARK_PLUGINS} components={MD_COMPONENTS}>
-        {content}
+        {normalizedContent}
       </ReactMarkdown>
     </div>
   )

--- a/app/src/renderer/components/shared/MarkdownRenderer.tsx
+++ b/app/src/renderer/components/shared/MarkdownRenderer.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react'
 import type { Components } from 'react-markdown'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
@@ -89,7 +90,7 @@ const MD_COMPONENTS: Components = {
   p: ({ children }) => <p>{children}</p>
 }
 
-export function MarkdownRenderer({
+export const MarkdownRenderer = memo(function MarkdownRenderer({
   content,
   className,
   renderMode = 'settled'
@@ -103,4 +104,4 @@ export function MarkdownRenderer({
       </ReactMarkdown>
     </div>
   )
-}
+})

--- a/app/src/renderer/components/shared/MarkdownRenderer.tsx
+++ b/app/src/renderer/components/shared/MarkdownRenderer.tsx
@@ -36,9 +36,11 @@ const MD_COMPONENTS: Components = {
     <li className={cn('leading-6 marker:text-muted-foreground', className)}>{children}</li>
   ),
   input: ({ checked, className, node: _node, ...props }) => {
+    /* v8 ignore start -- react-markdown only reaches this override for GFM task list checkboxes */
     if (props.type !== 'checkbox') {
       return <input {...props} checked={checked} className={className} readOnly />
     }
+    /* v8 ignore stop */
 
     return (
       <input

--- a/app/src/renderer/components/shared/MarkdownRenderer.tsx
+++ b/app/src/renderer/components/shared/MarkdownRenderer.tsx
@@ -30,10 +30,28 @@ const MD_COMPONENTS: Components = {
       {children}
     </blockquote>
   ),
-  ul: ({ children }) => <ul className="list-inside list-disc space-y-1">{children}</ul>,
+  ul: ({ children, className }) => (
+    <ul
+      className={cn(
+        'space-y-1',
+        className?.includes('contains-task-list') ? 'list-none pl-0' : 'list-inside list-disc',
+        className
+      )}
+    >
+      {children}
+    </ul>
+  ),
   ol: ({ children }) => <ol className="list-inside list-decimal space-y-1">{children}</ol>,
   li: ({ children, className }) => (
-    <li className={cn('leading-6 marker:text-muted-foreground', className)}>{children}</li>
+    <li
+      className={cn(
+        'leading-6',
+        className?.includes('task-list-item') ? 'list-none' : 'marker:text-muted-foreground',
+        className
+      )}
+    >
+      {children}
+    </li>
   ),
   input: ({ checked, className, node: _node, ...props }) => {
     /* v8 ignore start -- react-markdown only reaches this override for GFM task list checkboxes */
@@ -49,7 +67,6 @@ const MD_COMPONENTS: Components = {
         aria-label={checked ? 'Completed task' : 'Incomplete task'}
         className={cn('mr-2 translate-y-[1px]', className)}
         disabled
-        readOnly
       />
     )
   },

--- a/app/src/renderer/components/shared/normalize-markdown-for-render.ts
+++ b/app/src/renderer/components/shared/normalize-markdown-for-render.ts
@@ -1,6 +1,7 @@
 export type MarkdownRenderMode = 'settled' | 'streaming'
 
 type FenceInfo = {
+  containerPrefix: string
   length: number
   prefix: string
   suffix: string
@@ -52,15 +53,27 @@ function consumeListMarker(line: string, startIndex: number): number | null {
   return consumeOrderedListMarker(line, startIndex)
 }
 
+function getLineEnding(content: string): string {
+  const match = content.match(/\r\n|\n|\r/)
+
+  return match?.[0] ?? '\n'
+}
+
 function getFenceInfo(line: string): FenceInfo | null {
   let whitespace = consumeLeadingWhitespace(line, 0)
   let index = whitespace.index
   let fenceIndent = whitespace.width
+  let containerEnd = 0
 
   while (true) {
     if (line[index] === '>') {
-      index += 1
-      whitespace = consumeLeadingWhitespace(line, index)
+      let markerEnd = index + 1
+      if (line[markerEnd] === ' ' || line[markerEnd] === '\t') {
+        markerEnd += 1
+      }
+
+      containerEnd = markerEnd
+      whitespace = consumeLeadingWhitespace(line, markerEnd)
       index = whitespace.index
       fenceIndent = whitespace.width
       continue
@@ -71,6 +84,7 @@ function getFenceInfo(line: string): FenceInfo | null {
       break
     }
 
+    containerEnd = nextIndex
     whitespace = consumeLeadingWhitespace(line, nextIndex)
     index = whitespace.index
     fenceIndent = whitespace.width
@@ -90,6 +104,7 @@ function getFenceInfo(line: string): FenceInfo | null {
   }
 
   return {
+    containerPrefix: line.slice(0, containerEnd),
     length: fenceEnd - index,
     prefix: line.slice(0, index),
     suffix: line.slice(fenceEnd)
@@ -104,9 +119,10 @@ export function normalizeMarkdownForRender(
     return content
   }
 
+  const lineEnding = getLineEnding(content)
   let activeFence: FenceInfo | null = null
 
-  for (const line of content.split('\n')) {
+  for (const line of content.split(/\r\n|\n|\r/)) {
     const fence = getFenceInfo(line)
     if (fence === null) {
       continue
@@ -117,13 +133,17 @@ export function normalizeMarkdownForRender(
       continue
     }
 
-    if (fence.length >= activeFence.length && /^[ \t]*$/.test(fence.suffix)) {
+    if (
+      fence.containerPrefix === activeFence.containerPrefix &&
+      fence.length >= activeFence.length &&
+      /^[ \t]*$/.test(fence.suffix)
+    ) {
       activeFence = null
     }
   }
 
   if (activeFence !== null) {
-    return `${content}\n${activeFence.prefix}${'`'.repeat(activeFence.length)}`
+    return `${content}${lineEnding}${activeFence.prefix}${'`'.repeat(activeFence.length)}`
   }
 
   return content

--- a/app/src/renderer/components/shared/normalize-markdown-for-render.ts
+++ b/app/src/renderer/components/shared/normalize-markdown-for-render.ts
@@ -68,7 +68,6 @@ function getFenceInfo(line: string): FenceInfo | null {
   let whitespace = consumeLeadingWhitespace(line, 0)
   let index = whitespace.index
   let fenceIndent = whitespace.width
-  let containerEnd = 0
   const containerMarkers: string[] = []
 
   while (true) {
@@ -78,7 +77,6 @@ function getFenceInfo(line: string): FenceInfo | null {
         markerEnd += 1
       }
 
-      containerEnd = markerEnd
       containerMarkers.push('>')
       whitespace = consumeLeadingWhitespace(line, markerEnd)
       index = whitespace.index
@@ -91,7 +89,6 @@ function getFenceInfo(line: string): FenceInfo | null {
       break
     }
 
-    containerEnd = nextIndex
     containerMarkers.push(line.slice(index, nextIndex).trimEnd())
     whitespace = consumeLeadingWhitespace(line, nextIndex)
     index = whitespace.index

--- a/app/src/renderer/components/shared/normalize-markdown-for-render.ts
+++ b/app/src/renderer/components/shared/normalize-markdown-for-render.ts
@@ -43,10 +43,11 @@ function consumeOrderedListMarker(line: string, startIndex: number): number | nu
 }
 
 function consumeListMarker(line: string, startIndex: number): number | null {
-  if (
-    (line[startIndex] === '-' || line[startIndex] === '+' || line[startIndex] === '*') &&
-    (line[startIndex + 1] === ' ' || line[startIndex + 1] === '\t')
-  ) {
+  const hasBulletMarker =
+    line[startIndex] === '-' || line[startIndex] === '+' || line[startIndex] === '*'
+  const hasMarkerSpacing = line[startIndex + 1] === ' ' || line[startIndex + 1] === '\t'
+
+  if (hasBulletMarker && hasMarkerSpacing) {
     return startIndex + 2
   }
 

--- a/app/src/renderer/components/shared/normalize-markdown-for-render.ts
+++ b/app/src/renderer/components/shared/normalize-markdown-for-render.ts
@@ -1,7 +1,7 @@
 export type MarkdownRenderMode = 'settled' | 'streaming'
 
 type FenceInfo = {
-  containerPrefix: string
+  containerKey: string
   length: number
   prefix: string
   suffix: string
@@ -59,11 +59,16 @@ function getLineEnding(content: string): string {
   return match?.[0] ?? '\n'
 }
 
+function getContainerKey(markers: string[]): string {
+  return markers.join('|')
+}
+
 function getFenceInfo(line: string): FenceInfo | null {
   let whitespace = consumeLeadingWhitespace(line, 0)
   let index = whitespace.index
   let fenceIndent = whitespace.width
   let containerEnd = 0
+  const containerMarkers: string[] = []
 
   while (true) {
     if (line[index] === '>') {
@@ -73,6 +78,7 @@ function getFenceInfo(line: string): FenceInfo | null {
       }
 
       containerEnd = markerEnd
+      containerMarkers.push('>')
       whitespace = consumeLeadingWhitespace(line, markerEnd)
       index = whitespace.index
       fenceIndent = whitespace.width
@@ -85,6 +91,7 @@ function getFenceInfo(line: string): FenceInfo | null {
     }
 
     containerEnd = nextIndex
+    containerMarkers.push(line.slice(index, nextIndex).trimEnd())
     whitespace = consumeLeadingWhitespace(line, nextIndex)
     index = whitespace.index
     fenceIndent = whitespace.width
@@ -104,7 +111,7 @@ function getFenceInfo(line: string): FenceInfo | null {
   }
 
   return {
-    containerPrefix: line.slice(0, containerEnd),
+    containerKey: getContainerKey(containerMarkers),
     length: fenceEnd - index,
     prefix: line.slice(0, index),
     suffix: line.slice(fenceEnd)
@@ -134,7 +141,7 @@ export function normalizeMarkdownForRender(
     }
 
     if (
-      fence.containerPrefix === activeFence.containerPrefix &&
+      fence.containerKey === activeFence.containerKey &&
       fence.length >= activeFence.length &&
       /^[ \t]*$/.test(fence.suffix)
     ) {
@@ -143,7 +150,9 @@ export function normalizeMarkdownForRender(
   }
 
   if (activeFence !== null) {
-    return `${content}${lineEnding}${activeFence.prefix}${'`'.repeat(activeFence.length)}`
+    const separator = /(?:\r\n|\n|\r)$/.test(content) ? '' : lineEnding
+
+    return `${content}${separator}${activeFence.prefix}${'`'.repeat(activeFence.length)}`
   }
 
   return content

--- a/app/src/renderer/components/shared/normalize-markdown-for-render.ts
+++ b/app/src/renderer/components/shared/normalize-markdown-for-render.ts
@@ -3,16 +3,24 @@ export type MarkdownRenderMode = 'settled' | 'streaming'
 type FenceInfo = {
   length: number
   prefix: string
+  suffix: string
 }
 
-function consumeLeadingWhitespace(line: string, startIndex: number): number {
+type WhitespaceInfo = {
+  index: number
+  width: number
+}
+
+function consumeLeadingWhitespace(line: string, startIndex: number): WhitespaceInfo {
   let index = startIndex
+  let width = 0
 
   while (line[index] === ' ' || line[index] === '\t') {
+    width += line[index] === '\t' ? 4 : 1
     index += 1
   }
 
-  return index
+  return { index, width }
 }
 
 function consumeOrderedListMarker(line: string, startIndex: number): number | null {
@@ -45,12 +53,16 @@ function consumeListMarker(line: string, startIndex: number): number | null {
 }
 
 function getFenceInfo(line: string): FenceInfo | null {
-  let index = consumeLeadingWhitespace(line, 0)
+  let whitespace = consumeLeadingWhitespace(line, 0)
+  let index = whitespace.index
+  let fenceIndent = whitespace.width
 
   while (true) {
     if (line[index] === '>') {
       index += 1
-      index = consumeLeadingWhitespace(line, index)
+      whitespace = consumeLeadingWhitespace(line, index)
+      index = whitespace.index
+      fenceIndent = whitespace.width
       continue
     }
 
@@ -59,7 +71,13 @@ function getFenceInfo(line: string): FenceInfo | null {
       break
     }
 
-    index = consumeLeadingWhitespace(line, nextIndex)
+    whitespace = consumeLeadingWhitespace(line, nextIndex)
+    index = whitespace.index
+    fenceIndent = whitespace.width
+  }
+
+  if (fenceIndent > 3) {
+    return null
   }
 
   let fenceEnd = index
@@ -73,7 +91,8 @@ function getFenceInfo(line: string): FenceInfo | null {
 
   return {
     length: fenceEnd - index,
-    prefix: line.slice(0, index)
+    prefix: line.slice(0, index),
+    suffix: line.slice(fenceEnd)
   }
 }
 
@@ -98,7 +117,7 @@ export function normalizeMarkdownForRender(
       continue
     }
 
-    if (fence.length >= activeFence.length) {
+    if (fence.length >= activeFence.length && /^[ \t]*$/.test(fence.suffix)) {
       activeFence = null
     }
   }

--- a/app/src/renderer/components/shared/normalize-markdown-for-render.ts
+++ b/app/src/renderer/components/shared/normalize-markdown-for-render.ts
@@ -1,0 +1,19 @@
+export type MarkdownRenderMode = 'settled' | 'streaming'
+
+const FENCE_PATTERN = /^```/gm
+
+export function normalizeMarkdownForRender(
+  content: string,
+  mode: MarkdownRenderMode
+): string {
+  if (mode === 'settled') {
+    return content
+  }
+
+  const fenceCount = content.match(FENCE_PATTERN)?.length ?? 0
+  if (fenceCount % 2 === 1) {
+    return `${content}\n\`\`\``
+  }
+
+  return content
+}

--- a/app/src/renderer/components/shared/normalize-markdown-for-render.ts
+++ b/app/src/renderer/components/shared/normalize-markdown-for-render.ts
@@ -1,6 +1,81 @@
 export type MarkdownRenderMode = 'settled' | 'streaming'
 
-const FENCE_PATTERN = /^```/gm
+type FenceInfo = {
+  length: number
+  prefix: string
+}
+
+function consumeLeadingWhitespace(line: string, startIndex: number): number {
+  let index = startIndex
+
+  while (line[index] === ' ' || line[index] === '\t') {
+    index += 1
+  }
+
+  return index
+}
+
+function consumeOrderedListMarker(line: string, startIndex: number): number | null {
+  let index = startIndex
+
+  while (/\d/.test(line[index] ?? '')) {
+    index += 1
+  }
+
+  if (index === startIndex) {
+    return null
+  }
+
+  if ((line[index] !== '.' && line[index] !== ')') || (line[index + 1] !== ' ' && line[index + 1] !== '\t')) {
+    return null
+  }
+
+  return index + 2
+}
+
+function consumeListMarker(line: string, startIndex: number): number | null {
+  if (
+    (line[startIndex] === '-' || line[startIndex] === '+' || line[startIndex] === '*') &&
+    (line[startIndex + 1] === ' ' || line[startIndex + 1] === '\t')
+  ) {
+    return startIndex + 2
+  }
+
+  return consumeOrderedListMarker(line, startIndex)
+}
+
+function getFenceInfo(line: string): FenceInfo | null {
+  let index = consumeLeadingWhitespace(line, 0)
+
+  while (true) {
+    if (line[index] === '>') {
+      index += 1
+      index = consumeLeadingWhitespace(line, index)
+      continue
+    }
+
+    const nextIndex = consumeListMarker(line, index)
+    if (nextIndex === null) {
+      break
+    }
+
+    index = consumeLeadingWhitespace(line, nextIndex)
+  }
+
+  let fenceEnd = index
+  while (line[fenceEnd] === '`') {
+    fenceEnd += 1
+  }
+
+  if (fenceEnd - index < 3) {
+    return null
+  }
+
+  return {
+    length: fenceEnd - index,
+    prefix: line.slice(0, index)
+  }
+}
 
 export function normalizeMarkdownForRender(
   content: string,
@@ -10,9 +85,26 @@ export function normalizeMarkdownForRender(
     return content
   }
 
-  const fenceCount = content.match(FENCE_PATTERN)?.length ?? 0
-  if (fenceCount % 2 === 1) {
-    return `${content}\n\`\`\``
+  let activeFence: FenceInfo | null = null
+
+  for (const line of content.split('\n')) {
+    const fence = getFenceInfo(line)
+    if (fence === null) {
+      continue
+    }
+
+    if (activeFence === null) {
+      activeFence = fence
+      continue
+    }
+
+    if (fence.length >= activeFence.length) {
+      activeFence = null
+    }
+  }
+
+  if (activeFence !== null) {
+    return `${content}\n${activeFence.prefix}${'`'.repeat(activeFence.length)}`
   }
 
   return content

--- a/app/tests/unit/renderer/center/ChatPanel.test.tsx
+++ b/app/tests/unit/renderer/center/ChatPanel.test.tsx
@@ -4,6 +4,10 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { SessionConversationState } from '../../../../src/renderer/types/session-conversation'
 import { ChatPanel } from '../../../../src/renderer/components/center/ChatPanel'
 
+const { messageBubbleRenderSpy } = vi.hoisted(() => ({
+  messageBubbleRenderSpy: vi.fn()
+}))
+
 const mockHook = vi.fn<
   [string | null, (string | null)?],
   {
@@ -16,6 +20,26 @@ const mockHook = vi.fn<
 vi.mock('../../../../src/renderer/hooks/useIpcSessionConversation', () => ({
   useIpcSessionConversation: (...args: [string | null, (string | null)?]) => mockHook(...args),
 }))
+
+vi.mock('../../../../src/renderer/components/center/MessageBubble', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../../src/renderer/components/center/MessageBubble')>()
+
+  return {
+    ...actual,
+    MessageBubble: (props: Parameters<typeof actual.MessageBubble>[0]) => {
+      messageBubbleRenderSpy(props)
+
+      return (
+        <div
+          data-message-bubble-id={props.message.id}
+          data-render-mode={props.renderMode ?? 'unset'}
+        >
+          <actual.MessageBubble {...props} />
+        </div>
+      )
+    }
+  }
+})
 
 const decisionProposal = [
   '## Why',
@@ -43,6 +67,7 @@ describe('ChatPanel', () => {
   afterEach(() => {
     cleanup()
     vi.clearAllMocks()
+    messageBubbleRenderSpy.mockClear()
   })
 
   it('renders message list, run status badge, and chat input', () => {
@@ -114,6 +139,65 @@ describe('ChatPanel', () => {
     render(<ChatPanel sessionId={null} />)
 
     expect(screen.getAllByRole('status', { name: 'Drafting' })).toHaveLength(2)
+  })
+
+  it('renders the latest pending assistant message in streaming mode', () => {
+    mockHook.mockReturnValue({
+      state: idleState({
+        runState: 'pending',
+        messages: [
+          { id: 'm0', role: 'agent', content: 'Previous answer', createdAt: '2026-03-01T00:00:00Z' },
+          { id: 'm1', role: 'user', content: 'Show me progress', createdAt: '2026-03-01T00:00:01Z' },
+          { id: 'm2', role: 'agent', content: ['```ts', 'const ready = true'].join('\n'), createdAt: '2026-03-01T00:00:02Z' }
+        ]
+      }),
+      submitPrompt: vi.fn(),
+      retry: vi.fn()
+    })
+
+    render(<ChatPanel sessionId="sess-1" />)
+
+    expect(screen.getByRole('status', { name: 'Thinking' })).toBeTruthy()
+    expect(document.querySelector('[data-message-bubble-id="m0"]')?.getAttribute('data-render-mode')).toBe('settled')
+    expect(document.querySelector('[data-message-bubble-id="m1"]')?.getAttribute('data-render-mode')).toBe('settled')
+    expect(document.querySelector('[data-message-bubble-id="m2"]')?.getAttribute('data-render-mode')).toBe('streaming')
+    expect(
+      screen.getByText((_, node) => node?.tagName === 'CODE' && node.textContent?.includes('const ready = true') === true)
+    ).toBeTruthy()
+  })
+
+  it('stabilizes the same assistant message when the final append arrives', () => {
+    let currentState = idleState({
+      runState: 'pending',
+      messages: [
+        { id: 'm1', role: 'user', content: 'Show me progress', createdAt: '2026-03-01T00:00:00Z' },
+        { id: 'm2', role: 'agent', content: ['## Summary', '', '```ts', 'const ready = true'].join('\n'), createdAt: '2026-03-01T00:00:01Z' }
+      ]
+    })
+
+    mockHook.mockImplementation(() => ({
+      state: currentState,
+      submitPrompt: vi.fn(),
+      retry: vi.fn()
+    }))
+
+    const { rerender } = render(<ChatPanel sessionId="sess-1" />)
+    expect(document.querySelector('[data-message-id="m2"]')).toBeTruthy()
+
+    currentState = idleState({
+      runState: 'idle',
+      messages: [
+        { id: 'm1', role: 'user', content: 'Show me progress', createdAt: '2026-03-01T00:00:00Z' },
+        { id: 'm2', role: 'agent', content: ['## Summary', '', '```ts', 'const ready = true', '```'].join('\n'), createdAt: '2026-03-01T00:00:01Z' }
+      ]
+    })
+
+    rerender(<ChatPanel sessionId="sess-1" />)
+
+    expect(screen.getByRole('status', { name: 'Stopped' })).toBeTruthy()
+    expect(document.querySelector('[data-message-id="m2"]')).toBeTruthy()
+    expect(document.querySelector('[data-message-bubble-id="m2"]')?.getAttribute('data-render-mode')).toBe('settled')
+    expect(screen.getByRole('heading', { name: 'Summary', level: 2 })).toBeTruthy()
   })
 
   it('renders pasted-context affordances through the real center panel path', () => {

--- a/app/tests/unit/renderer/center/MessageBubble.test.tsx
+++ b/app/tests/unit/renderer/center/MessageBubble.test.tsx
@@ -200,6 +200,25 @@ describe('MessageBubble', () => {
     expect(screen.getByText('Use full content when summary is blank.')).toBeTruthy()
   })
 
+  it('keeps user markdown markers as plain text', () => {
+    render(
+      <MessageBubble
+        message={{
+          id: 'user-markdown',
+          role: 'user',
+          content: '## Do not render this as a heading'
+        }}
+      />
+    )
+
+    expect(screen.getByText('## Do not render this as a heading')).toBeTruthy()
+    expect(
+      screen.queryByRole('heading', {
+        name: 'Do not render this as a heading'
+      })
+    ).toBeNull()
+  })
+
   it('renders decision action buttons when a decision card is provided', () => {
     const onDecisionAction = vi.fn()
 

--- a/app/tests/unit/renderer/center/primitives/ConversationMessage.test.tsx
+++ b/app/tests/unit/renderer/center/primitives/ConversationMessage.test.tsx
@@ -1,7 +1,8 @@
 import { render, screen } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { ConversationMessage } from '../../../../../src/renderer/components/center/primitives/ConversationMessage'
+import * as MarkdownRendererModule from '../../../../../src/renderer/components/shared/MarkdownRenderer'
 
 describe('ConversationMessage', () => {
   it('renders user role as plain text with left-aligned full-width layout', () => {
@@ -62,5 +63,32 @@ describe('ConversationMessage', () => {
 
     expect(screen.getByText('Short summary')).toBeTruthy()
     expect(screen.queryByText('Long content')).toBeNull()
+  })
+
+  it('passes streaming render mode to assistant markdown content', () => {
+    const markdownRendererSpy = vi
+      .spyOn(MarkdownRendererModule, 'MarkdownRenderer')
+      .mockImplementation(({ content, renderMode }) => (
+        <div data-testid="markdown-renderer" data-render-mode={renderMode}>
+          {content}
+        </div>
+      ))
+
+    render(
+      <ConversationMessage
+        message={{
+          id: 'agent-stream',
+          role: 'agent',
+          content: ['```ts', 'const ready = true'].join('\n')
+        }}
+        renderMode="streaming"
+      />
+    )
+
+    expect(
+      screen.getByTestId('markdown-renderer').getAttribute('data-render-mode')
+    ).toBe('streaming')
+
+    markdownRendererSpy.mockRestore()
   })
 })

--- a/app/tests/unit/renderer/center/primitives/ConversationMessage.test.tsx
+++ b/app/tests/unit/renderer/center/primitives/ConversationMessage.test.tsx
@@ -1,10 +1,29 @@
-import { render, screen } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const { markdownRendererSpy } = vi.hoisted(() => ({
+  markdownRendererSpy: vi.fn()
+}))
+
+vi.mock('../../../../../src/renderer/components/shared/MarkdownRenderer', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../../../src/renderer/components/shared/MarkdownRenderer')>()
+  return {
+    ...actual,
+    MarkdownRenderer: (props: Parameters<typeof actual.MarkdownRenderer>[0]) => {
+      markdownRendererSpy(props)
+      return <actual.MarkdownRenderer {...props} />
+    }
+  }
+})
 
 import { ConversationMessage } from '../../../../../src/renderer/components/center/primitives/ConversationMessage'
-import * as MarkdownRendererModule from '../../../../../src/renderer/components/shared/MarkdownRenderer'
 
 describe('ConversationMessage', () => {
+  afterEach(() => {
+    cleanup()
+    markdownRendererSpy.mockClear()
+  })
+
   it('renders user role as plain text with left-aligned full-width layout', () => {
     render(
       <ConversationMessage
@@ -66,14 +85,6 @@ describe('ConversationMessage', () => {
   })
 
   it('passes streaming render mode to assistant markdown content', () => {
-    const markdownRendererSpy = vi
-      .spyOn(MarkdownRendererModule, 'MarkdownRenderer')
-      .mockImplementation(({ content, renderMode }) => (
-        <div data-testid="markdown-renderer" data-render-mode={renderMode}>
-          {content}
-        </div>
-      ))
-
     render(
       <ConversationMessage
         message={{
@@ -85,10 +96,8 @@ describe('ConversationMessage', () => {
       />
     )
 
-    expect(
-      screen.getByTestId('markdown-renderer').getAttribute('data-render-mode')
-    ).toBe('streaming')
-
-    markdownRendererSpy.mockRestore()
+    expect(markdownRendererSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ renderMode: 'streaming' })
+    )
   })
 })

--- a/app/tests/unit/renderer/shared/MarkdownRenderer.test.tsx
+++ b/app/tests/unit/renderer/shared/MarkdownRenderer.test.tsx
@@ -118,8 +118,8 @@ describe('MarkdownRenderer', () => {
     expect(quote?.className).toContain('border-l')
   })
 
-  it('renders GFM checklist items as disabled checkboxes', () => {
-    render(
+  it('renders GFM checklist items as disabled checkboxes without disc markers', () => {
+    const { container } = render(
       <MarkdownRenderer
         content={[
           '- [x] Capture screenshot evidence',
@@ -135,6 +135,16 @@ describe('MarkdownRenderer', () => {
     expect(checkboxes[1]?.checked).toBe(false)
     expect(checkboxes[0]?.disabled).toBe(true)
     expect(checkboxes[1]?.disabled).toBe(true)
+
+    const taskList = container.querySelector('ul.contains-task-list')
+    expect(taskList).toBeTruthy()
+    expect(taskList?.className).toContain('list-none')
+    expect(taskList?.className).not.toContain('list-disc')
+
+    const taskItems = container.querySelectorAll('li.task-list-item')
+    expect(taskItems).toHaveLength(2)
+    expect(taskItems[0]?.className).toContain('list-none')
+    expect(taskItems[0]?.className).not.toContain('marker:text-muted-foreground')
   })
 
   it('normalizes unterminated fences when renderMode is streaming', () => {

--- a/app/tests/unit/renderer/shared/MarkdownRenderer.test.tsx
+++ b/app/tests/unit/renderer/shared/MarkdownRenderer.test.tsx
@@ -100,4 +100,57 @@ describe('MarkdownRenderer', () => {
     expect(screen.getByRole('heading', { name: 'Minor heading', level: 5 })).toBeTruthy()
     expect(screen.getByRole('heading', { name: 'Small heading', level: 6 })).toBeTruthy()
   })
+
+  it('renders blockquotes with readable structure', () => {
+    render(
+      <MarkdownRenderer
+        content={['> Review the current spec draft.', '>', '> Keep the layout stable.'].join(
+          '\n'
+        )}
+      />
+    )
+
+    const quote = screen
+      .getByText('Review the current spec draft.')
+      .closest('blockquote')
+
+    expect(quote).toBeTruthy()
+    expect(quote?.className).toContain('border-l')
+  })
+
+  it('renders GFM checklist items as disabled checkboxes', () => {
+    render(
+      <MarkdownRenderer
+        content={[
+          '- [x] Capture screenshot evidence',
+          '- [ ] Verify streaming readability'
+        ].join('\n')}
+      />
+    )
+
+    const checkboxes = screen.getAllByRole('checkbox') as HTMLInputElement[]
+
+    expect(checkboxes).toHaveLength(2)
+    expect(checkboxes[0]?.checked).toBe(true)
+    expect(checkboxes[1]?.checked).toBe(false)
+    expect(checkboxes[0]?.disabled).toBe(true)
+    expect(checkboxes[1]?.disabled).toBe(true)
+  })
+
+  it('normalizes unterminated fences when renderMode is streaming', () => {
+    const { container } = render(
+      <MarkdownRenderer
+        renderMode="streaming"
+        content={['```ts', 'const ready = true'].join('\n')}
+      />
+    )
+
+    expect(
+      within(container).getByText(
+        (_, node) =>
+          node?.tagName === 'CODE' &&
+          node.textContent?.includes('const ready = true') === true
+      )
+    ).toBeTruthy()
+  })
 })

--- a/app/tests/unit/renderer/shared/normalize-markdown-for-render.test.ts
+++ b/app/tests/unit/renderer/shared/normalize-markdown-for-render.test.ts
@@ -82,4 +82,18 @@ describe('normalizeMarkdownForRender', () => {
       ['```ts', 'const ready = true', '```'].join('\r\n')
     )
   })
+
+  it('treats structurally equivalent blockquote prefixes as the same container', () => {
+    const content = ['> ```ts', '> const ready = true', '>```'].join('\n')
+
+    expect(normalizeMarkdownForRender(content, 'streaming')).toBe(content)
+  })
+
+  it('does not double the trailing newline when appending a synthetic closer', () => {
+    const content = ['```ts', 'const ready = true', ''].join('\n')
+
+    expect(normalizeMarkdownForRender(content, 'streaming')).toBe(
+      ['```ts', 'const ready = true', '```'].join('\n')
+    )
+  })
 })

--- a/app/tests/unit/renderer/shared/normalize-markdown-for-render.test.ts
+++ b/app/tests/unit/renderer/shared/normalize-markdown-for-render.test.ts
@@ -52,4 +52,18 @@ describe('normalizeMarkdownForRender', () => {
 
     expect(normalizeMarkdownForRender(content, 'streaming')).toBe(content)
   })
+
+  it('does not treat a backtick line with trailing info as a closing fence', () => {
+    const content = ['```ts', 'const ready = true', '```not a closer'].join('\n')
+
+    expect(normalizeMarkdownForRender(content, 'streaming')).toBe(
+      ['```ts', 'const ready = true', '```not a closer', '```'].join('\n')
+    )
+  })
+
+  it('does not treat four-space indented code as a fenced opener', () => {
+    const content = ['    ```ts', '    const ready = true'].join('\n')
+
+    expect(normalizeMarkdownForRender(content, 'streaming')).toBe(content)
+  })
 })

--- a/app/tests/unit/renderer/shared/normalize-markdown-for-render.test.ts
+++ b/app/tests/unit/renderer/shared/normalize-markdown-for-render.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  normalizeMarkdownForRender
+} from '../../../../src/renderer/components/shared/normalize-markdown-for-render'
+
+describe('normalizeMarkdownForRender', () => {
+  it('returns settled markdown unchanged', () => {
+    const content = ['## Summary', '', '> stable quote', '', '```ts', 'const ready = true', '```'].join('\n')
+
+    expect(normalizeMarkdownForRender(content, 'settled')).toBe(content)
+  })
+
+  it('closes an unterminated fenced block only for streaming mode', () => {
+    const content = ['## Summary', '', '```ts', 'const ready = true'].join('\n')
+
+    expect(normalizeMarkdownForRender(content, 'streaming')).toBe(
+      ['## Summary', '', '```ts', 'const ready = true', '```'].join('\n')
+    )
+  })
+
+  it('preserves blockquote line breaks while streaming', () => {
+    const content = ['> first line', '> second line'].join('\n')
+
+    expect(normalizeMarkdownForRender(content, 'streaming')).toBe(content)
+  })
+
+  it('does not append a closing fence when the markdown is already balanced', () => {
+    const content = ['```md', '- item', '```'].join('\n')
+
+    expect(normalizeMarkdownForRender(content, 'streaming')).toBe(content)
+  })
+})

--- a/app/tests/unit/renderer/shared/normalize-markdown-for-render.test.ts
+++ b/app/tests/unit/renderer/shared/normalize-markdown-for-render.test.ts
@@ -30,4 +30,26 @@ describe('normalizeMarkdownForRender', () => {
 
     expect(normalizeMarkdownForRender(content, 'streaming')).toBe(content)
   })
+
+  it('closes unterminated quoted fences while preserving the quote prefix', () => {
+    const content = ['> ```ts', '> const ready = true'].join('\n')
+
+    expect(normalizeMarkdownForRender(content, 'streaming')).toBe(
+      ['> ```ts', '> const ready = true', '> ```'].join('\n')
+    )
+  })
+
+  it('closes unterminated indented fences using the matching fence length', () => {
+    const content = ['  ````ts', '  const ready = true'].join('\n')
+
+    expect(normalizeMarkdownForRender(content, 'streaming')).toBe(
+      ['  ````ts', '  const ready = true', '  ````'].join('\n')
+    )
+  })
+
+  it('does not append a closing fence for balanced quoted fences with longer markers', () => {
+    const content = ['> ````md', '> - item', '> ````'].join('\n')
+
+    expect(normalizeMarkdownForRender(content, 'streaming')).toBe(content)
+  })
 })

--- a/app/tests/unit/renderer/shared/normalize-markdown-for-render.test.ts
+++ b/app/tests/unit/renderer/shared/normalize-markdown-for-render.test.ts
@@ -66,4 +66,20 @@ describe('normalizeMarkdownForRender', () => {
 
     expect(normalizeMarkdownForRender(content, 'streaming')).toBe(content)
   })
+
+  it('does not let a plain fence close a quoted fence', () => {
+    const content = ['> ```ts', '> const x = 1', '```', 'after'].join('\n')
+
+    expect(normalizeMarkdownForRender(content, 'streaming')).toBe(
+      ['> ```ts', '> const x = 1', '```', 'after', '> ```'].join('\n')
+    )
+  })
+
+  it('preserves existing CRLF line endings when appending a synthetic closer', () => {
+    const content = ['```ts', 'const ready = true'].join('\r\n')
+
+    expect(normalizeMarkdownForRender(content, 'streaming')).toBe(
+      ['```ts', 'const ready = true', '```'].join('\r\n')
+    )
+  })
 })

--- a/app/tests/unit/renderer/shared/normalize-markdown-for-render.test.ts
+++ b/app/tests/unit/renderer/shared/normalize-markdown-for-render.test.ts
@@ -96,4 +96,46 @@ describe('normalizeMarkdownForRender', () => {
       ['```ts', 'const ready = true', '```'].join('\n')
     )
   })
+
+  it('closes unterminated ordered-list fences while preserving the list prefix', () => {
+    const content = ['1. ```ts', '   const ready = true'].join('\n')
+
+    expect(normalizeMarkdownForRender(content, 'streaming')).toBe(
+      ['1. ```ts', '   const ready = true', '1. ```'].join('\n')
+    )
+  })
+
+  it('does not treat malformed ordered-list markers as fence containers', () => {
+    const content = ['1.```ts', 'const ready = true'].join('\n')
+
+    expect(normalizeMarkdownForRender(content, 'streaming')).toBe(content)
+  })
+
+  it('does not treat tab-indented code as a fenced opener', () => {
+    const content = ['\t```ts', '\tconst ready = true'].join('\n')
+
+    expect(normalizeMarkdownForRender(content, 'streaming')).toBe(content)
+  })
+
+  it('closes unordered-list fences with alternate markers', () => {
+    const content = ['+ ```ts', '  const ready = true'].join('\n')
+
+    expect(normalizeMarkdownForRender(content, 'streaming')).toBe(
+      ['+ ```ts', '  const ready = true', '+ ```'].join('\n')
+    )
+  })
+
+  it('closes unordered-list fences with star markers', () => {
+    const content = ['* ```ts', '  const ready = true'].join('\n')
+
+    expect(normalizeMarkdownForRender(content, 'streaming')).toBe(
+      ['* ```ts', '  const ready = true', '* ```'].join('\n')
+    )
+  })
+
+  it('does not treat malformed ordered-list markers with closing parens as fence containers', () => {
+    const content = ['1)```ts', 'const ready = true'].join('\n')
+
+    expect(normalizeMarkdownForRender(content, 'streaming')).toBe(content)
+  })
 })


### PR DESCRIPTION
## Summary
- add a shared streaming-safe markdown normalization helper for coordinator assistant output
- extend shared markdown rendering with blockquote, checklist, and render-mode support for coordinator parity
- thread streaming render mode through the center conversation components and document KAT-219 verification evidence

## Test Plan
- `npx vitest run tests/unit/renderer/shared/normalize-markdown-for-render.test.ts tests/unit/renderer/shared/MarkdownRenderer.test.tsx`
- `npm run test:coverage`
- `npm run -w app test:ci:local`
- manual Electron UAT walkthrough for pending and final coordinator markdown states

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Highlights the currently streaming assistant message in the chat UI.
  * Improved markdown rendering: blockquotes, GFM task lists (checkboxes), and auto-closing of incomplete code fences in streaming mode.
* **Tests**
  * Added comprehensive unit tests covering streaming rendering, markdown normalization, blockquotes, checklists, and fence-closing edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a streaming-safe markdown normalization layer for the center coordinator conversation panel, ensuring that partially-streamed assistant messages render cleanly while in-flight and stabilize correctly on completion. It also extends the shared `MarkdownRenderer` with blockquote, GFM checklist, and explicit `renderMode` support to achieve coordinator–assistant rendering parity.

Key changes:
- **`normalize-markdown-for-render.ts`** (new): Parses content line-by-line to detect unterminated backtick code fences (including those inside blockquote/list containers) and auto-closes them during `streaming` mode. Passes through unchanged in `settled` mode.
- **`MarkdownRenderer.tsx`**: Adds `blockquote`, `input` (checklist), and `renderMode` prop; calls the new normalization helper before passing content to `react-markdown`.
- **`ChatPanel.tsx`**: Computes `streamingMessageId` — the last agent message when `runState === 'pending'` — and passes `renderMode='streaming'` only to that message; all others receive `renderMode='settled'`.
- **`MessageBubble` / `ConversationMessageCard` / `ConversationMessage`**: Thread the `MarkdownRenderMode` prop down the component tree; user-role messages always receive `settled` regardless of context.
- Minor redundancy: both `disabled` and `readOnly` are applied to task-list checkboxes, where `disabled` is sufficient.

<h3>Confidence Score: 5/5</h3>

- Safe to merge. Streaming normalization logic is sound, prop threading is correct, and only a minor style redundancy remains.
- The streaming normalization helper correctly detects and auto-closes unterminated backtick code fences in all contexts (plain, blockquotes, nested lists), and the prop-threading architecture safely isolates streaming mode to only the last pending agent message. Component logic is well-tested and race-condition-safe. The sole remaining finding is a minor redundancy in checkbox attribute handling.
- app/src/renderer/components/shared/MarkdownRenderer.tsx — remove redundant `readOnly` from task-list checkbox.

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant IPC as useIpcSessionConversation
    participant CP as ChatPanel
    participant MB as MessageBubble
    participant CMC as ConversationMessageCard
    participant CM as ConversationMessage
    participant MR as MarkdownRenderer
    participant NM as normalizeMarkdownForRender

    IPC-->>CP: state.runState / state.messages
    CP->>CP: compute streamingMessageId<br/>(last agent msg when pending)
    CP->>MB: message + renderMode<br/>('streaming' | 'settled')
    MB->>MB: force 'settled' for user role
    MB->>CMC: renderMode
    CMC->>CM: renderMode
    CM->>MR: content + renderMode
    MR->>NM: normalizeMarkdownForRender(content, mode)
    alt mode === 'streaming'
        NM->>NM: scan lines for open backtick fence
        NM-->>MR: content + closing fence appended
    else mode === 'settled'
        NM-->>MR: content unchanged
    end
    MR-->>CM: <ReactMarkdown> rendered output
```

<sub>Last reviewed commit: 81ebf16</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->